### PR TITLE
feat: [#21] 질문 핵심 키워드 포함 여부 API 구현

### DIFF
--- a/src/main/java/com/ktb/hashtag/domain/QuestionHashtag.java
+++ b/src/main/java/com/ktb/hashtag/domain/QuestionHashtag.java
@@ -1,0 +1,61 @@
+package com.ktb.hashtag.domain;
+
+import com.ktb.common.domain.BaseTimeEntity;
+import com.ktb.question.domain.Question;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(
+        name = "QUESTION_HASHTAG",
+        indexes = {
+                @Index(name = "uk_question_hashtag", columnList = "question_id, tag_id", unique = true),
+                @Index(name = "idx_question_id", columnList = "question_id"),
+                @Index(name = "idx_tag_id", columnList = "tag_id"),
+                @Index(name = "idx_created_at", columnList = "created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"question", "hashtag"})
+public class QuestionHashtag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_hashtag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Hashtag hashtag;
+
+    @Builder
+    private QuestionHashtag(Question question, Hashtag hashtag) {
+        this.question = question;
+        this.hashtag = hashtag;
+    }
+
+    public static QuestionHashtag create(Question question, Hashtag hashtag) {
+        return QuestionHashtag.builder()
+                .question(question)
+                .hashtag(hashtag)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
+++ b/src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
@@ -1,0 +1,22 @@
+package com.ktb.hashtag.repository;
+
+import com.ktb.hashtag.domain.QuestionHashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionHashtagRepository extends JpaRepository<QuestionHashtag, Long> {
+
+    @Query("""
+            SELECT DISTINCT h.name
+            FROM QuestionHashtag qh
+            JOIN qh.hashtag h
+            WHERE qh.question.id = :questionId
+            """)
+    List<String> findKeywordNamesByQuestionId(@Param("questionId") Long questionId);
+
+    boolean existsByQuestion_IdAndHashtag_NameIgnoreCase(Long questionId, String name);
+}

--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -5,6 +5,9 @@ import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import com.ktb.question.dto.QuestionCreateRequest;
 import com.ktb.question.dto.QuestionDetailResponse;
+import com.ktb.question.dto.QuestionKeywordCheckRequest;
+import com.ktb.question.dto.QuestionKeywordCheckResponse;
+import com.ktb.question.dto.QuestionKeywordListResponse;
 import com.ktb.question.dto.QuestionListResponse;
 import com.ktb.question.dto.QuestionSearchResponse;
 import com.ktb.question.dto.QuestionUpdateRequest;
@@ -106,5 +109,28 @@ public class QuestionController {
     ) {
         questionService.deleteQuestion(questionId);
         return ResponseEntity.ok(new ApiResponse<>("question_deleted_success", null));
+    }
+
+    /**
+     * 질문 핵심 키워드 조회
+     */
+    @GetMapping("/{questionId}/keywords")
+    public ResponseEntity<ApiResponse<QuestionKeywordListResponse>> getQuestionKeywords(
+            @PathVariable Long questionId
+    ) {
+        QuestionKeywordListResponse result = questionService.getQuestionKeywords(questionId);
+        return ResponseEntity.ok(new ApiResponse<>("question_keywords_retrieval_success", result));
+    }
+
+    /**
+     * 질문 핵심 키워드 포함 여부 확인
+     */
+    @PostMapping("/{questionId}/keyword-checks")
+    public ResponseEntity<ApiResponse<QuestionKeywordCheckResponse>> checkQuestionKeyword(
+            @PathVariable Long questionId,
+            @Valid @RequestBody QuestionKeywordCheckRequest request
+    ) {
+        QuestionKeywordCheckResponse result = questionService.checkQuestionKeywords(questionId, request.keywords());
+        return ResponseEntity.ok(new ApiResponse<>("question_keywords_check_success", result));
     }
 }

--- a/src/main/java/com/ktb/question/dto/KeywordMatchResponse.java
+++ b/src/main/java/com/ktb/question/dto/KeywordMatchResponse.java
@@ -1,0 +1,7 @@
+package com.ktb.question.dto;
+
+public record KeywordMatchResponse(
+        String keyword,
+        boolean included
+) {
+}

--- a/src/main/java/com/ktb/question/dto/QuestionKeywordCheckRequest.java
+++ b/src/main/java/com/ktb/question/dto/QuestionKeywordCheckRequest.java
@@ -1,0 +1,12 @@
+package com.ktb.question.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record QuestionKeywordCheckRequest(
+        @NotEmpty
+        List<@NotBlank @Size(max = 100) String> keywords
+) {
+}

--- a/src/main/java/com/ktb/question/dto/QuestionKeywordCheckResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionKeywordCheckResponse.java
@@ -1,0 +1,8 @@
+package com.ktb.question.dto;
+
+import java.util.List;
+
+public record QuestionKeywordCheckResponse(
+        List<KeywordMatchResponse> keywords
+) {
+}

--- a/src/main/java/com/ktb/question/dto/QuestionKeywordListResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionKeywordListResponse.java
@@ -1,0 +1,8 @@
+package com.ktb.question.dto;
+
+import java.util.List;
+
+public record QuestionKeywordListResponse(
+        List<String> keywords
+) {
+}

--- a/src/main/java/com/ktb/question/service/QuestionService.java
+++ b/src/main/java/com/ktb/question/service/QuestionService.java
@@ -5,6 +5,8 @@ import com.ktb.question.domain.QuestionType;
 import com.ktb.question.dto.QuestionCreateRequest;
 import com.ktb.question.dto.QuestionDetailResponse;
 import com.ktb.question.dto.QuestionListResponse;
+import com.ktb.question.dto.QuestionKeywordCheckResponse;
+import com.ktb.question.dto.QuestionKeywordListResponse;
 import com.ktb.question.dto.QuestionSearchResponse;
 import com.ktb.question.dto.QuestionUpdateRequest;
 
@@ -21,4 +23,8 @@ public interface QuestionService {
     QuestionDetailResponse updateQuestion(Long questionId, QuestionUpdateRequest request);
 
     void deleteQuestion(Long questionId);
+
+    QuestionKeywordListResponse getQuestionKeywords(Long questionId);
+
+    QuestionKeywordCheckResponse checkQuestionKeywords(Long questionId, java.util.List<String> keywords);
 }


### PR DESCRIPTION
# Summary

- 구현 기능  
  - 질문 핵심 키워드 조회  
  - 질문 핵심 키워드 포함 여부 확인 (다중 키워드)

- Added  
  - docs/question-api.md  
  - src/main/java/com/ktb/hashtag/domain/QuestionHashtag.java  
  - src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java  
  - src/main/java/com/ktb/question/dto/KeywordMatchResponse.java  
  - src/main/java/com/ktb/question/dto/QuestionKeywordCheckRequest.java  
  - src/main/java/com/ktb/question/dto/QuestionKeywordCheckResponse.java  
  - src/main/java/com/ktb/question/dto/QuestionKeywordListResponse.java  

- Modified  
  - src/main/java/com/ktb/question/controller/QuestionController.java  
  - src/main/java/com/ktb/question/service/QuestionService.java  
  - src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java  

- Deleted  
  - 없음

---

# Architecture / Flow

## 요청 흐름

- GET /api/v1/questions/{questionId}/keywords  
  - QuestionController  
    → QuestionService.getQuestionKeywords  
    → QuestionHashtagRepository.findKeywordNamesByQuestionId  

- POST /api/v1/questions/{questionId}/keyword-checks  
  - QuestionController  
    → QuestionService.checkQuestionKeywords  
  - 각 입력 키워드에 대해  
    QuestionHashtagRepository.existsByQuestion_IdAndHashtag_NameIgnoreCase  
    로 포함 여부 계산

## 주요 컴포넌트 역할

- QuestionHashtag  
  - 질문-해시태그 매핑 엔티티  
  - BaseTimeEntity 상속

- QuestionHashtagRepository  
  - 질문별 키워드 목록 조회  
  - 키워드 포함 여부 확인 쿼리 제공

- DTO  
  - 키워드 체크 요청/응답 모델링

---

# Key Points

- 핵심 구현
  - 질문별 핵심 키워드 리스트 반환 API 추가
  - 입력 키워드 리스트에 대해 “질문 핵심 키워드인지” 여부를 boolean으로 반환

- 중요한 설계 판단
  - 키워드 포함 여부는 정확 일치 + 대소문자 무시 기준
  - 체크 API 경로는 동사 제거, 명사형 리소스 keyword-checks 사용
  - 질문 존재 여부를 existsById로 선검증 후 로직 수행

---

# Edge / Failure

- 질문이 존재하지 않으면 QuestionNotFoundException
- keywords가 비어 있거나, 요소가 빈 문자열이면 요청 검증 실패 (400)
- 키워드가 등록되어 있지 않으면 included = false
- 스키마 주의  
  - QuestionHashtag는 question_hashtag_id, created_at, updated_at 컬럼을 기대  
  - 실제 DDL이 question_id, tag_id만 있을 경우 매핑 불일치 가능

---

# Test

- 수동 확인
  - GET /api/v1/questions/{questionId}/keywords
  - POST /api/v1/questions/{questionId}/keyword-checks  
    Body 예시:
    ```json
    {
      "keywords": ["프로세스", "스레드"]
    }
    ```

---

# Review Focus

- QUESTION_HASHTAG 테이블 스키마와 QuestionHashtag 엔티티 매핑 일치 여부
- 키워드 판정 로직  
  - 정확 일치 기준 유지 여부  
  - 향후 부분 일치 / 형태소 분석 필요성 검토
- 질문 존재 체크 시 useYn, deletedAt 등 상태 컬럼까지 고려할지 여부
