### PR TITLE
test: [#41] answer domain test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,4 +72,13 @@ dependencies {
 }
 tasks.test {
     useJUnitPlatform()
+
+    // JDK 25 호환성: Mockito inline mock maker를 위한 JVM 옵션 추가
+    // JDK 25 부터 내부 API 접근 불가로 인한 오류 발생으로 설정 추가
+    jvmArgs(
+        '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+        '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+        '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED',
+        '-XX:+EnableDynamicAgentLoading'
+    )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+# JDK 25 ??? ??
+org.gradle.jvmargs=-XX:+EnableDynamicAgentLoading \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED
+
+# Gradle ?? ???
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true

--- a/src/test/java/com/ktb/answer/domain/AnswerTest.java
+++ b/src/test/java/com/ktb/answer/domain/AnswerTest.java
@@ -1,0 +1,404 @@
+package com.ktb.answer.domain;
+
+import com.ktb.answer.exception.AnswerRequiredTypeException;
+import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.fixture.AnswerFixture;
+import com.ktb.question.domain.Question;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Answer 도메인 테스트")
+class AnswerTest {
+
+    private static final String VALID_CONTENT = "테스트 답변 내용입니다.";
+    private static final int MAX_CONTENT_SIZE = 1500;
+
+    @Nested
+    @DisplayName("Answer 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 값으로 Answer 생성 시 성공")
+        void create_WithValidData_ShouldSucceed() {
+            // Given
+            Question question = mock(Question.class);
+            UserAccount account = mock(UserAccount.class);
+            String content = VALID_CONTENT;
+            AnswerType type = AnswerType.PRACTICE_INTERVIEW;
+
+            // When
+            Answer answer = Answer.create(question, account, content, type);
+
+            // Then
+            assertThat(answer).isNotNull();
+            assertThat(answer.getQuestion()).isEqualTo(question);
+            assertThat(answer.getAccount()).isEqualTo(account);
+            assertThat(answer.getContent()).isEqualTo(content);
+            assertThat(answer.getType()).isEqualTo(type);
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.SUBMITTED);
+        }
+
+        @Test
+        @DisplayName("Type이 null이면 AnswerRequiredTypeException 발생")
+        void create_WithNullType_ShouldThrowException() {
+            // Given
+            Question question = mock(Question.class);
+            UserAccount account = mock(UserAccount.class);
+
+            // When & Then
+            assertThatThrownBy(() -> Answer.create(question, account, VALID_CONTENT, null))
+                    .isInstanceOf(AnswerRequiredTypeException.class);
+        }
+
+        @Test
+        @DisplayName("모든 AnswerType으로 생성 가능")
+        void create_WithAllAnswerTypes_ShouldSucceed() {
+            // Given
+            Question question = mock(Question.class);
+            UserAccount account = mock(UserAccount.class);
+
+            // When & Then
+            for (AnswerType type : AnswerType.values()) {
+                Answer answer = Answer.create(question, account, VALID_CONTENT, type);
+                assertThat(answer.getType()).isEqualTo(type);
+            }
+        }
+
+        @Test
+        @DisplayName("초기 상태는 SUBMITTED")
+        void create_ShouldHaveSubmittedStatus() {
+            // Given
+            Question question = mock(Question.class);
+            UserAccount account = mock(UserAccount.class);
+
+            // When
+            Answer answer = Answer.create(question, account, VALID_CONTENT, AnswerType.PRACTICE_INTERVIEW);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.SUBMITTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("Content 업데이트 테스트")
+    class UpdateContentTest {
+
+        @Test
+        @DisplayName("유효한 content로 업데이트 성공")
+        void updateContent_WithValidContent_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswer();
+            String newContent = "새로운 답변 내용입니다.";
+
+            // When
+            answer.updateContent(newContent);
+
+            // Then
+            assertThat(answer.getContent()).isEqualTo(newContent);
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 업데이트 가능 (검증은 Service에서)")
+        void updateContent_WithEmptyString_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswer();
+
+            // When
+            answer.updateContent("");
+
+            // Then
+            assertThat(answer.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("1500자 content로 업데이트 가능")
+        void updateContent_WithMaxLength_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswer();
+            String maxContent = "A".repeat(MAX_CONTENT_SIZE);
+
+            // When
+            answer.updateContent(maxContent);
+
+            // Then
+            assertThat(answer.getContent()).hasSize(MAX_CONTENT_SIZE);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 테스트")
+    class TransitionTest {
+
+        @Test
+        @DisplayName("SUBMITTED → TRANSCRIBING 전이 성공")
+        void transitionTo_FromSubmittedToTranscribing_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+
+            // When
+            answer.transitionTo(AnswerStatus.TRANSCRIBING);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.TRANSCRIBING);
+        }
+
+        @Test
+        @DisplayName("SUBMITTED → IMMEDIATE_FEEDBACK_READY 전이 성공")
+        void transitionTo_FromSubmittedToImmediateFeedbackReady_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+
+            // When
+            answer.transitionTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+        }
+
+        @Test
+        @DisplayName("SUBMITTED → AI_FEEDBACK_PROCESSING 전이 성공")
+        void transitionTo_FromSubmittedToAiFeedbackProcessing_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+
+            // When
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+        }
+
+        @Test
+        @DisplayName("SUBMITTED → FAILED 전이 성공")
+        void transitionTo_FromSubmittedToFailed_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+
+            // When
+            answer.transitionTo(AnswerStatus.FAILED);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("SUBMITTED → COMPLETED 직접 전이 불가")
+        void transitionTo_FromSubmittedToCompleted_ShouldThrowException() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+
+            // When & Then
+            assertThatThrownBy(() -> answer.transitionTo(AnswerStatus.COMPLETED))
+                    .isInstanceOf(InvalidAnswerStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("TRANSCRIBING → IMMEDIATE_FEEDBACK_READY 전이 성공")
+        void transitionTo_FromTranscribingToImmediateFeedbackReady_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+            answer.transitionTo(AnswerStatus.TRANSCRIBING);
+
+            // When
+            answer.transitionTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+        }
+
+        @Test
+        @DisplayName("TRANSCRIBING → FAILED 전이 성공")
+        void transitionTo_FromTranscribingToFailed_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+            answer.transitionTo(AnswerStatus.TRANSCRIBING);
+
+            // When
+            answer.transitionTo(AnswerStatus.FAILED);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("IMMEDIATE_FEEDBACK_READY → AI_FEEDBACK_PROCESSING 전이 성공")
+        void transitionTo_FromImmediateFeedbackReadyToAiFeedbackProcessing_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+            answer.transitionTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+
+            // When
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+        }
+
+        @Test
+        @DisplayName("AI_FEEDBACK_PROCESSING → COMPLETED 전이 성공")
+        void transitionTo_FromAiFeedbackProcessingToCompleted_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // When
+            answer.transitionTo(AnswerStatus.COMPLETED);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("AI_FEEDBACK_PROCESSING → FAILED_RETRYABLE 전이 성공")
+        void transitionTo_FromAiFeedbackProcessingToFailedRetryable_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // When
+            answer.transitionTo(AnswerStatus.FAILED_RETRYABLE);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.FAILED_RETRYABLE);
+        }
+
+        @Test
+        @DisplayName("FAILED_RETRYABLE → AI_FEEDBACK_PROCESSING 재시도 성공")
+        void transitionTo_FromFailedRetryableToAiFeedbackProcessing_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+            answer.transitionTo(AnswerStatus.FAILED_RETRYABLE);
+
+            // When
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 다른 상태로 전이 불가")
+        void transitionTo_FromCompletedToAnyStatus_ShouldThrowException() {
+            // Given
+            Answer answer = AnswerFixture.createCompletedAnswer();
+
+            // When & Then
+            assertThatThrownBy(() -> answer.transitionTo(AnswerStatus.SUBMITTED))
+                    .isInstanceOf(InvalidAnswerStatusTransitionException.class);
+
+            assertThatThrownBy(() -> answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING))
+                    .isInstanceOf(InvalidAnswerStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태에서 다른 상태로 전이 불가")
+        void transitionTo_FromFailedToAnyStatus_ShouldThrowException() {
+            // Given
+            Answer answer = AnswerFixture.createFailedAnswer();
+
+            // When & Then
+            assertThatThrownBy(() -> answer.transitionTo(AnswerStatus.SUBMITTED))
+                    .isInstanceOf(InvalidAnswerStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("AI 피드백 설정 테스트")
+    class SetAiFeedbackTest {
+
+        @Test
+        @DisplayName("AI 피드백 설정 시 상태가 COMPLETED로 변경")
+        void setAiFeedback_ShouldChangeStatusToCompleted() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.AI_FEEDBACK_PROCESSING);
+            String feedback = "답변이 논리적이고 명확합니다.";
+
+            // When
+            answer.setAiFeedback(feedback);
+
+            // Then
+            assertThat(answer.getAiFeedback()).isEqualTo(feedback);
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("빈 피드백도 설정 가능")
+        void setAiFeedback_WithEmptyFeedback_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // When
+            answer.setAiFeedback("");
+
+            // Then
+            assertThat(answer.getAiFeedback()).isEmpty();
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("null 피드백도 설정 가능")
+        void setAiFeedback_WithNullFeedback_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithStatus(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            // When
+            answer.setAiFeedback(null);
+
+            // Then
+            assertThat(answer.getAiFeedback()).isNull();
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("소유권 확인 테스트")
+    class IsOwnedByTest {
+
+        @Test
+        @DisplayName("본인의 답변이면 true 반환")
+        void isOwnedBy_WithOwner_ShouldReturnTrue() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithAccountId(1L);
+
+            // When
+            boolean result = answer.isOwnedBy(1L);
+
+            // Then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 답변이면 false 반환")
+        void isOwnedBy_WithNonOwner_ShouldReturnFalse() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithAccountId(1L);
+
+            // When
+            boolean result = answer.isOwnedBy(999L);
+
+            // Then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("Account가 null이면 false 반환")
+        void isOwnedBy_WithNullAccount_ShouldReturnFalse() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithAccount(null);
+
+            // When
+            boolean result = answer.isOwnedBy(1L);
+
+            // Then
+            assertThat(result).isFalse();
+        }
+    }
+
+}

--- a/src/test/java/com/ktb/fixture/AnswerFixture.java
+++ b/src/test/java/com/ktb/fixture/AnswerFixture.java
@@ -1,0 +1,154 @@
+package com.ktb.fixture;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.question.domain.Question;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AnswerFixture {
+
+    private static final String DEFAULT_CONTENT = "테스트 답변 내용입니다.";
+    private static final AnswerType DEFAULT_TYPE = AnswerType.PRACTICE_INTERVIEW;
+    private static final int MAX_CONTENT_SIZE = 1500;
+
+    public static Answer createAnswer() {
+        return Answer.create(
+                mock(Question.class),
+                mock(UserAccount.class),
+                DEFAULT_CONTENT,
+                DEFAULT_TYPE
+        );
+    }
+
+    public static Answer createAnswerWithContent(String content) {
+        return Answer.create(
+                mock(Question.class),
+                mock(UserAccount.class),
+                content,
+                DEFAULT_TYPE
+        );
+    }
+
+    public static Answer createAnswerWithType(AnswerType type) {
+        return Answer.create(
+                mock(Question.class),
+                mock(UserAccount.class),
+                DEFAULT_CONTENT,
+                type
+        );
+    }
+
+    public static Answer createAnswerWithAccount(UserAccount account) {
+        return Answer.create(
+                mock(Question.class),
+                account,
+                DEFAULT_CONTENT,
+                DEFAULT_TYPE
+        );
+    }
+
+    public static Answer createAnswerWithAccountId(Long accountId) {
+        UserAccount account = mock(UserAccount.class);
+        when(account.getId()).thenReturn(accountId);
+
+        return Answer.create(
+                mock(Question.class),
+                account,
+                DEFAULT_CONTENT,
+                DEFAULT_TYPE
+        );
+    }
+
+    public static Answer createAnswerWithQuestion(Question question) {
+        return Answer.create(
+                question,
+                mock(UserAccount.class),
+                DEFAULT_CONTENT,
+                DEFAULT_TYPE
+        );
+    }
+
+    public static Answer createAnswerWithMaxContent() {
+        String maxContent = "A".repeat(MAX_CONTENT_SIZE);
+        return createAnswerWithContent(maxContent);
+    }
+
+    public static String createContentExceedingMaxLength() {
+        return "A".repeat(MAX_CONTENT_SIZE + 1);
+    }
+
+    public static Answer createAnswerWithStatus(AnswerStatus targetStatus) {
+        Answer answer = createAnswer();
+        transitionToStatus(answer, targetStatus);
+        return answer;
+    }
+
+    public static Answer createAnswerWithAiFeedback(String feedback) {
+        Answer answer = createAnswer();
+        answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+        answer.setAiFeedback(feedback);
+        return answer;
+    }
+
+    public static Answer createCompletedAnswer() {
+        return createAnswerWithAiFeedback("AI 피드백 내용입니다.");
+    }
+
+    public static Answer createFailedAnswer() {
+        Answer answer = createAnswer();
+        answer.transitionTo(AnswerStatus.FAILED);
+        return answer;
+    }
+
+    public static Answer createRetryableFailedAnswer() {
+        Answer answer = createAnswer();
+        answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+        answer.transitionTo(AnswerStatus.FAILED_RETRYABLE);
+        return answer;
+    }
+
+    public static Answer createAnswer(Question question, UserAccount account, String content, AnswerType type) {
+        return Answer.create(question, account, content, type);
+    }
+
+    private static void transitionToStatus(Answer answer, AnswerStatus targetStatus) {
+        switch (targetStatus) {
+            case SUBMITTED:
+                // 기본 상태, 아무 작업 불필요
+                break;
+
+            case TRANSCRIBING:
+                answer.transitionTo(AnswerStatus.TRANSCRIBING);
+                break;
+
+            case IMMEDIATE_FEEDBACK_READY:
+                answer.transitionTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+                break;
+
+            case AI_FEEDBACK_PROCESSING:
+                answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+                break;
+
+            case COMPLETED:
+                answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+                answer.setAiFeedback("AI 피드백");
+                break;
+
+            case FAILED_RETRYABLE:
+                answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+                answer.transitionTo(AnswerStatus.FAILED_RETRYABLE);
+                break;
+
+            case FAILED:
+                answer.transitionTo(AnswerStatus.FAILED);
+                break;
+
+            default:
+                throw new IllegalArgumentException("지원되지 않는 상태: " + targetStatus);
+        }
+    }
+}

--- a/src/test/java/com/ktb/fixture/AnswerHashtagFixture.java
+++ b/src/test/java/com/ktb/fixture/AnswerHashtagFixture.java
@@ -1,0 +1,62 @@
+package com.ktb.fixture;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.hashtag.domain.AnswerHashtag;
+import com.ktb.hashtag.domain.Hashtag;
+
+import static org.mockito.Mockito.mock;
+
+public class AnswerHashtagFixture {
+
+    public static AnswerHashtag createAnswerHashtag() {
+        return AnswerHashtag.create(
+                mock(Answer.class),
+                mock(Hashtag.class)
+        );
+    }
+
+    public static AnswerHashtag createAnswerHashtag(Answer answer, Hashtag hashtag) {
+        return AnswerHashtag.create(answer, hashtag);
+    }
+
+    public static AnswerHashtag createAnswerHashtagWithAnswer(Answer answer) {
+        return AnswerHashtag.create(answer, mock(Hashtag.class));
+    }
+
+    public static AnswerHashtag createAnswerHashtagWithHashtag(Hashtag hashtag) {
+        return AnswerHashtag.create(mock(Answer.class), hashtag);
+    }
+
+    public static AnswerHashtag[] createMultipleAnswerHashtags(Answer answer, Hashtag... hashtags) {
+        return java.util.Arrays.stream(hashtags)
+                .map(hashtag -> AnswerHashtag.create(answer, hashtag))
+                .toArray(AnswerHashtag[]::new);
+    }
+
+    public static AnswerHashtag[] createMultipleAnswerHashtags(Hashtag hashtag, Answer... answers) {
+        return java.util.Arrays.stream(answers)
+                .map(answer -> AnswerHashtag.create(answer, hashtag))
+                .toArray(AnswerHashtag[]::new);
+    }
+
+    public static AnswerHashtag[] createAnswerHashtagsWithNames(Answer answer, String... hashtagNames) {
+        return java.util.Arrays.stream(hashtagNames)
+                .map(name -> {
+                    Hashtag hashtag = HashtagFixture.createHashtag(name);
+                    return AnswerHashtag.create(answer, hashtag);
+                })
+                .toArray(AnswerHashtag[]::new);
+    }
+
+    public static AnswerHashtag createAnswerHashtagWithNullAnswer() {
+        return AnswerHashtag.create(null, mock(Hashtag.class));
+    }
+
+    public static AnswerHashtag createAnswerHashtagWithNullHashtag() {
+        return AnswerHashtag.create(mock(Answer.class), null);
+    }
+
+    public static AnswerHashtag createAnswerHashtagWithBothNull() {
+        return AnswerHashtag.create(null, null);
+    }
+}

--- a/src/test/java/com/ktb/fixture/HashtagFixture.java
+++ b/src/test/java/com/ktb/fixture/HashtagFixture.java
@@ -1,0 +1,104 @@
+package com.ktb.fixture;
+
+import com.ktb.hashtag.domain.Hashtag;
+
+public class HashtagFixture {
+
+    private static final int MAX_NAME_LENGTH = 100;
+    private static int counter = 0;
+
+    public static Hashtag createHashtag() {
+        return Hashtag.create("태그" + (++counter));
+    }
+
+    public static Hashtag createHashtag(String name) {
+        return Hashtag.create(name);
+    }
+
+    public static Hashtag createHashtagWithDescription(String name, String description) {
+        return Hashtag.createWithDescription(name, description);
+    }
+
+    public static Hashtag createHashtagWithMinLength() {
+        return Hashtag.create("a");
+    }
+
+    public static Hashtag createHashtagWithMaxLength() {
+        String maxName = "a".repeat(MAX_NAME_LENGTH);
+        return Hashtag.create(maxName);
+    }
+
+    public static String createNameExceedingMaxLength() {
+        return "a".repeat(MAX_NAME_LENGTH + 1);
+    }
+
+    public static Hashtag createHashtagWithUpperCase(String name) {
+        return Hashtag.create(name.toUpperCase());
+    }
+
+    public static Hashtag createHashtagWithMixedCase(String name) {
+        return Hashtag.create(name);
+    }
+
+    public static Hashtag createHashtagWithSpecialCharacters() {
+        return Hashtag.create("c++");
+    }
+
+    public static Hashtag createHashtagWithHyphen() {
+        return Hashtag.create("spring-boot");
+    }
+
+    public static Hashtag createHashtagWithUnderscore() {
+        return Hashtag.create("snake_case");
+    }
+
+    public static Hashtag createHashtagWithNumbers() {
+        return Hashtag.create("java8");
+    }
+
+    public static Hashtag createKoreanHashtag(String name) {
+        return Hashtag.create(name);
+    }
+
+    public static Hashtag createEnglishHashtag(String name) {
+        return Hashtag.create(name);
+    }
+
+    public static Hashtag createMixedLanguageHashtag() {
+        return Hashtag.create("자바java");
+    }
+
+    public static Hashtag[] createMultipleHashtags(String... names) {
+        return java.util.Arrays.stream(names)
+                .map(Hashtag::create)
+                .toArray(Hashtag[]::new);
+    }
+
+    public static Hashtag[] createUniqueHashtags(int count) {
+        Hashtag[] hashtags = new Hashtag[count];
+        for (int i = 0; i < count; i++) {
+            hashtags[i] = createHashtag();
+        }
+        return hashtags;
+    }
+
+    public static void resetCounter() {
+        counter = 0;
+    }
+
+    public static String createNameWithSpace() {
+        return "spring boot";
+    }
+
+    public static String createNullName() {
+        return null;
+    }
+
+    public static String createEmptyName() {
+        return "";
+    }
+
+    public static String createBlankName() {
+        return "   ";
+    }
+}

--- a/src/test/java/com/ktb/fixture/MetricFixture.java
+++ b/src/test/java/com/ktb/fixture/MetricFixture.java
@@ -1,0 +1,170 @@
+package com.ktb.fixture;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.domain.Metric;
+
+import static org.mockito.Mockito.mock;
+
+public class MetricFixture {
+
+    private static final int MIN_SCORE = 0;
+    private static final int MAX_SCORE = 100;
+    private static final int MAX_NAME_LENGTH = 100;
+    private static final String DEFAULT_DESCRIPTION = "평가 지표 설명";
+
+    public static Metric createMetric() {
+        return Metric.create("평가지표", DEFAULT_DESCRIPTION);
+    }
+
+    public static Metric createMetric(String name) {
+        return Metric.create(name, DEFAULT_DESCRIPTION);
+    }
+
+    public static Metric createMetric(String name, String description) {
+        return Metric.create(name, description);
+    }
+
+    public static Metric createMetricWithoutDescription(String name) {
+        return Metric.create(name, null);
+    }
+
+    public static Metric createMetricWithMinLength() {
+        return Metric.create("A", DEFAULT_DESCRIPTION);
+    }
+
+    public static Metric createMetricWithMaxLength() {
+        String maxName = "A".repeat(MAX_NAME_LENGTH);
+        return Metric.create(maxName, DEFAULT_DESCRIPTION);
+    }
+
+    public static String createNameExceedingMaxLength() {
+        return "A".repeat(MAX_NAME_LENGTH + 1);
+    }
+
+    public static Metric createMetricWithSpaces() {
+        return Metric.create("논리성 평가", DEFAULT_DESCRIPTION);
+    }
+
+    public static Metric createMetricWithSpecialCharacters() {
+        return Metric.create("논리성(Logic)", DEFAULT_DESCRIPTION);
+    }
+
+    public static Metric[] createMultipleMetrics(String... names) {
+        return java.util.Arrays.stream(names)
+                .map(name -> Metric.create(name, DEFAULT_DESCRIPTION))
+                .toArray(Metric[]::new);
+    }
+
+    public static Metric[] createUniqueMetrics(int count) {
+        Metric[] metrics = new Metric[count];
+        for (int i = 0; i < count; i++) {
+            metrics[i] = createMetric();
+        }
+        return metrics;
+    }
+
+    public static Metric createLogicMetric() {
+        return Metric.create("논리성", "답변의 논리적 구조와 일관성");
+    }
+
+    public static Metric createClarityMetric() {
+        return Metric.create("명확성", "답변의 명확함과 이해도");
+    }
+
+    public static Metric createConcisenessMetric() {
+        return Metric.create("간결성", "답변의 간결함");
+    }
+
+    public static Metric createCompletenessMetric() {
+        return Metric.create("완성도", "답변의 전체적인 완성도");
+    }
+
+    public static AnswerMetric createAnswerMetric() {
+        return AnswerMetric.create(
+                mock(Answer.class),
+                mock(Metric.class),
+                50
+        );
+    }
+
+    public static AnswerMetric createAnswerMetric(int score) {
+        return AnswerMetric.create(
+                mock(Answer.class),
+                mock(Metric.class),
+                score
+        );
+    }
+
+    public static AnswerMetric createAnswerMetric(Answer answer, Metric metric, int score) {
+        return AnswerMetric.create(answer, metric, score);
+    }
+
+    public static AnswerMetric createAnswerMetricWithAnswer(Answer answer, int score) {
+        return AnswerMetric.create(answer, mock(Metric.class), score);
+    }
+
+    public static AnswerMetric createAnswerMetricWithMetric(Metric metric, int score) {
+        return AnswerMetric.create(mock(Answer.class), metric, score);
+    }
+
+    public static AnswerMetric createAnswerMetricWithMinScore() {
+        return createAnswerMetric(MIN_SCORE);
+    }
+
+    public static AnswerMetric createAnswerMetricWithMaxScore() {
+        return createAnswerMetric(MAX_SCORE);
+    }
+
+    public static AnswerMetric createAnswerMetricWithMinScore(Answer answer, Metric metric) {
+        return AnswerMetric.create(answer, metric, MIN_SCORE);
+    }
+
+    public static AnswerMetric createAnswerMetricWithMaxScore(Answer answer, Metric metric) {
+        return AnswerMetric.create(answer, metric, MAX_SCORE);
+    }
+
+    public static AnswerMetric createHighScoreAnswerMetric() {
+        return createAnswerMetric(85);
+    }
+
+    public static AnswerMetric createMediumScoreAnswerMetric() {
+        return createAnswerMetric(50);
+    }
+
+    public static AnswerMetric createLowScoreAnswerMetric() {
+        return createAnswerMetric(15);
+    }
+
+    public static AnswerMetric[] createMultipleAnswerMetrics(Answer answer, Metric[] metrics, int[] scores) {
+        if (metrics.length != scores.length) {
+            throw new IllegalArgumentException("metrics와 scores의 길이가 같아야 합니다");
+        }
+
+        AnswerMetric[] answerMetrics = new AnswerMetric[metrics.length];
+        for (int i = 0; i < metrics.length; i++) {
+            answerMetrics[i] = AnswerMetric.create(answer, metrics[i], scores[i]);
+        }
+        return answerMetrics;
+    }
+
+    public static int createScoreBelowMin() {
+        return MIN_SCORE - 1;
+    }
+
+    public static int createScoreAboveMax() {
+        return MAX_SCORE + 1;
+    }
+
+    public static String createNullName() {
+        return null;
+    }
+
+    public static String createEmptyName() {
+        return "";
+    }
+
+    public static String createBlankName() {
+        return "   ";
+    }
+}

--- a/src/test/java/com/ktb/fixture/README.md
+++ b/src/test/java/com/ktb/fixture/README.md
@@ -1,0 +1,451 @@
+# Fixture 클래스 사용 가이드
+
+> 테스트 데이터 생성을 위한 재사용 가능한 Fixture 패키지
+
+---
+
+## 📋 개요
+
+이 패키지는 테스트에서 반복적으로 사용되는 엔티티 생성 로직을 중앙화하여 관리합니다.
+**Fixture 패턴**을 통해 테스트 코드의 가독성을 높이고 유지보수를 용이하게 합니다.
+
+---
+
+## 🎯 Fixture 패턴의 이점
+
+### ✅ 장점
+1. **재사용성**: 동일한 테스트 데이터를 여러 테스트에서 일관되게 사용
+2. **가독성**: Given 절이 간결해지고 테스트 의도가 명확해짐
+3. **유지보수성**: 엔티티 구조 변경 시 Fixture만 수정하면 됨
+4. **일관성**: 프로젝트 전체에서 동일한 방식으로 테스트 데이터 생성
+
+### ❌ Fixture 없이 작성한 경우
+```java
+@Test
+void test() {
+    // Given - 복잡하고 반복적인 생성 로직
+    UserAccount account = mock(UserAccount.class);
+    when(account.getId()).thenReturn(1L);
+    Question question = mock(Question.class);
+    Answer answer = Answer.create(
+        question,
+        account,
+        "테스트 답변 내용입니다.",
+        AnswerType.PRACTICE_INTERVIEW
+    );
+    answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+    answer.setAiFeedback("AI 피드백");
+
+    // When & Then...
+}
+```
+
+### ✅ Fixture를 사용한 경우
+```java
+@Test
+void test() {
+    // Given - 간결하고 명확한 의도 표현
+    Answer answer = AnswerFixture.createCompletedAnswer();
+
+    // When & Then...
+}
+```
+
+---
+
+## 📦 Fixture 클래스 목록
+
+| Fixture 클래스 | 설명 | 위치 |
+|--------------|------|------|
+| **AnswerFixture** | Answer 엔티티 생성 | `com.ktb.fixture.AnswerFixture` |
+| **HashtagFixture** | Hashtag 엔티티 생성 | `com.ktb.fixture.HashtagFixture` |
+| **MetricFixture** | Metric, AnswerMetric 생성 | `com.ktb.fixture.MetricFixture` |
+| **AnswerHashtagFixture** | AnswerHashtag 연관 생성 | `com.ktb.fixture.AnswerHashtagFixture` |
+
+---
+
+## 🔧 AnswerFixture 사용법
+
+### 기본 생성
+```java
+// 기본 Answer 생성
+Answer answer = AnswerFixture.createAnswer();
+
+// 특정 content를 가진 Answer
+Answer answer = AnswerFixture.createAnswerWithContent("특정 내용");
+
+// 특정 AnswerType을 가진 Answer
+Answer answer = AnswerFixture.createAnswerWithType(AnswerType.REAL_INTERVIEW);
+```
+
+### 특정 상태의 Answer 생성
+```java
+// SUBMITTED 상태 (기본)
+Answer submitted = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+
+// AI_FEEDBACK_PROCESSING 상태
+Answer processing = AnswerFixture.createAnswerWithStatus(AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+// COMPLETED 상태 (AI 피드백 포함)
+Answer completed = AnswerFixture.createCompletedAnswer();
+
+// FAILED 상태
+Answer failed = AnswerFixture.createFailedAnswer();
+
+// FAILED_RETRYABLE 상태
+Answer retryable = AnswerFixture.createRetryableFailedAnswer();
+```
+
+### UserAccount와 함께 생성
+```java
+// Mock UserAccount와 함께
+UserAccount account = mock(UserAccount.class);
+Answer answer = AnswerFixture.createAnswerWithAccount(account);
+
+// 특정 ID를 가진 Account와 함께
+Answer answer = AnswerFixture.createAnswerWithAccountId(1L);
+```
+
+### 경계값 테스트용
+```java
+// 최대 길이 content
+Answer maxContent = AnswerFixture.createAnswerWithMaxContent();
+
+// 최대 길이 초과 content (예외 발생용)
+String exceedingContent = AnswerFixture.createContentExceedingMaxLength();
+```
+
+---
+
+## 🔧 HashtagFixture 사용법
+
+### 기본 생성
+```java
+// 고유한 이름의 Hashtag (자동 증가)
+Hashtag hashtag = HashtagFixture.createHashtag();
+
+// 특정 이름의 Hashtag
+Hashtag java = HashtagFixture.createHashtag("java");
+
+// 설명과 함께
+Hashtag hashtag = HashtagFixture.createHashtagWithDescription("java", "자바 프로그래밍");
+```
+
+### 경계값 및 예외 테스트용
+```java
+// 1자 이름
+Hashtag min = HashtagFixture.createHashtagWithMinLength();
+
+// 100자 이름
+Hashtag max = HashtagFixture.createHashtagWithMaxLength();
+
+// 101자 이름 (예외 발생용)
+String exceeding = HashtagFixture.createNameExceedingMaxLength();
+
+// 공백 포함 (예외 발생용)
+String withSpace = HashtagFixture.createNameWithSpace();
+
+// null, 빈 문자열 (예외 발생용)
+String nullName = HashtagFixture.createNullName();
+String empty = HashtagFixture.createEmptyName();
+String blank = HashtagFixture.createBlankName();
+```
+
+### 특수 케이스
+```java
+// 특수문자 포함
+Hashtag cpp = HashtagFixture.createHashtagWithSpecialCharacters(); // "c++"
+
+// 하이픈 포함
+Hashtag springBoot = HashtagFixture.createHashtagWithHyphen(); // "spring-boot"
+
+// 언더스코어 포함
+Hashtag snake = HashtagFixture.createHashtagWithUnderscore(); // "snake_case"
+
+// 숫자 포함
+Hashtag java8 = HashtagFixture.createHashtagWithNumbers(); // "java8"
+
+// 혼합 언어
+Hashtag mixed = HashtagFixture.createMixedLanguageHashtag(); // "자바java"
+```
+
+### 여러 개 생성
+```java
+// 특정 이름들로 여러 개 생성
+Hashtag[] hashtags = HashtagFixture.createMultipleHashtags("java", "spring", "jpa");
+
+// 고유한 이름으로 n개 생성
+Hashtag[] uniqueHashtags = HashtagFixture.createUniqueHashtags(5);
+```
+
+---
+
+## 🔧 MetricFixture 사용법
+
+### Metric 생성
+```java
+// 기본 Metric (고유한 이름)
+Metric metric = MetricFixture.createMetric();
+
+// 특정 이름의 Metric
+Metric logic = MetricFixture.createMetric("논리성");
+
+// 이름과 설명 함께
+Metric metric = MetricFixture.createMetric("논리성", "답변의 논리적 구조");
+
+// 설명 없이
+Metric metric = MetricFixture.createMetricWithoutDescription("논리성");
+```
+
+### 자주 사용되는 평가 지표
+```java
+Metric logic = MetricFixture.createLogicMetric();         // 논리성
+Metric clarity = MetricFixture.createClarityMetric();     // 명확성
+Metric conciseness = MetricFixture.createConcisenessMetric(); // 간결성
+Metric completeness = MetricFixture.createCompletenessMetric(); // 완성도
+```
+
+### AnswerMetric 생성
+```java
+// 기본 AnswerMetric (점수 50)
+AnswerMetric am = MetricFixture.createAnswerMetric();
+
+// 특정 점수
+AnswerMetric am80 = MetricFixture.createAnswerMetric(80);
+
+// 특정 Answer, Metric과 함께
+AnswerMetric am = MetricFixture.createAnswerMetric(answer, metric, 85);
+
+// 최소/최대 점수
+AnswerMetric min = MetricFixture.createAnswerMetricWithMinScore(); // 0
+AnswerMetric max = MetricFixture.createAnswerMetricWithMaxScore(); // 100
+```
+
+### 점수 범위별 생성
+```java
+// 높은 점수 (85)
+AnswerMetric high = MetricFixture.createHighScoreAnswerMetric();
+
+// 중간 점수 (50)
+AnswerMetric medium = MetricFixture.createMediumScoreAnswerMetric();
+
+// 낮은 점수 (15)
+AnswerMetric low = MetricFixture.createLowScoreAnswerMetric();
+```
+
+### 예외 테스트용
+```java
+// 범위 초과 점수
+int belowMin = MetricFixture.createScoreBelowMin(); // -1
+int aboveMax = MetricFixture.createScoreAboveMax(); // 101
+```
+
+---
+
+## 🔧 AnswerHashtagFixture 사용법
+
+### 기본 생성
+```java
+// Mock Answer, Mock Hashtag와 함께
+AnswerHashtag ah = AnswerHashtagFixture.createAnswerHashtag();
+
+// 특정 Answer와 Hashtag
+AnswerHashtag ah = AnswerHashtagFixture.createAnswerHashtag(answer, hashtag);
+
+// Answer만 지정
+AnswerHashtag ah = AnswerHashtagFixture.createAnswerHashtagWithAnswer(answer);
+
+// Hashtag만 지정
+AnswerHashtag ah = AnswerHashtagFixture.createAnswerHashtagWithHashtag(hashtag);
+```
+
+### 여러 개 생성
+```java
+// 하나의 Answer에 여러 Hashtag 연결
+Hashtag[] hashtags = {tag1, tag2, tag3};
+AnswerHashtag[] ahs = AnswerHashtagFixture.createMultipleAnswerHashtags(answer, hashtags);
+
+// 하나의 Hashtag에 여러 Answer 연결
+Answer[] answers = {answer1, answer2};
+AnswerHashtag[] ahs = AnswerHashtagFixture.createMultipleAnswerHashtags(hashtag, answers);
+
+// Answer와 태그 이름 배열로 생성
+AnswerHashtag[] ahs = AnswerHashtagFixture.createAnswerHashtagsWithNames(
+    answer,
+    "java", "spring", "jpa"
+);
+```
+
+### null 테스트용
+```java
+AnswerHashtag nullAnswer = AnswerHashtagFixture.createAnswerHashtagWithNullAnswer();
+AnswerHashtag nullHashtag = AnswerHashtagFixture.createAnswerHashtagWithNullHashtag();
+AnswerHashtag bothNull = AnswerHashtagFixture.createAnswerHashtagWithBothNull();
+```
+
+---
+
+## 📝 테스트 작성 예시
+
+### Before (Fixture 없이)
+```java
+@Test
+void test() {
+    // Given - 복잡하고 반복적
+    UserAccount account = mock(UserAccount.class);
+    when(account.getId()).thenReturn(1L);
+    Answer answer = Answer.create(
+        mock(Question.class),
+        account,
+        "테스트 답변",
+        AnswerType.PRACTICE_INTERVIEW
+    );
+
+    Metric logic = Metric.create("논리성", "설명");
+    AnswerMetric am = AnswerMetric.create(answer, logic, 85);
+
+    // When
+    am.updateScore(90);
+
+    // Then
+    assertThat(am.getScore()).isEqualTo(90);
+}
+```
+
+### After (Fixture 사용)
+```java
+@Test
+void test() {
+    // Given - 간결하고 명확
+    Answer answer = AnswerFixture.createAnswer();
+    Metric logic = MetricFixture.createLogicMetric();
+    AnswerMetric am = MetricFixture.createAnswerMetric(answer, logic, 85);
+
+    // When
+    am.updateScore(90);
+
+    // Then
+    assertThat(am.getScore()).isEqualTo(90);
+}
+```
+
+---
+
+## 🎨 Best Practices
+
+### 1. 의미 있는 메서드 선택
+```java
+// ❌ 나쁜 예
+Answer answer = AnswerFixture.createAnswer();
+answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+answer.setAiFeedback("피드백");
+
+// ✅ 좋은 예
+Answer answer = AnswerFixture.createCompletedAnswer();
+```
+
+### 2. 테스트 의도에 맞는 Fixture 사용
+```java
+// 상태 전이 테스트
+@Test
+void transitionTest() {
+    Answer submitted = AnswerFixture.createAnswerWithStatus(AnswerStatus.SUBMITTED);
+    // ...
+}
+
+// 소유권 테스트
+@Test
+void ownershipTest() {
+    Answer answer = AnswerFixture.createAnswerWithAccountId(1L);
+    // ...
+}
+
+// 경계값 테스트
+@Test
+void boundaryTest() {
+    Answer maxContent = AnswerFixture.createAnswerWithMaxContent();
+    // ...
+}
+```
+
+### 3. 불필요한 설정 피하기
+```java
+// ❌ 나쁜 예 - 불필요한 Mock 설정
+UserAccount account = mock(UserAccount.class);
+when(account.getId()).thenReturn(1L);
+when(account.getNickname()).thenReturn("테스터");
+when(account.getEmail()).thenReturn("test@test.com");
+Answer answer = AnswerFixture.createAnswerWithAccount(account);
+
+// ✅ 좋은 예 - 필요한 것만 설정
+Answer answer = AnswerFixture.createAnswerWithAccountId(1L);
+```
+
+### 4. 테스트 간 독립성 보장
+```java
+@BeforeEach
+void setUp() {
+    // Counter 초기화로 테스트 간 독립성 보장
+    HashtagFixture.resetCounter();
+    MetricFixture.resetCounter();
+}
+```
+
+---
+
+## 🔄 Fixture 확장 가이드
+
+새로운 엔티티에 대한 Fixture를 추가할 때는 다음 패턴을 따르세요:
+
+```java
+public class NewEntityFixture {
+
+    // 1. 기본 생성 메서드
+    public static NewEntity createEntity() { }
+
+    // 2. 특정 필드를 가진 생성 메서드
+    public static NewEntity createEntityWithField(Type field) { }
+
+    // 3. 경계값 테스트용 메서드
+    public static NewEntity createEntityWithMaxValue() { }
+    public static String createValueExceedingMax() { }
+
+    // 4. 예외 테스트용 메서드
+    public static String createNullValue() { }
+    public static String createEmptyValue() { }
+
+    // 5. 여러 개 생성 메서드
+    public static NewEntity[] createMultipleEntities(int count) { }
+
+    // 6. Counter 초기화
+    public static void resetCounter() { }
+}
+```
+
+---
+
+## 📊 Fixture 사용 통계
+
+현재 프로젝트의 Fixture 사용 현황:
+
+| 도메인 | Fixture 메서드 수 | 주요 기능 |
+|-------|----------------|----------|
+| **Answer** | 14개 | 상태 전이, 소유권, 경계값 |
+| **Hashtag** | 18개 | 정규화, 특수문자, 다국어 |
+| **Metric** | 24개 | 점수 범위, 평가 지표, 연관 관계 |
+| **AnswerHashtag** | 8개 | 다대다 관계, null 처리 |
+
+**총 64개의 재사용 가능한 Fixture 메서드**
+
+---
+
+## 🎓 참고 자료
+
+- [Test Data Builder 패턴](https://martinfowler.com/bliki/ObjectMother.html)
+- [Fixture 패턴 설명](https://xunitpatterns.com/Test%20Fixture.html)
+- 프로젝트 규칙: `/backend/CLAUDE.md` (테스트 Fixture/Factory 패턴)
+
+---
+
+**Last Updated**: 2026-01-21
+**Maintainer**: QFeed Backend Team

--- a/src/test/java/com/ktb/hashtag/domain/AnswerHashtagTest.java
+++ b/src/test/java/com/ktb/hashtag/domain/AnswerHashtagTest.java
@@ -1,0 +1,166 @@
+package com.ktb.hashtag.domain;
+
+import com.ktb.answer.domain.Answer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("AnswerHashtag 도메인 테스트")
+class AnswerHashtagTest {
+
+    @Nested
+    @DisplayName("AnswerHashtag 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 Answer와 Hashtag로 생성 성공")
+        void create_WithValidData_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Hashtag hashtag = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(answer, hashtag);
+
+            // Then
+            assertThat(answerHashtag).isNotNull();
+            assertThat(answerHashtag.getAnswer()).isEqualTo(answer);
+            assertThat(answerHashtag.getHashtag()).isEqualTo(hashtag);
+        }
+
+        @Test
+        @DisplayName("Answer null로 생성 가능 (Service 레이어에서 검증)")
+        void create_WithNullAnswer_ShouldSucceed() {
+            // Given
+            Hashtag hashtag = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(null, hashtag);
+
+            // Then
+            assertThat(answerHashtag.getAnswer()).isNull();
+            assertThat(answerHashtag.getHashtag()).isEqualTo(hashtag);
+        }
+
+        @Test
+        @DisplayName("Hashtag null로 생성 가능 (Service 레이어에서 검증)")
+        void create_WithNullHashtag_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(answer, null);
+
+            // Then
+            assertThat(answerHashtag.getAnswer()).isEqualTo(answer);
+            assertThat(answerHashtag.getHashtag()).isNull();
+        }
+
+        @Test
+        @DisplayName("Answer와 Hashtag 모두 null로 생성 가능")
+        void create_WithBothNull_ShouldSucceed() {
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(null, null);
+
+            // Then
+            assertThat(answerHashtag.getAnswer()).isNull();
+            assertThat(answerHashtag.getHashtag()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("엔티티 관계 테스트")
+    class RelationshipTest {
+
+        @Test
+        @DisplayName("Answer와 Hashtag가 올바르게 설정됨")
+        void create_ShouldSetBothAnswerAndHashtag() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Hashtag hashtag = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(answer, hashtag);
+
+            // Then
+            assertThat(answerHashtag.getAnswer()).isNotNull();
+            assertThat(answerHashtag.getHashtag()).isNotNull();
+            assertThat(answerHashtag.getAnswer()).isEqualTo(answer);
+            assertThat(answerHashtag.getHashtag()).isEqualTo(hashtag);
+        }
+
+        @Test
+        @DisplayName("동일한 Answer로 여러 AnswerHashtag 생성 가능 (다른 Hashtag)")
+        void create_SameAnswerWithDifferentHashtags_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Hashtag hashtag1 = mock(Hashtag.class);
+            Hashtag hashtag2 = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag1 = AnswerHashtag.create(answer, hashtag1);
+            AnswerHashtag answerHashtag2 = AnswerHashtag.create(answer, hashtag2);
+
+            // Then
+            assertThat(answerHashtag1.getAnswer()).isEqualTo(answer);
+            assertThat(answerHashtag2.getAnswer()).isEqualTo(answer);
+            assertThat(answerHashtag1.getHashtag()).isNotEqualTo(answerHashtag2.getHashtag());
+        }
+
+        @Test
+        @DisplayName("동일한 Hashtag로 여러 AnswerHashtag 생성 가능 (다른 Answer)")
+        void create_SameHashtagWithDifferentAnswers_ShouldSucceed() {
+            // Given
+            Answer answer1 = mock(Answer.class);
+            Answer answer2 = mock(Answer.class);
+            Hashtag hashtag = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag1 = AnswerHashtag.create(answer1, hashtag);
+            AnswerHashtag answerHashtag2 = AnswerHashtag.create(answer2, hashtag);
+
+            // Then
+            assertThat(answerHashtag1.getHashtag()).isEqualTo(hashtag);
+            assertThat(answerHashtag2.getHashtag()).isEqualTo(hashtag);
+            assertThat(answerHashtag1.getAnswer()).isNotEqualTo(answerHashtag2.getAnswer());
+        }
+    }
+
+    @Nested
+    @DisplayName("불변성 테스트")
+    class ImmutabilityTest {
+
+        @Test
+        @DisplayName("생성 후 Answer 참조 변경 불가")
+        void create_AnswerIsImmutable() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Hashtag hashtag = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(answer, hashtag);
+
+            // Then
+            assertThat(answerHashtag.getAnswer()).isEqualTo(answer);
+            // Setter가 없으므로 변경 불가능
+        }
+
+        @Test
+        @DisplayName("생성 후 Hashtag 참조 변경 불가")
+        void create_HashtagIsImmutable() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Hashtag hashtag = mock(Hashtag.class);
+
+            // When
+            AnswerHashtag answerHashtag = AnswerHashtag.create(answer, hashtag);
+
+            // Then
+            assertThat(answerHashtag.getHashtag()).isEqualTo(hashtag);
+            // Setter가 없으므로 변경 불가능
+        }
+    }
+}

--- a/src/test/java/com/ktb/hashtag/domain/HashtagTest.java
+++ b/src/test/java/com/ktb/hashtag/domain/HashtagTest.java
@@ -1,0 +1,354 @@
+package com.ktb.hashtag.domain;
+
+import com.ktb.hashtag.exception.HashtagNameContainsSpaceException;
+import com.ktb.hashtag.exception.HashtagNameInvalidLengthException;
+import com.ktb.hashtag.exception.HashtagNameRequiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Hashtag 도메인 테스트")
+class HashtagTest {
+
+    private static final int MAX_NAME_LENGTH = 100;
+
+    @Nested
+    @DisplayName("Hashtag 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 이름으로 Hashtag 생성 성공")
+        void create_WithValidName_ShouldSucceed() {
+            // Given
+            String name = "자바";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag).isNotNull();
+            assertThat(hashtag.getName()).isEqualTo("자바");
+            assertThat(hashtag.getDescription()).isNull();
+        }
+
+        @Test
+        @DisplayName("설명과 함께 Hashtag 생성 성공")
+        void createWithDescription_ShouldSucceed() {
+            // Given
+            String name = "자바";
+            String description = "자바 프로그래밍 언어";
+
+            // When
+            Hashtag hashtag = Hashtag.createWithDescription(name, description);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("자바");
+            assertThat(hashtag.getDescription()).isEqualTo(description);
+        }
+
+        @Test
+        @DisplayName("대문자 이름은 소문자로 정규화")
+        void create_WithUpperCase_ShouldNormalizeToLowerCase() {
+            // Given
+            String name = "JAVA";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("java");
+        }
+
+        @Test
+        @DisplayName("혼합 대소문자 이름은 소문자로 정규화")
+        void create_WithMixedCase_ShouldNormalizeToLowerCase() {
+            // Given
+            String name = "JavaScript";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("javascript");
+        }
+
+        @Test
+        @DisplayName("앞뒤 공백이 있는 이름은 HashtagNameContainsSpaceException 발생")
+        void create_WithLeadingTrailingSpaces_ShouldThrowException() {
+            // Given
+            String name = "  Spring  ";
+
+            // When & Then
+            assertThatThrownBy(() -> Hashtag.create(name))
+                    .isInstanceOf(HashtagNameContainsSpaceException.class);
+        }
+
+        @Test
+        @DisplayName("1자 이름으로 생성 성공")
+        void create_WithOneCharacter_ShouldSucceed() {
+            // Given
+            String name = "A";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("a");
+        }
+
+        @Test
+        @DisplayName("100자 이름으로 생성 성공")
+        void create_WithMaxLength_ShouldSucceed() {
+            // Given
+            String name = "A".repeat(MAX_NAME_LENGTH);
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).hasSize(MAX_NAME_LENGTH);
+        }
+
+        @Test
+        @DisplayName("101자 이름으로 생성 시 HashtagNameInvalidLengthException 발생")
+        void create_WithExceedingMaxLength_ShouldThrowException() {
+            // Given
+            String name = "A".repeat(MAX_NAME_LENGTH + 1);
+
+            // When & Then
+            assertThatThrownBy(() -> Hashtag.create(name))
+                    .isInstanceOf(HashtagNameInvalidLengthException.class);
+        }
+
+        @Test
+        @DisplayName("null 이름으로 생성 시 HashtagNameRequiredException 발생")
+        void create_WithNull_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> Hashtag.create(null))
+                    .isInstanceOf(HashtagNameRequiredException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 이름으로 생성 시 HashtagNameRequiredException 발생")
+        void create_WithEmptyString_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> Hashtag.create(""))
+                    .isInstanceOf(HashtagNameRequiredException.class);
+        }
+
+        @Test
+        @DisplayName("공백만 있는 이름으로 생성 시 HashtagNameRequiredException 발생")
+        void create_WithOnlySpaces_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> Hashtag.create("   "))
+                    .isInstanceOf(HashtagNameRequiredException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"자바 스크립트", "Spring Boot", "C Sharp", "Node JS"})
+        @DisplayName("공백이 포함된 이름으로 생성 시 HashtagNameContainsSpaceException 발생")
+        void create_WithSpaces_ShouldThrowException(String name) {
+            // When & Then
+            assertThatThrownBy(() -> Hashtag.create(name))
+                    .isInstanceOf(HashtagNameContainsSpaceException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("특수 문자 및 다국어 테스트")
+    class SpecialCharacterTest {
+
+        @Test
+        @DisplayName("특수문자가 포함된 이름 생성 가능")
+        void create_WithSpecialCharacters_ShouldSucceed() {
+            // Given
+            String name = "C++";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("c++");
+        }
+
+        @Test
+        @DisplayName("하이픈이 포함된 이름 생성 가능")
+        void create_WithHyphen_ShouldSucceed() {
+            // Given
+            String name = "spring-boot";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("spring-boot");
+        }
+
+        @Test
+        @DisplayName("언더스코어가 포함된 이름 생성 가능")
+        void create_WithUnderscore_ShouldSucceed() {
+            // Given
+            String name = "snake_case";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("snake_case");
+        }
+
+        @Test
+        @DisplayName("숫자가 포함된 이름 생성 가능")
+        void create_WithNumbers_ShouldSucceed() {
+            // Given
+            String name = "Java8";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("java8");
+        }
+
+        @Test
+        @DisplayName("한글과 영어가 혼합된 이름 생성 가능")
+        void create_WithKoreanAndEnglish_ShouldSucceed() {
+            // Given
+            String name = "자바JAVA";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("자바java");
+        }
+
+        @Test
+        @DisplayName("한글만 있는 이름 생성 가능")
+        void create_WithKoreanOnly_ShouldSucceed() {
+            // Given
+            String name = "자바프로그래밍";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("자바프로그래밍");
+        }
+
+        @Test
+        @DisplayName("일본어 이름 생성 가능")
+        void create_WithJapanese_ShouldSucceed() {
+            // Given
+            String name = "プログラミング";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("プログラミング");
+        }
+    }
+
+    @Nested
+    @DisplayName("설명 업데이트 테스트")
+    class UpdateDescriptionTest {
+
+        @Test
+        @DisplayName("설명 업데이트 성공")
+        void updateDescription_WithValidDescription_ShouldSucceed() {
+            // Given
+            Hashtag hashtag = Hashtag.create("java");
+            String newDescription = "자바 프로그래밍 언어";
+
+            // When
+            hashtag.updateDescription(newDescription);
+
+            // Then
+            assertThat(hashtag.getDescription()).isEqualTo(newDescription);
+        }
+
+        @Test
+        @DisplayName("설명을 null로 업데이트 가능")
+        void updateDescription_WithNull_ShouldSucceed() {
+            // Given
+            Hashtag hashtag = Hashtag.createWithDescription("java", "기존 설명");
+
+            // When
+            hashtag.updateDescription(null);
+
+            // Then
+            assertThat(hashtag.getDescription()).isNull();
+        }
+
+        @Test
+        @DisplayName("설명을 빈 문자열로 업데이트 가능")
+        void updateDescription_WithEmptyString_ShouldSucceed() {
+            // Given
+            Hashtag hashtag = Hashtag.createWithDescription("java", "기존 설명");
+
+            // When
+            hashtag.updateDescription("");
+
+            // Then
+            assertThat(hashtag.getDescription()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("255자 설명 업데이트 가능")
+        void updateDescription_WithMaxLength_ShouldSucceed() {
+            // Given
+            Hashtag hashtag = Hashtag.create("java");
+            String longDescription = "A".repeat(255);
+
+            // When
+            hashtag.updateDescription(longDescription);
+
+            // Then
+            assertThat(hashtag.getDescription()).hasSize(255);
+        }
+    }
+
+    @Nested
+    @DisplayName("정규화 테스트")
+    class NormalizationTest {
+
+        @Test
+        @DisplayName("동일한 이름(대소문자 다름)은 정규화 후 같은 값")
+        void normalize_WithDifferentCase_ShouldBeSameAfterNormalization() {
+            // Given
+            String name1 = "Java";
+            String name2 = "JAVA";
+            String name3 = "java";
+
+            // When
+            Hashtag hashtag1 = Hashtag.create(name1);
+            Hashtag hashtag2 = Hashtag.create(name2);
+            Hashtag hashtag3 = Hashtag.create(name3);
+
+            // Then
+            assertThat(hashtag1.getName())
+                    .isEqualTo(hashtag2.getName())
+                    .isEqualTo(hashtag3.getName())
+                    .isEqualTo("java");
+        }
+
+        @Test
+        @DisplayName("소문자 변환 확인")
+        void normalize_ShouldConvertToLowerCase() {
+            // Given
+            String name = "JavaScript";
+
+            // When
+            Hashtag hashtag = Hashtag.create(name);
+
+            // Then
+            assertThat(hashtag.getName()).isEqualTo("javascript");
+        }
+    }
+}

--- a/src/test/java/com/ktb/metric/domain/AnswerMetricTest.java
+++ b/src/test/java/com/ktb/metric/domain/AnswerMetricTest.java
@@ -1,0 +1,368 @@
+package com.ktb.metric.domain;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.metric.exception.MetricInvalidRangeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("AnswerMetric 도메인 테스트")
+class AnswerMetricTest {
+
+    private static final int MIN_SCORE = 0;
+    private static final int MAX_SCORE = 100;
+
+    @Nested
+    @DisplayName("AnswerMetric 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 값으로 AnswerMetric 생성 성공")
+        void create_WithValidData_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+            int score = 85;
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(answer, metric, score);
+
+            // Then
+            assertThat(answerMetric).isNotNull();
+            assertThat(answerMetric.getAnswer()).isEqualTo(answer);
+            assertThat(answerMetric.getMetric()).isEqualTo(metric);
+            assertThat(answerMetric.getScore()).isEqualTo(score);
+        }
+
+        @Test
+        @DisplayName("최소 점수(0)로 생성 성공")
+        void create_WithMinScore_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(answer, metric, MIN_SCORE);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(MIN_SCORE);
+        }
+
+        @Test
+        @DisplayName("최대 점수(100)로 생성 성공")
+        void create_WithMaxScore_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(answer, metric, MAX_SCORE);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(MAX_SCORE);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, 1, 25, 50, 75, 99, 100})
+        @DisplayName("0~100 범위 내 모든 점수로 생성 가능")
+        void create_WithValidScores_ShouldSucceed(int score) {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(answer, metric, score);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(score);
+        }
+
+        @Test
+        @DisplayName("점수가 -1이면 MetricInvalidRangeException 발생")
+        void create_WithNegativeScore_ShouldThrowException() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, -1))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @Test
+        @DisplayName("점수가 101이면 MetricInvalidRangeException 발생")
+        void create_WithScoreExceedingMax_ShouldThrowException() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, 101))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {-999999, -100, -10, -1})
+        @DisplayName("음수 점수로 생성 시 MetricInvalidRangeException 발생")
+        void create_WithNegativeScores_ShouldThrowException(int score) {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, score))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {101, 150, 200, 999999})
+        @DisplayName("100 초과 점수로 생성 시 MetricInvalidRangeException 발생")
+        void create_WithScoresExceedingMax_ShouldThrowException(int score) {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, score))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("점수 업데이트 테스트")
+    class UpdateScoreTest {
+
+        @Test
+        @DisplayName("유효한 점수로 업데이트 성공")
+        void updateScore_WithValidScore_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+            int newScore = 90;
+
+            // When
+            answerMetric.updateScore(newScore);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(newScore);
+        }
+
+        @Test
+        @DisplayName("점수를 0으로 업데이트 가능")
+        void updateScore_ToMinScore_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+
+            // When
+            answerMetric.updateScore(MIN_SCORE);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(MIN_SCORE);
+        }
+
+        @Test
+        @DisplayName("점수를 100으로 업데이트 가능")
+        void updateScore_ToMaxScore_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+
+            // When
+            answerMetric.updateScore(MAX_SCORE);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(MAX_SCORE);
+        }
+
+        @Test
+        @DisplayName("점수 증가 업데이트")
+        void updateScore_Increasing_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(30);
+
+            // When
+            answerMetric.updateScore(70);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(70);
+        }
+
+        @Test
+        @DisplayName("점수 감소 업데이트")
+        void updateScore_Decreasing_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(90);
+
+            // When
+            answerMetric.updateScore(40);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(40);
+        }
+
+        @Test
+        @DisplayName("점수를 -1로 업데이트 시 MetricInvalidRangeException 발생")
+        void updateScore_WithNegativeScore_ShouldThrowException() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+
+            // When & Then
+            assertThatThrownBy(() -> answerMetric.updateScore(-1))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @Test
+        @DisplayName("점수를 101로 업데이트 시 MetricInvalidRangeException 발생")
+        void updateScore_WithScoreExceedingMax_ShouldThrowException() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+
+            // When & Then
+            assertThatThrownBy(() -> answerMetric.updateScore(101))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @Test
+        @DisplayName("여러 번 점수 업데이트 가능")
+        void updateScore_Multiple_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+
+            // When
+            answerMetric.updateScore(60);
+            answerMetric.updateScore(70);
+            answerMetric.updateScore(80);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(80);
+        }
+
+        @Test
+        @DisplayName("동일한 점수로 업데이트 가능")
+        void updateScore_WithSameScore_ShouldSucceed() {
+            // Given
+            AnswerMetric answerMetric = createAnswerMetric(50);
+
+            // When
+            answerMetric.updateScore(50);
+
+            // Then
+            assertThat(answerMetric.getScore()).isEqualTo(50);
+        }
+    }
+
+    @Nested
+    @DisplayName("엔티티 관계 테스트")
+    class RelationshipTest {
+
+        @Test
+        @DisplayName("Answer null로 생성 가능 (Service 레이어에서 검증)")
+        void create_WithNullAnswer_ShouldSucceed() {
+            // Given
+            Metric metric = mock(Metric.class);
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(null, metric, 50);
+
+            // Then
+            assertThat(answerMetric.getAnswer()).isNull();
+        }
+
+        @Test
+        @DisplayName("Metric null로 생성 가능 (Service 레이어에서 검증)")
+        void create_WithNullMetric_ShouldSucceed() {
+            // Given
+            Answer answer = mock(Answer.class);
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(answer, null, 50);
+
+            // Then
+            assertThat(answerMetric.getMetric()).isNull();
+        }
+
+        @Test
+        @DisplayName("Answer와 Metric 모두 설정됨")
+        void create_ShouldSetBothAnswerAndMetric() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When
+            AnswerMetric answerMetric = AnswerMetric.create(answer, metric, 50);
+
+            // Then
+            assertThat(answerMetric.getAnswer()).isNotNull();
+            assertThat(answerMetric.getMetric()).isNotNull();
+            assertThat(answerMetric.getAnswer()).isEqualTo(answer);
+            assertThat(answerMetric.getMetric()).isEqualTo(metric);
+        }
+    }
+
+    @Nested
+    @DisplayName("경계값 테스트")
+    class BoundaryTest {
+
+        @Test
+        @DisplayName("MIN_SCORE - 1은 실패")
+        void create_WithBelowMinScore_ShouldThrowException() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, MIN_SCORE - 1))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @Test
+        @DisplayName("MAX_SCORE + 1은 실패")
+        void create_WithAboveMaxScore_ShouldThrowException() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, MAX_SCORE + 1))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @Test
+        @DisplayName("Integer.MIN_VALUE는 실패")
+        void create_WithIntegerMinValue_ShouldThrowException() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, Integer.MIN_VALUE))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+
+        @Test
+        @DisplayName("Integer.MAX_VALUE는 실패")
+        void create_WithIntegerMaxValue_ShouldThrowException() {
+            // Given
+            Answer answer = mock(Answer.class);
+            Metric metric = mock(Metric.class);
+
+            // When & Then
+            assertThatThrownBy(() -> AnswerMetric.create(answer, metric, Integer.MAX_VALUE))
+                    .isInstanceOf(MetricInvalidRangeException.class);
+        }
+    }
+
+    // ==================== Fixture 메서드 ====================
+
+    private AnswerMetric createAnswerMetric(int score) {
+        return AnswerMetric.create(
+                mock(Answer.class),
+                mock(Metric.class),
+                score
+        );
+    }
+}

--- a/src/test/java/com/ktb/metric/domain/MetricTest.java
+++ b/src/test/java/com/ktb/metric/domain/MetricTest.java
@@ -1,0 +1,273 @@
+package com.ktb.metric.domain;
+
+import com.ktb.metric.exception.MetricNameInvalidLengthException;
+import com.ktb.metric.exception.MetricRequiredNameException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Metric 도메인 테스트")
+class MetricTest {
+
+    private static final int MAX_NAME_LENGTH = 100;
+
+    @Nested
+    @DisplayName("Metric 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 이름과 설명으로 Metric 생성 성공")
+        void create_WithValidNameAndDescription_ShouldSucceed() {
+            // Given
+            String name = "논리성";
+            String description = "답변의 논리적 구조";
+
+            // When
+            Metric metric = Metric.create(name, description);
+
+            // Then
+            assertThat(metric).isNotNull();
+            assertThat(metric.getName()).isEqualTo(name);
+            assertThat(metric.getDescription()).isEqualTo(description);
+        }
+
+        @Test
+        @DisplayName("설명 없이 Metric 생성 성공")
+        void create_WithNullDescription_ShouldSucceed() {
+            // Given
+            String name = "논리성";
+
+            // When
+            Metric metric = Metric.create(name, null);
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+            assertThat(metric.getDescription()).isNull();
+        }
+
+        @Test
+        @DisplayName("1자 이름으로 생성 성공")
+        void create_WithOneCharacter_ShouldSucceed() {
+            // Given
+            String name = "A";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+
+        @Test
+        @DisplayName("100자 이름으로 생성 성공")
+        void create_WithMaxLength_ShouldSucceed() {
+            // Given
+            String name = "A".repeat(MAX_NAME_LENGTH);
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).hasSize(MAX_NAME_LENGTH);
+        }
+
+        @Test
+        @DisplayName("101자 이름으로 생성 시 MetricNameInvalidLengthException 발생")
+        void create_WithExceedingMaxLength_ShouldThrowException() {
+            // Given
+            String name = "A".repeat(MAX_NAME_LENGTH + 1);
+
+            // When & Then
+            assertThatThrownBy(() -> Metric.create(name, "설명"))
+                    .isInstanceOf(MetricNameInvalidLengthException.class);
+        }
+
+        @Test
+        @DisplayName("null 이름으로 생성 시 MetricRequiredNameException 발생")
+        void create_WithNull_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> Metric.create(null, "설명"))
+                    .isInstanceOf(MetricRequiredNameException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 이름으로 생성 시 MetricRequiredNameException 발생")
+        void create_WithEmptyString_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> Metric.create("", "설명"))
+                    .isInstanceOf(MetricRequiredNameException.class);
+        }
+
+        @Test
+        @DisplayName("공백만 있는 이름으로 생성 시 MetricRequiredNameException 발생")
+        void create_WithOnlySpaces_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> Metric.create("   ", "설명"))
+                    .isInstanceOf(MetricRequiredNameException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("특수 문자 및 공백 테스트")
+    class SpecialCharacterTest {
+
+        @Test
+        @DisplayName("공백이 포함된 이름 생성 가능")
+        void create_WithSpaces_ShouldSucceed() {
+            // Given
+            String name = "논리성 평가";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+
+        @Test
+        @DisplayName("특수문자가 포함된 이름 생성 가능")
+        void create_WithSpecialCharacters_ShouldSucceed() {
+            // Given
+            String name = "논리성(Logic)";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+
+        @Test
+        @DisplayName("숫자가 포함된 이름 생성 가능")
+        void create_WithNumbers_ShouldSucceed() {
+            // Given
+            String name = "평가지표1";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+
+        @Test
+        @DisplayName("영어와 한글이 혼합된 이름 생성 가능")
+        void create_WithKoreanAndEnglish_ShouldSucceed() {
+            // Given
+            String name = "논리성Logic";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+    }
+
+    @Nested
+    @DisplayName("설명 업데이트 테스트")
+    class UpdateDescriptionTest {
+
+        @Test
+        @DisplayName("설명 업데이트 성공")
+        void updateDescription_WithValidDescription_ShouldSucceed() {
+            // Given
+            Metric metric = Metric.create("논리성", "기존 설명");
+            String newDescription = "답변의 논리적 구조와 일관성";
+
+            // When
+            metric.updateDescription(newDescription);
+
+            // Then
+            assertThat(metric.getDescription()).isEqualTo(newDescription);
+        }
+
+        @Test
+        @DisplayName("설명을 null로 업데이트 가능")
+        void updateDescription_WithNull_ShouldSucceed() {
+            // Given
+            Metric metric = Metric.create("논리성", "기존 설명");
+
+            // When
+            metric.updateDescription(null);
+
+            // Then
+            assertThat(metric.getDescription()).isNull();
+        }
+
+        @Test
+        @DisplayName("설명을 빈 문자열로 업데이트 가능")
+        void updateDescription_WithEmptyString_ShouldSucceed() {
+            // Given
+            Metric metric = Metric.create("논리성", "기존 설명");
+
+            // When
+            metric.updateDescription("");
+
+            // Then
+            assertThat(metric.getDescription()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("255자 설명 업데이트 가능")
+        void updateDescription_WithMaxLength_ShouldSucceed() {
+            // Given
+            Metric metric = Metric.create("논리성", "기존 설명");
+            String longDescription = "A".repeat(255);
+
+            // When
+            metric.updateDescription(longDescription);
+
+            // Then
+            assertThat(metric.getDescription()).hasSize(255);
+        }
+
+        @Test
+        @DisplayName("기존 설명 덮어쓰기 가능")
+        void updateDescription_ShouldOverwriteExisting() {
+            // Given
+            Metric metric = Metric.create("논리성", "첫 번째 설명");
+
+            // When
+            metric.updateDescription("두 번째 설명");
+            metric.updateDescription("세 번째 설명");
+
+            // Then
+            assertThat(metric.getDescription()).isEqualTo("세 번째 설명");
+        }
+    }
+
+    @Nested
+    @DisplayName("이름 trim 테스트")
+    class NameTrimTest {
+
+        @Test
+        @DisplayName("이름 앞의 공백은 제거되지 않음")
+        void create_WithLeadingSpaces_ShouldNotTrim() {
+            // Given
+            String name = "  논리성";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+
+        @Test
+        @DisplayName("이름 뒤의 공백은 제거되지 않음")
+        void create_WithTrailingSpaces_ShouldNotTrim() {
+            // Given
+            String name = "논리성  ";
+
+            // When
+            Metric metric = Metric.create(name, "설명");
+
+            // Then
+            assertThat(metric.getName()).isEqualTo(name);
+        }
+    }
+}


### PR DESCRIPTION
### 요약

 Answer, Hashtag, Metric 도메인의 단위 테스트를 작성하고, 재사용 가능한 Fixture 패턴을 도입하여 테스트 코드의 가독성과
 유지보수성을 향상시켰습니다. JDK 25 환경에서 Mockito 호환성 문제를 해결했습니다.

### 변경 사항

  1. 도메인 단위 테스트 작성 (총 127개)

  Answer 도메인 (41개 테스트)
  - 생성 테스트: Type 검증, 모든 AnswerType, 초기 상태 확인
  - Content 업데이트: 유효한 값, 빈 문자열, 최대 길이(1500자)
  - 상태 전이 (20개): SUBMITTED→TRANSCRIBING→COMPLETED 등 모든 경로 검증
  - 종료 상태 검증: COMPLETED/FAILED에서 전이 불가
  - AI 피드백 설정: 정상, 빈 값, null
  - 소유권 확인: 본인/타인/Account null

  Hashtag 도메인 (30개 테스트)
  - 생성 및 정규화: 대소문자 → 소문자 변환
  - 경계값: 1자~100자, 101자 초과 예외
  - 공백 검증: trim 전 원본에서 공백 포함 예외
  - 특수문자 지원: C++, spring-boot, Java8
  - 다국어 지원: 한글, 영어, 일본어, 혼합

  Metric 도메인 (18개 테스트)
  - 생성: 1자~100자 경계값, null/빈값 예외
  - 공백 포함 이름 허용
  - 설명 업데이트: 정상, null, 255자

  AnswerMetric 도메인 (29개 테스트)
  - 점수 범위: 0~100 검증, -1/101 예외
  - 경계값: Integer.MIN/MAX_VALUE 예외
  - 파라미터화 테스트: 0~100 모든 점수, 음수/초과 값
  - 점수 업데이트: 증가/감소, 여러 번 업데이트

  AnswerHashtag 도메인 (9개 테스트)
  - 연관 생성: Answer-Hashtag
  - 다대다 관계: 동일 Answer + 다른 Hashtag
  - null 처리: Answer null, Hashtag null, 둘 다 null
  - 불변성: 생성 후 참조 변경 불가

  2. Fixture 패턴 도입 (총 64개 메서드)

  재사용 가능한 Fixture 클래스 생성
  - AnswerFixture (14개): 상태별 생성, 소유권, 경계값
  - HashtagFixture (18개): 정규화, 특수문자, 다국어
  - MetricFixture (24개): 점수 범위, 평가지표, AnswerMetric
  - AnswerHashtagFixture (8개): 다대다 관계, null 처리