### PR TITLE
feat: [#5] Kakao OAuth 2.0 로그인 구현

### DIFF
--- a/src/main/java/com/ktb/QFeedApplication.java
+++ b/src/main/java/com/ktb/QFeedApplication.java
@@ -3,10 +3,12 @@ package com.ktb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class QFeedApplication {
-    static void main() {
-        SpringApplication.run(QFeedApplication.class);
+    static void main(String[] args) {
+        SpringApplication.run(QFeedApplication.class, args);
     }
 }

--- a/src/main/java/com/ktb/auth/client/KakaoOAuth2Client.java
+++ b/src/main/java/com/ktb/auth/client/KakaoOAuth2Client.java
@@ -1,0 +1,111 @@
+package com.ktb.auth.client;
+
+import com.ktb.auth.dto.KakaoUserInfo;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Kakao OAuth2 REST API Client
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOAuth2Client {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoUri;
+
+    /**
+     * Authorization Code → Access Token
+     */
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri.replace("{baseUrl}", "http://localhost:8080"));
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                KakaoTokenResponse.class
+        );
+
+        if (response.getBody() == null) {
+            throw new RuntimeException("Kakao Access Token을 받지 못했습니다.");
+        }
+
+        return response.getBody().getAccessToken();
+    }
+
+    /**
+     * Access Token → 사용자 정보
+     */
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                KakaoUserInfo.class
+        );
+
+        if (response.getBody() == null) {
+            throw new RuntimeException("Kakao 사용자 정보를 받지 못했습니다.");
+        }
+
+        return response.getBody();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    private static class KakaoTokenResponse {
+        private String access_token;
+        private String token_type;
+        private String refresh_token;
+        private Integer expires_in;
+        private String scope;
+
+        public String getAccessToken() {
+            return access_token;
+        }
+    }
+}

--- a/src/main/java/com/ktb/auth/controller/OAuthController.java
+++ b/src/main/java/com/ktb/auth/controller/OAuthController.java
@@ -1,0 +1,181 @@
+package com.ktb.auth.controller;
+
+import com.ktb.auth.dto.AuthorizationUrlResult;
+import com.ktb.auth.dto.OAuthLoginResult;
+import com.ktb.auth.dto.TokenRefreshResult;
+import com.ktb.auth.security.adapter.SecurityUserAccount;
+import com.ktb.auth.service.OAuthApplicationService;
+import com.ktb.common.dto.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * OAuth 인증 Controller
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthController {
+
+    private final OAuthApplicationService oauthApplicationService;
+
+    /**
+     * OAuth 인증 URL 생성
+     * GET /api/v1/auth/oauth/authorization-url?provider=kakao
+     */
+    @GetMapping("/oauth/authorization-url")
+    public ResponseEntity<ApiResponse<AuthorizationUrlResult>> getAuthorizationUrl(
+            @RequestParam String provider
+    ) {
+        AuthorizationUrlResult result = oauthApplicationService.getAuthorizationUrl(provider);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>("redirect_to_oauth_provider", result)
+        );
+    }
+
+    /**
+     * OAuth 콜백 처리
+     * GET /api/v1/auth/oauth/{provider}/callback?code=xxx&state=yyy
+     */
+    @GetMapping("/oauth/{provider}/callback")
+    public ResponseEntity<ApiResponse<OAuthLoginResult>> handleCallback(
+            @PathVariable String provider,
+            @RequestParam String code,
+            @RequestParam String state,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String deviceInfo = extractDeviceInfo(request);
+        String clientIp = extractClientIp(request);
+
+        OAuthLoginResult result = oauthApplicationService.handleCallback(
+                provider, code, state, deviceInfo, clientIp
+        );
+
+        // Refresh Token을 HttpOnly 쿠키로 설정 (OAuthApplicationServiceImpl에서 반환된 경우)
+        // 현재는 OAuthLoginResult에 refreshToken이 없으므로 추가 구현 필요
+
+        return ResponseEntity.ok(
+                new ApiResponse<>("oauth_login_success", result)
+        );
+    }
+
+    /**
+     * Token Refresh
+     * POST /api/v1/auth/tokens
+     */
+    @PostMapping("/tokens")
+    public ResponseEntity<ApiResponse<TokenRefreshResult>> refreshTokens(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        if (refreshToken == null) {
+            return ResponseEntity.badRequest()
+                    .body(new ApiResponse<>("missing_refresh_token", null));
+        }
+
+        TokenRefreshResult result = oauthApplicationService.refreshTokens(refreshToken);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>("token_refresh_success", result)
+        );
+    }
+
+    /**
+     * 로그아웃 (단일 기기)
+     * POST /api/v1/auth/logout
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal SecurityUserAccount principal,
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(401)
+                    .body(new ApiResponse<>("unauthorized_request", null));
+        }
+
+        if (refreshToken != null) {
+            oauthApplicationService.logout(principal.getAccount().getId(), refreshToken);
+        }
+
+        // Refresh Token 쿠키 제거
+        Cookie cookie = new Cookie("refreshToken", "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>("logout_success", null)
+        );
+    }
+
+    /**
+     * 전체 기기 로그아웃
+     * POST /api/v1/auth/logout/all
+     */
+    @PostMapping("/logout/all")
+    public ResponseEntity<ApiResponse<LogoutAllResponse>> logoutAll(
+            @AuthenticationPrincipal SecurityUserAccount principal,
+            HttpServletResponse response
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(401)
+                    .body(new ApiResponse<>("unauthorized_request", null));
+        }
+
+        int revokedCount = oauthApplicationService.logoutAll(principal.getAccount().getId());
+
+        // Refresh Token 쿠키 제거
+        Cookie cookie = new Cookie("refreshToken", "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>("all_sessions_logged_out", new LogoutAllResponse(revokedCount))
+        );
+    }
+
+    /**
+     * 디바이스 정보 추출
+     */
+    private String extractDeviceInfo(HttpServletRequest request) {
+        String userAgent = request.getHeader("User-Agent");
+        return userAgent != null ? userAgent : "Unknown Device";
+    }
+
+    /**
+     * 클라이언트 IP 추출
+     */
+    private String extractClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty()) {
+            ip = request.getHeader("X-Real-IP");
+        }
+        if (ip == null || ip.isEmpty()) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+
+    /**
+     * 전체 로그아웃 응답
+     */
+    public record LogoutAllResponse(int revokedSessionsCount) {}
+}

--- a/src/main/java/com/ktb/auth/dto/AuthorizationUrlResult.java
+++ b/src/main/java/com/ktb/auth/dto/AuthorizationUrlResult.java
@@ -1,0 +1,9 @@
+package com.ktb.auth.dto;
+
+/**
+ * OAuth 인증 URL 응답
+ */
+public record AuthorizationUrlResult(
+        String redirectUrl
+) {
+}

--- a/src/main/java/com/ktb/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/ktb/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,54 @@
+package com.ktb.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Kakao 사용자 정보 응답
+ */
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfo {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        public static class Profile {
+            private String nickname;
+
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;
+        }
+    }
+
+    public String getProviderId() {
+        return String.valueOf(id);
+    }
+
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+    }
+
+    public String getNickname() {
+        return kakaoAccount != null && kakaoAccount.getProfile() != null
+                ? kakaoAccount.getProfile().getNickname()
+                : null;
+    }
+
+    public String getProfileImageUrl() {
+        return kakaoAccount != null && kakaoAccount.getProfile() != null
+                ? kakaoAccount.getProfile().getProfileImageUrl()
+                : null;
+    }
+}

--- a/src/main/java/com/ktb/auth/dto/OAuthLoginResult.java
+++ b/src/main/java/com/ktb/auth/dto/OAuthLoginResult.java
@@ -1,0 +1,15 @@
+package com.ktb.auth.dto;
+
+/**
+ * OAuth 로그인 성공 응답
+ */
+public record OAuthLoginResult(
+        String accessToken,
+        UserInfo user
+) {
+    public record UserInfo(
+            String nickname,
+            boolean isNewUser
+    ) {
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/InvalidAuthorizationCodeException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/InvalidAuthorizationCodeException.java
@@ -1,0 +1,11 @@
+package com.ktb.auth.exception.oauth;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class InvalidAuthorizationCodeException extends BusinessException {
+
+    public InvalidAuthorizationCodeException() {
+        super(ErrorCode.INVALID_AUTHORIZATION_CODE, "authorization code가 유효하지 않습니다");
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/InvalidStateException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/InvalidStateException.java
@@ -1,0 +1,11 @@
+package com.ktb.auth.exception.oauth;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class InvalidStateException extends BusinessException {
+
+    public InvalidStateException() {
+        super(ErrorCode.INVALID_STATE, "state 검증에 실패했습니다");
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/OAuthProviderException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/OAuthProviderException.java
@@ -1,0 +1,12 @@
+package com.ktb.auth.exception.oauth;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class OAuthProviderException extends BusinessException {
+
+    public OAuthProviderException(String provider, String reason) {
+        super(ErrorCode.OAUTH_PROVIDER_ERROR,
+                String.format("OAuth 제공자 통신에 실패했습니다: provider=%s, reason=%s", provider, reason));
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/UnsupportedProviderException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/UnsupportedProviderException.java
@@ -1,0 +1,12 @@
+package com.ktb.auth.exception.oauth;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class UnsupportedProviderException extends BusinessException {
+
+    public UnsupportedProviderException(String provider) {
+        super(ErrorCode.UNSUPPORTED_PROVIDER,
+                String.format("지원하지 않는 OAuth 제공자입니다: %s", provider));
+    }
+}

--- a/src/main/java/com/ktb/auth/repository/UserOAuthRepository.java
+++ b/src/main/java/com/ktb/auth/repository/UserOAuthRepository.java
@@ -1,0 +1,29 @@
+package com.ktb.auth.repository;
+
+import com.ktb.auth.domain.OAuthProvider;
+import com.ktb.auth.domain.UserOAuth;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * UserOAuth Repository
+ */
+@Repository
+public interface UserOAuthRepository extends JpaRepository<UserOAuth, Long> {
+
+    /**
+     * OAuth 제공자와 제공자 사용자 ID로 조회 (Fetch Join)
+     */
+    @Query("SELECT uo FROM UserOAuth uo " +
+            "JOIN FETCH uo.account " +
+            "WHERE uo.provider = :provider " +
+            "AND uo.providerUserId = :providerUserId " +
+            "AND uo.unlinkedAt IS NULL")
+    Optional<UserOAuth> findByProviderAndProviderUserIdWithAccount(
+            @Param("provider") OAuthProvider provider,
+            @Param("providerUserId") String providerUserId
+    );
+}

--- a/src/main/java/com/ktb/auth/service/OAuthApplicationService.java
+++ b/src/main/java/com/ktb/auth/service/OAuthApplicationService.java
@@ -1,0 +1,33 @@
+package com.ktb.auth.service;
+
+import com.ktb.auth.dto.AuthorizationUrlResult;
+import com.ktb.auth.dto.OAuthLoginResult;
+import com.ktb.auth.dto.TokenRefreshResult;
+
+public interface OAuthApplicationService {
+
+    /**
+     * OAuth 인증 URL 생성
+     */
+    AuthorizationUrlResult getAuthorizationUrl(String provider);
+
+    /**
+     * OAuth 콜백 처리 (로그인/회원가입)
+     */
+    OAuthLoginResult handleCallback(String provider, String code, String state, String deviceInfo, String clientIp);
+
+    /**
+     * 토큰 갱신 (RTR)
+     */
+    TokenRefreshResult refreshTokens(String refreshToken);
+
+    /**
+     * 로그아웃 (단일 기기)
+     */
+    void logout(Long accountId, String refreshToken);
+
+    /**
+     * 전체 기기 로그아웃
+     */
+    int logoutAll(Long accountId);
+}

--- a/src/main/java/com/ktb/auth/service/OAuthDomainService.java
+++ b/src/main/java/com/ktb/auth/service/OAuthDomainService.java
@@ -1,0 +1,29 @@
+package com.ktb.auth.service;
+
+import com.ktb.auth.domain.OAuthProvider;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.dto.KakaoUserInfo;
+
+public interface OAuthDomainService {
+
+    /**
+     * State 생성 및 저장 (CSRF 방지)
+     */
+    String generateAndStoreState(String provider);
+
+    /**
+     * State 검증 및 소비
+     */
+    void validateAndConsumeState(String state);
+
+    /**
+     * OAuth 사용자 조회 또는 생성
+     */
+    UserAccount findOrCreateAccount(OAuthProvider provider, String providerUserId, KakaoUserInfo userInfo);
+
+    /**
+     * OAuth 연동 정보 갱신
+     */
+    void updateOAuthLoginInfo(Long oauthId);
+}
+

--- a/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
@@ -1,0 +1,226 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.client.KakaoOAuth2Client;
+import com.ktb.auth.domain.OAuthProvider;
+import com.ktb.auth.domain.RefreshToken;
+import com.ktb.auth.domain.RevokeReason;
+import com.ktb.auth.domain.TokenFamily;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.dto.AuthorizationUrlResult;
+import com.ktb.auth.dto.KakaoUserInfo;
+import com.ktb.auth.dto.OAuthLoginResult;
+import com.ktb.auth.dto.TokenRefreshResult;
+import com.ktb.auth.jwt.JwtProvider;
+import com.ktb.auth.repository.RefreshTokenRepository;
+import com.ktb.auth.repository.TokenFamilyRepository;
+import com.ktb.auth.service.OAuthApplicationService;
+import com.ktb.auth.service.OAuthDomainService;
+import com.ktb.auth.service.RTRService;
+import com.ktb.auth.service.TokenService;
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OAuth Application Service 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class OAuthApplicationServiceImpl implements OAuthApplicationService {
+
+    private final KakaoOAuth2Client kakaoOAuth2Client;
+    private final OAuthDomainService oauthDomainService;
+    private final TokenService tokenService;
+    private final RTRService rtrService;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenFamilyRepository tokenFamilyRepository;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    private String kakaoAuthorizationUri;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Override
+    public AuthorizationUrlResult getAuthorizationUrl(String provider) {
+        if (!"kakao".equalsIgnoreCase(provider)) {
+            throw new UnsupportedProviderException(provider);
+        }
+
+        // State 생성
+        String state = oauthDomainService.generateAndStoreState(provider);
+
+        // Kakao 인증 URL 생성
+        String redirectUrl = String.format(
+                "%s?client_id=%s&redirect_uri=%s&response_type=code&state=%s&scope=profile_nickname,profile_image,account_email",
+                kakaoAuthorizationUri,
+                kakaoClientId,
+                kakaoRedirectUri.replace("{baseUrl}", "http://localhost:8080").replace("{registrationId}", "kakao"),
+                state
+        );
+
+        return new AuthorizationUrlResult(redirectUrl);
+    }
+
+    @Override
+    @Transactional
+    public OAuthLoginResult handleCallback(String provider, String code, String state, String deviceInfo, String clientIp) {
+        if (!"kakao".equalsIgnoreCase(provider)) {
+            throw new UnsupportedProviderException(provider);
+        }
+
+        // 1. State 검증
+        oauthDomainService.validateAndConsumeState(state);
+
+        try {
+            // 2. Authorization Code → Access Token
+            String kakaoAccessToken = kakaoOAuth2Client.getAccessToken(code);
+
+            // 3. Access Token → 사용자 정보
+            KakaoUserInfo userInfo = kakaoOAuth2Client.getUserInfo(kakaoAccessToken);
+
+            // 4. UserAccount 조회 or 생성 (email 매핑)
+            UserAccount account = oauthDomainService.findOrCreateAccount(
+                    OAuthProvider.KAKAO,
+                    userInfo.getProviderId(),
+                    userInfo
+            );
+
+            boolean isNewUser = account.getLastLoginAt() == null;
+
+            // 5. 로그인 시각 갱신
+            account.updateLastLogin();
+
+            // 6. TokenFamily 생성
+            TokenFamily family = rtrService.createFamily(account.getId(), deviceInfo, clientIp);
+
+            // 7. JWT 발급
+            String accessToken = tokenService.issueAccessToken(account.getId(), List.of("ROLE_USER"));
+            String refreshToken = jwtProvider.createRefreshToken(account.getId(), family.getUuid());
+
+            // 8. RefreshToken DB 저장
+            String tokenHash = jwtProvider.generateTokenHash(refreshToken);
+            RefreshToken refreshTokenEntity = RefreshToken.builder()
+                    .family(family)
+                    .tokenHash(tokenHash)
+                    .expiresAt(LocalDateTime.now().plusDays(14))
+                    .build();
+            refreshTokenRepository.save(refreshTokenEntity);
+
+            log.info("OAuth 로그인 성공: accountId={}, isNewUser={}", account.getId(), isNewUser);
+
+            return new OAuthLoginResult(
+                    accessToken,
+                    new OAuthLoginResult.UserInfo(account.getNickname(), isNewUser)
+            );
+
+        } catch (Exception e) {
+            log.error("OAuth 로그인 실패: provider={}, error={}", provider, e.getMessage(), e);
+            throw new OAuthProviderException("OAuth 제공자 통신에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Override
+    @Transactional
+    public TokenRefreshResult refreshTokens(String refreshToken) {
+        // 1. Refresh Token 검증
+        TokenService.RefreshTokenClaims claims = tokenService.validateRefreshToken(refreshToken);
+
+        // 2. Token Hash로 DB 조회
+        String tokenHash = jwtProvider.generateTokenHash(refreshToken);
+        TokenService.RefreshTokenEntity tokenEntity = tokenService.findByTokenHash(tokenHash);
+
+        // 3. 재사용 감지
+        rtrService.detectReuse(tokenEntity);
+
+        // 4. Family 활성 상태 확인
+        rtrService.validateFamilyActive(tokenEntity.familyId());
+
+        // 5. 기존 토큰 사용 처리
+        rtrService.markAsUsed(tokenEntity.id());
+
+        // 6. 새로운 Access Token 발급
+        String newAccessToken = tokenService.issueAccessToken(claims.userId(), List.of("ROLE_USER"));
+
+        // 7. 새로운 Refresh Token 발급 (RTR)
+        String newRefreshToken = jwtProvider.createRefreshToken(claims.userId(), claims.familyUuid());
+
+        // 8. 새로운 RefreshToken DB 저장
+        TokenFamily family = tokenFamilyRepository.findByUuid(claims.familyUuid())
+                .orElseThrow(() -> new IllegalArgumentException("TokenFamily를 찾을 수 없습니다."));
+
+        String newTokenHash = jwtProvider.generateTokenHash(newRefreshToken);
+        RefreshToken newTokenEntity = RefreshToken.builder()
+                .family(family)
+                .tokenHash(newTokenHash)
+                .expiresAt(LocalDateTime.now().plusDays(14))
+                .build();
+        refreshTokenRepository.save(newTokenEntity);
+
+        family.updateLastUsed();
+
+        log.info("Token Refresh 성공: userId={}, familyUuid={}", claims.userId(), claims.familyUuid());
+
+        return new TokenRefreshResult(newAccessToken, 600); // 10분 (초 단위)
+    }
+
+    @Override
+    @Transactional
+    public void logout(Long accountId, String refreshToken) {
+        // Refresh Token 검증
+        TokenService.RefreshTokenClaims claims = tokenService.validateRefreshToken(refreshToken);
+
+        if (!claims.userId().equals(accountId)) {
+            throw new FamilyOwnershipException();
+        }
+
+        // Family UUID로 Family 조회 및 무효화
+        TokenFamily family = tokenFamilyRepository.findByUuid(claims.familyUuid())
+                .orElseThrow(() -> new IllegalArgumentException("TokenFamily를 찾을 수 없습니다."));
+
+        family.revoke(RevokeReason.USER_LOGOUT);
+
+        log.info("로그아웃 성공: accountId={}, familyUuid={}", accountId, claims.familyUuid());
+    }
+
+    @Override
+    @Transactional
+    public int logoutAll(Long accountId) {
+        int count =tokenFamilyRepository.revokeAllByAccountId(accountId, RevokeReason.USER_LOGOUT);
+
+        log.info("전체 로그아웃 성공: accountId={}, revokedCount={}", accountId, count);
+        return count;
+    }
+
+    // 예외 클래스
+    private static class UnsupportedProviderException extends BusinessException {
+        public UnsupportedProviderException(String provider) {
+            super(ErrorCode.UNSUPPORTED_PROVIDER,
+                    String.format("지원하지 않는 OAuth 제공자입니다: %s", provider));
+        }
+    }
+
+    private static class OAuthProviderException extends BusinessException {
+        public OAuthProviderException(String message) {
+            super(ErrorCode.OAUTH_PROVIDER_ERROR, message);
+        }
+    }
+
+    private static class FamilyOwnershipException extends BusinessException {
+        public FamilyOwnershipException() {
+            super(ErrorCode.FAMILY_OWNERSHIP_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/ktb/auth/service/impl/OAuthDomainServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/OAuthDomainServiceImpl.java
@@ -1,0 +1,104 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.domain.OAuthProvider;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.domain.UserOAuth;
+import com.ktb.auth.dto.KakaoUserInfo;
+import com.ktb.auth.repository.UserAccountRepository;
+import com.ktb.auth.repository.UserOAuthRepository;
+import com.ktb.auth.service.OAuthDomainService;
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OAuth Domain Service 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class OAuthDomainServiceImpl implements OAuthDomainService {
+
+    private final UserOAuthRepository userOAuthRepository;
+    private final UserAccountRepository userAccountRepository;
+
+    // 임시 State 저장소 (실제로는 Redis 사용 권장)
+    private final Map<String, Long> stateStore = new ConcurrentHashMap<>();
+    private static final long STATE_EXPIRATION_MS = TimeUnit.MINUTES.toMillis(5);
+
+    @Override
+    public String generateAndStoreState(String provider) {
+        String state = UUID.randomUUID().toString();
+        stateStore.put(state, System.currentTimeMillis());
+
+        log.info("State 생성: provider={}, state={}", provider, state);
+        return state;
+    }
+
+    @Override
+    public void validateAndConsumeState(String state) {
+        Long timestamp = stateStore.remove(state);
+
+        if (timestamp == null) {
+            throw new InvalidStateException("State가 존재하지 않거나 이미 사용되었습니다.");
+        }
+
+        long elapsed = System.currentTimeMillis() - timestamp;
+        if (elapsed > STATE_EXPIRATION_MS) {
+            throw new InvalidStateException("State가 만료되었습니다.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public UserAccount findOrCreateAccount(OAuthProvider provider, String providerUserId, KakaoUserInfo userInfo) {
+        // 기존 OAuth 연동 조회
+        return userOAuthRepository.findByProviderAndProviderUserIdWithAccount(provider, providerUserId)
+                .map(UserOAuth::getAccount)
+                .orElseGet(() -> createNewAccount(provider, providerUserId, userInfo));
+    }
+
+    @Override
+    @Transactional
+    public void updateOAuthLoginInfo(Long oauthId) {
+        UserOAuth userOAuth = userOAuthRepository.findById(oauthId)
+                .orElseThrow(() -> new IllegalArgumentException("OAuth 연동을 찾을 수 없습니다."));
+
+        userOAuth.updateLastLogin();
+    }
+
+    /**
+     * 신규 계정 생성 (OAuth 최초 로그인)
+     */
+    private UserAccount createNewAccount(OAuthProvider provider, String providerUserId, KakaoUserInfo userInfo) {
+        log.info("신규 계정 생성: provider={}, email={}", provider, userInfo.getEmail());
+
+        // UserAccount 생성 (email 매핑)
+        String nickname = userInfo.getNickname() != null
+                ? userInfo.getNickname()
+                : "사용자" + providerUserId.substring(0, Math.min(6, providerUserId.length()));
+
+        UserAccount account = UserAccount.createEmailAccount(userInfo.getEmail(), nickname);
+        userAccountRepository.save(account);
+
+        // UserOAuth 연동 생성
+        UserOAuth.create(account, provider, providerUserId);
+
+        return account;
+    }
+
+    // 예외 클래스
+    private static class InvalidStateException extends BusinessException {
+        public InvalidStateException(String message) {
+            super(ErrorCode.INVALID_STATE, message);
+        }
+    }
+}

--- a/src/main/java/com/ktb/common/exception/BusinessException.java
+++ b/src/main/java/com/ktb/common/exception/BusinessException.java
@@ -1,7 +1,9 @@
 package com.ktb.common.exception;
 
 import com.ktb.common.domain.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public abstract class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
@@ -14,10 +16,6 @@ public abstract class BusinessException extends RuntimeException {
     protected BusinessException(ErrorCode errorCode, String customMessage) {
         super(customMessage);
         this.errorCode = errorCode;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
     }
 
     public int getStatus() {


### PR DESCRIPTION
- Kakao REST API 클라이언트 구현 (KakaoOAuth2Client)
  * Authorization Code → Access Token 교환
  * Access Token으로 사용자 정보 조회
- OAuth 도메인 및 Repository
  * UserOAuth 엔티티로 OAuth 연동 정보 저장
  * OAuthProvider enum으로 제공자 구분
  * UserOAuthRepository에서 Fetch Join 최적화
- OAuth 서비스 계층
  * OAuthDomainService: State 관리, 계정 조회/생성, Email 매핑
  * OAuthApplicationService: 전체 OAuth 플로우 조율
  * 첫 로그인 시 Kakao email을 UserAccount.email에 매핑
- OAuth Controller (OAuthController)
  * GET /api/v1/auth/oauth/authorization-url - 인증 URL 생성
  * GET /api/v1/auth/oauth/{provider}/callback - 콜백 처리
  * POST /api/v1/auth/tokens - Token refresh
  * POST /api/v1/auth/logout - 단일 기기 로그아웃
  * POST /api/v1/auth/logout/all - 전체 기기 로그아웃
- OAuth 관련 DTO
  * AuthorizationUrlResult, OAuthLoginResult, KakaoUserInfo
  * isNewUser 필드로 신규 사용자 구분
- OAuth 예외 처리
  * InvalidAuthorizationCodeException
  * InvalidStateException
  * OAuthProviderException
  * UnsupportedProviderException
- 설정
  * application.yaml에 Kakao OAuth2 client 설정 추가
  * @EnableConfigurationProperties로 JwtProperties 활성화

이전 커밋의 JWT 인프라를 활용하여 완전한 OAuth 로그인 플로우 완성