### PR TITLE
refactor: [#12] JWT 응답 Body가 아닌 Cookie로 설정

### DIFF
--- a/src/main/java/com/ktb/auth/dto/KakaoAccount.java
+++ b/src/main/java/com/ktb/auth/dto/KakaoAccount.java
@@ -1,0 +1,10 @@
+package com.ktb.auth.dto;
+
+/**
+ * Kakao 사용자 계정 정보
+ */
+public record KakaoAccount(
+        String email,
+        KakaoProfile profile
+) {
+}

--- a/src/main/java/com/ktb/auth/dto/KakaoProfile.java
+++ b/src/main/java/com/ktb/auth/dto/KakaoProfile.java
@@ -1,0 +1,9 @@
+package com.ktb.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoProfile(
+        String nickname,
+        @JsonProperty("profile_image_url") String profileImageUrl
+) {
+}

--- a/src/main/java/com/ktb/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/ktb/auth/dto/KakaoUserInfo.java
@@ -1,54 +1,32 @@
 package com.ktb.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
- * Kakao 사용자 정보 응답
+ * Kakao 사용자 정보 응답 record
  */
-@Getter
-@NoArgsConstructor
-public class KakaoUserInfo {
-
-    private Long id;
-
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
-
-    @Getter
-    @NoArgsConstructor
-    public static class KakaoAccount {
-        private String email;
-        private Profile profile;
-
-        @Getter
-        @NoArgsConstructor
-        public static class Profile {
-            private String nickname;
-
-            @JsonProperty("profile_image_url")
-            private String profileImageUrl;
-        }
-    }
+public record KakaoUserInfo(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
 
     public String getProviderId() {
-        return String.valueOf(id);
+        return id != null ? String.valueOf(id) : null;
     }
 
     public String getEmail() {
-        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+        return kakaoAccount != null ? kakaoAccount.email() : null;
     }
 
     public String getNickname() {
-        return kakaoAccount != null && kakaoAccount.getProfile() != null
-                ? kakaoAccount.getProfile().getNickname()
+        return kakaoAccount != null && kakaoAccount.profile() != null
+                ? kakaoAccount.profile().nickname()
                 : null;
     }
 
     public String getProfileImageUrl() {
-        return kakaoAccount != null && kakaoAccount.getProfile() != null
-                ? kakaoAccount.getProfile().getProfileImageUrl()
+        return kakaoAccount != null && kakaoAccount.profile() != null
+                ? kakaoAccount.profile().profileImageUrl()
                 : null;
     }
 }

--- a/src/main/java/com/ktb/auth/dto/LogoutAllResponse.java
+++ b/src/main/java/com/ktb/auth/dto/LogoutAllResponse.java
@@ -1,0 +1,4 @@
+package com.ktb.auth.dto;
+
+public record LogoutAllResponse(int revokedSessionsCount) {
+}

--- a/src/main/java/com/ktb/auth/dto/OAuthLoginResponseDto.java
+++ b/src/main/java/com/ktb/auth/dto/OAuthLoginResponseDto.java
@@ -1,0 +1,4 @@
+package com.ktb.auth.dto;
+
+public record OAuthLoginResponseDto(UserInfo user) {
+}

--- a/src/main/java/com/ktb/auth/dto/OAuthLoginResult.java
+++ b/src/main/java/com/ktb/auth/dto/OAuthLoginResult.java
@@ -5,11 +5,7 @@ package com.ktb.auth.dto;
  */
 public record OAuthLoginResult(
         String accessToken,
+        String refreshToken,
         UserInfo user
 ) {
-    public record UserInfo(
-            String nickname,
-            boolean isNewUser
-    ) {
-    }
 }

--- a/src/main/java/com/ktb/auth/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/ktb/auth/dto/TokenRefreshResponseDto.java
@@ -1,0 +1,4 @@
+package com.ktb.auth.dto;
+
+public record TokenRefreshResponseDto(int expiresIn) {
+}

--- a/src/main/java/com/ktb/auth/dto/TokenRefreshResult.java
+++ b/src/main/java/com/ktb/auth/dto/TokenRefreshResult.java
@@ -2,6 +2,7 @@ package com.ktb.auth.dto;
 
 public record TokenRefreshResult(
         String accessToken,
+        String refreshToken,
         int expiresIn
 ) {
 }

--- a/src/main/java/com/ktb/auth/dto/UserInfo.java
+++ b/src/main/java/com/ktb/auth/dto/UserInfo.java
@@ -1,0 +1,7 @@
+package com.ktb.auth.dto;
+
+public record UserInfo(
+        String nickname,
+        boolean isNewUser
+) {
+}

--- a/src/main/java/com/ktb/auth/jwt/JwtProperties.java
+++ b/src/main/java/com/ktb/auth/jwt/JwtProperties.java
@@ -35,4 +35,9 @@ public class JwtProperties {
      * JWT Issuer
      */
     private String issuer = "QFeed";
+
+    /**
+     * Refresh Token 쿠키 이름
+     */
+    private String refreshTokenCookieName = "refreshToken";
 }

--- a/src/main/java/com/ktb/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/auth/security/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                // CSRF 비활성화 (JWT 사용)
+                // CSRF 설정
                 .csrf(AbstractHttpConfigurer::disable)
 
                 // CORS 설정

--- a/src/main/java/com/ktb/auth/service/CookieService.java
+++ b/src/main/java/com/ktb/auth/service/CookieService.java
@@ -1,0 +1,24 @@
+package com.ktb.auth.service;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * Cookie 관리 서비스
+ */
+public interface CookieService {
+
+    /**
+     * Refresh Token 쿠키 생성
+     *
+     * @param refreshToken Refresh Token 값
+     * @return 생성된 쿠키
+     */
+    Cookie createRefreshTokenCookie(String refreshToken);
+
+    /**
+     * Refresh Token 쿠키 삭제를 위한 빈 쿠키 생성
+     *
+     * @return 만료된 쿠키
+     */
+    Cookie createExpiredRefreshTokenCookie();
+}

--- a/src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
@@ -1,0 +1,38 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.jwt.JwtProperties;
+import com.ktb.auth.service.CookieService;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Cookie 관리 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+public class CookieServiceImpl implements CookieService {
+
+    private final JwtProperties jwtProperties;
+
+    @Override
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+        Cookie cookie = new Cookie(jwtProperties.getRefreshTokenCookieName(), refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true); // HTTPS에서만 전송 (프로덕션)
+        cookie.setPath("/api/v1/auth");
+        cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000)); // 밀리초 → 초
+        // cookie.setAttribute("SameSite", "Strict"); // Spring Boot 3.x+에서 지원
+        return cookie;
+    }
+
+    @Override
+    public Cookie createExpiredRefreshTokenCookie() {
+        Cookie cookie = new Cookie(jwtProperties.getRefreshTokenCookieName(), "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/api/v1/auth");
+        cookie.setMaxAge(0); // 즉시 만료
+        return cookie;
+    }
+}

--- a/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
@@ -123,6 +123,7 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
 
             return new OAuthLoginResult(
                     accessToken,
+                    refreshToken,
                     new OAuthLoginResult.UserInfo(account.getNickname(), isNewUser)
             );
 
@@ -173,7 +174,7 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
 
         log.info("Token Refresh 성공: userId={}, familyUuid={}", claims.userId(), claims.familyUuid());
 
-        return new TokenRefreshResult(newAccessToken, 600); // 10분 (초 단위)
+        return new TokenRefreshResult(newAccessToken, newRefreshToken, 600); // 10분 (초 단위)
     }
 
     @Override


### PR DESCRIPTION
  1. JwtProperties 확장 (JwtProperties.java:42)

  - refreshTokenCookieName 필드 추가 (기본값: "refreshToken")
  - 쿠키 이름을 중앙에서 관리

  2. DTO 수정

  - OAuthLoginResult (OAuthLoginResult.java:8): refreshToken 필드 추가
  - TokenRefreshResult (TokenRefreshResult.java:5): refreshToken 필드 추가

  3. Service Layer 수정

  - OAuthApplicationServiceImpl:
    - handleCallback() (line 126): Refresh Token을 반환값에 포함
    - refreshTokens() (line 177): 새 Refresh Token을 반환값에 포함

  4. CookieService 생성 (SRP 원칙 준수)

  - CookieService 인터페이스: 쿠키 관리 책임 분리
  - CookieServiceImpl: JwtProperties를 주입받아 쿠키 생성
    - createRefreshTokenCookie(): HTTP-only, Secure, 14일 만료
    - createExpiredRefreshTokenCookie(): 로그아웃 시 쿠키 삭제용

  5. Controller Layer 수정

  - OAuthController:
    - CookieService 주입 (JwtProperties는 직접 사용 안 함)
    - handleCallback() (line 72-73): Refresh Token을 HTTP-only 쿠키로 설정
    - refreshTokens() (line 104-105): 새 Refresh Token을 HTTP-only 쿠키로 갱신
    - logout() (line 139-140): CookieService 사용
    - logoutAll() (line 164-165): CookieService 사용

  보안 강화

  - XSS 공격 방지 (HttpOnly)
  - HTTPS 전용 전송 (Secure)
  - Refresh Token이 JSON 응답에 노출되지 않음
  - SRP 원칙 준수 (JwtProperties는 JwtProvider와 CookieService에서만 사용)

  동작 흐름

  1. 로그인: Authorization: Bearer {accessToken} 헤더 사용 + Refresh Token (HTTP-only Cookie)
  2. API 요청: Authorization: Bearer {accessToken} 헤더 사용
  3. Token Refresh: Cookie의 Refresh Token → 새 Access Token (Authorization: Bearer {accessToken}) + 새 Refresh Token (Cookie)
  4. 로그아웃: Refresh Token 쿠키 삭제