### PR TITLE
refactor: FileUploadService 구조 개선 및 뼈대 작성 (#48)

### DIFF
--- a/src/main/java/com/ktb/common/domain/ErrorCode.java
+++ b/src/main/java/com/ktb/common/domain/ErrorCode.java
@@ -40,6 +40,15 @@ public enum ErrorCode {
     ANSWER_INVALID_STATUS_TRANSITION(400, "A005", "허용되지 않는 답변 상태 전이입니다"),
     ANSWER_TYPE_REQUIRED(400, "A006", "답변 유형은 필수입니다"),
 
+    // ==================== File 관련 ====================
+    INVALID_FILE_FORMAT(400, "F001", "지원하지 않는 파일 형식입니다"),
+    FILE_NOT_FOUND(404, "F002", "파일을 찾을 수 없습니다"),
+    FILE_ALREADY_DELETED(409, "F003", "이미 삭제된 파일입니다"),
+    FILE_SIZE_EXCEEDED(422, "F004", "파일 크기 제한을 초과했습니다"),
+    FILE_STORAGE_MIGRATION_FAILED(422, "F005", "파일 저장소 마이그레이션에 실패했습니다"),
+    FILE_INVALID_METADATA(400, "F006", "파일 메타데이터가 올바르지 않습니다"),
+    FILE_NOT_DELETED(409, "F007", "삭제되지 않은 파일입니다"),
+
     // ==================== Hashtag 관련 ====================
     HASHTAG_NAME_REQUIRED(400, "H001", "해시태그 이름은 필수입니다"),
     HASHTAG_NAME_TOO_LONG(400, "H002", "해시태그 이름은 100자를 초과할 수 없습니다"),

--- a/src/main/java/com/ktb/file/domain/FileCategory.java
+++ b/src/main/java/com/ktb/file/domain/FileCategory.java
@@ -9,35 +9,56 @@ public enum FileCategory {
     PROFILE(
             "프로필 이미지",
             5 * 1024 * 1024L, // 5MB
-            Arrays.asList("jpg", "jpeg", "png", "gif", "webp")
+            Arrays.asList("jpg", "jpeg", "png", "gif", "webp"),
+            Arrays.asList("image/jpeg", "image/png", "image/gif", "image/webp")
     ),
 
     ARCHITECTURE(
             "아키텍처 다이어그램",
             10 * 1024 * 1024L, // 10MB
-            Arrays.asList("jpg", "jpeg", "png", "gif", "svg")
+            Arrays.asList("jpg", "jpeg", "png", "gif", "svg"),
+            Arrays.asList("image/jpeg", "image/png", "image/gif", "image/svg+xml")
     ),
 
     ATTACHMENT(
             "일반 첨부파일",
             50 * 1024 * 1024L, // 50MB
-            Arrays.asList("jpg", "jpeg", "png", "gif")
+            Arrays.asList("jpg", "jpeg", "png", "gif"),
+            Arrays.asList("image/jpeg", "image/png", "image/gif")
     ),
 
     TEMP(
             "임시 파일",
             100 * 1024 * 1024L, // 100MB
-            Arrays.asList("jpg", "jpeg", "png", "gif")
+            Arrays.asList("jpg", "jpeg", "png", "gif"),
+            Arrays.asList("image/jpeg", "image/png", "image/gif")
+    ),
+
+    AUDIO(
+            "음성 파일",
+            10 * 1024 * 1024L, // 10MB
+            Arrays.asList("mp3", "wav", "m4a"),
+            Arrays.asList("audio/mpeg", "audio/wav", "audio/x-m4a", "audio/mp4")
+    ),
+
+    VIDEO(
+            "비디오 파일",
+            100 * 1024 * 1024L, // 100MB
+            Arrays.asList("mp4", "mov", "avi"),
+            Arrays.asList("video/mp4", "video/quicktime", "video/x-msvideo")
     );
 
     private final String description;
     private final long maxSizeBytes;
     private final List<String> allowedExtensions;
+    private final List<String> allowedMimeTypes;
 
-    FileCategory(String description, long maxSizeBytes, List<String> allowedExtensions) {
+    FileCategory(String description, long maxSizeBytes, List<String> allowedExtensions,
+                 List<String> allowedMimeTypes) {
         this.description = description;
         this.maxSizeBytes = maxSizeBytes;
         this.allowedExtensions = allowedExtensions;
+        this.allowedMimeTypes = allowedMimeTypes;
     }
 
     public boolean isAllowedExtension(String extension) {
@@ -59,7 +80,18 @@ public enum FileCategory {
         return this == TEMP;
     }
 
+    public boolean isAllowedMimeType(String mimeType) {
+        if (mimeType == null) {
+            return false;
+        }
+        return allowedMimeTypes.contains(mimeType.toLowerCase());
+    }
+
     public String getAllowedExtensionsAsString() {
         return String.join(", ", allowedExtensions);
+    }
+
+    public String getAllowedMimeTypesAsString() {
+        return String.join(", ", allowedMimeTypes);
     }
 }

--- a/src/main/java/com/ktb/file/dto/FileUploadResult.java
+++ b/src/main/java/com/ktb/file/dto/FileUploadResult.java
@@ -1,0 +1,9 @@
+package com.ktb.file.dto;
+
+public record FileUploadResult(
+    String fileUrl,
+    String fileName,
+    Long fileSize,
+    String mimeType
+) {
+}

--- a/src/main/java/com/ktb/file/exception/FileAlreadyDeletedException.java
+++ b/src/main/java/com/ktb/file/exception/FileAlreadyDeletedException.java
@@ -1,7 +1,19 @@
 package com.ktb.file.exception;
 
-public class FileAlreadyDeletedException extends RuntimeException {
-    public FileAlreadyDeletedException(String message) {
-        super(message);
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class FileAlreadyDeletedException extends BusinessException {
+
+    public FileAlreadyDeletedException(Long fileId) {
+        super(ErrorCode.FILE_ALREADY_DELETED, buildMessage(fileId));
+    }
+
+    public FileAlreadyDeletedException(String identifier) {
+        super(ErrorCode.FILE_ALREADY_DELETED, buildMessage(identifier));
+    }
+
+    private static String buildMessage(Object identifier) {
+        return String.format("%s identifier=%s",ErrorCode.FILE_ALREADY_DELETED , identifier);
     }
 }

--- a/src/main/java/com/ktb/file/exception/FileExtensionNotAllowedException.java
+++ b/src/main/java/com/ktb/file/exception/FileExtensionNotAllowedException.java
@@ -1,18 +1,24 @@
 package com.ktb.file.exception;
 
+import static com.ktb.common.domain.ErrorCode.INVALID_FILE_FORMAT;
+
+import com.ktb.common.exception.BusinessException;
 import com.ktb.file.domain.FileCategory;
 
-public class FileExtensionNotAllowedException extends RuntimeException {
-    public FileExtensionNotAllowedException(String message) {
-        super(message);
+public class FileExtensionNotAllowedException extends BusinessException {
+    public FileExtensionNotAllowedException() {
+        super(INVALID_FILE_FORMAT);
     }
 
     public FileExtensionNotAllowedException(FileCategory category, String extension) {
-        super(String.format(
-                "허용되지 않은 파일 확장자입니다. 카테고리: %s, 확장자: %s, 허용 확장자: %s",
-                category.name(),
-                extension,
-                category.getAllowedExtensionsAsString()
-        ));
+        String errMsg = String.format(
+            "%s 카테고리: %s, 확장자: %s, 허용 확장자: %s",
+            INVALID_FILE_FORMAT.getMessage(),
+            category.name(),
+            extension,
+            category.getAllowedExtensionsAsString()
+        );
+
+        super(INVALID_FILE_FORMAT, errMsg);
     }
 }

--- a/src/main/java/com/ktb/file/exception/FileInvalidMetadataException.java
+++ b/src/main/java/com/ktb/file/exception/FileInvalidMetadataException.java
@@ -1,0 +1,16 @@
+package com.ktb.file.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class FileInvalidMetadataException extends BusinessException {
+
+    public FileInvalidMetadataException(String reason) {
+        super(ErrorCode.FILE_INVALID_METADATA,
+            String.format(
+                "%s %s"
+                , ErrorCode.FILE_INVALID_METADATA.getMessage()
+                , reason
+            ));
+    }
+}

--- a/src/main/java/com/ktb/file/exception/FileNotDeletedException.java
+++ b/src/main/java/com/ktb/file/exception/FileNotDeletedException.java
@@ -1,0 +1,15 @@
+package com.ktb.file.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class FileNotDeletedException extends BusinessException {
+
+    public FileNotDeletedException(Long fileId) {
+        super(ErrorCode.FILE_NOT_DELETED, String.format(
+            "%s fileId=%d"
+            ,ErrorCode.FILE_NOT_FOUND.getMessage()
+            ,fileId
+        ));
+    }
+}

--- a/src/main/java/com/ktb/file/exception/FileNotFoundException.java
+++ b/src/main/java/com/ktb/file/exception/FileNotFoundException.java
@@ -1,11 +1,19 @@
 package com.ktb.file.exception;
 
-public class FileNotFoundException extends RuntimeException {
-    public FileNotFoundException(String message) {
-        super(message);
-    }
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class FileNotFoundException extends BusinessException {
 
     public FileNotFoundException(Long fileId) {
-        super("파일을 찾을 수 없습니다. ID: " + fileId);
+        super(ErrorCode.FILE_NOT_FOUND, buildMessage(fileId));
+    }
+
+    public FileNotFoundException(String identifier) {
+        super(ErrorCode.FILE_NOT_FOUND, buildMessage(identifier));
+    }
+
+    private static String buildMessage(Object identifier) {
+        return String.format("%s identifier=%s",ErrorCode.FILE_NOT_FOUND, identifier);
     }
 }

--- a/src/main/java/com/ktb/file/exception/FileSizeExceededException.java
+++ b/src/main/java/com/ktb/file/exception/FileSizeExceededException.java
@@ -1,18 +1,18 @@
 package com.ktb.file.exception;
 
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
 import com.ktb.file.domain.FileCategory;
 
-public class FileSizeExceededException extends RuntimeException {
-    public FileSizeExceededException(String message) {
-        super(message);
-    }
+public class FileSizeExceededException extends BusinessException {
 
-    public FileSizeExceededException(FileCategory category, long fileSize) {
-        super(String.format(
-                "파일 크기가 제한을 초과했습니다. 카테고리: %s, 최대 크기: %.2f MB, 업로드 크기: %.2f MB",
-                category.name(),
-                category.getMaxSizeMB(),
-                fileSize / (1024.0 * 1024.0)
-        ));
+    public FileSizeExceededException(FileCategory category, String fileSize) {
+        String errMsg = String.format(
+            "%s 카테고리: %s, 최대 크기: %.2f MB, 업로드 크기: %s",
+            ErrorCode.FILE_SIZE_EXCEEDED,
+            category.name(),
+            category.getMaxSizeMB(),
+            fileSize);
+        super(ErrorCode.FILE_SIZE_EXCEEDED, errMsg);
     }
 }

--- a/src/main/java/com/ktb/file/exception/FileStorageMigrationException.java
+++ b/src/main/java/com/ktb/file/exception/FileStorageMigrationException.java
@@ -1,11 +1,15 @@
 package com.ktb.file.exception;
 
-public class FileStorageMigrationException extends RuntimeException {
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class FileStorageMigrationException extends BusinessException {
+
     public FileStorageMigrationException(String message) {
-        super(message);
+        super(ErrorCode.FILE_STORAGE_MIGRATION_FAILED, message);
     }
 
     public FileStorageMigrationException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.FILE_STORAGE_MIGRATION_FAILED, message, cause);
     }
 }

--- a/src/main/java/com/ktb/file/repository/FileRepository.java
+++ b/src/main/java/com/ktb/file/repository/FileRepository.java
@@ -1,0 +1,12 @@
+package com.ktb.file.repository;
+
+import com.ktb.file.domain.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * File 엔티티 Repository
+ */
+@Repository
+public interface FileRepository extends JpaRepository<File, Long> {
+}

--- a/src/main/java/com/ktb/file/service/FileUploadService.java
+++ b/src/main/java/com/ktb/file/service/FileUploadService.java
@@ -1,0 +1,45 @@
+package com.ktb.file.service;
+
+import com.ktb.file.domain.FileCategory;
+import com.ktb.file.dto.FileUploadResult;
+import com.ktb.file.exception.FileInvalidMetadataException;
+import com.ktb.file.exception.FileSizeExceededException;
+import com.ktb.file.exception.FileStorageMigrationException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public interface FileUploadService {
+    /**
+     * 파일을 업로드하고 저장합니다.
+     *
+     * @param file 업로드할 파일
+     * @param category 파일 카테고리 (AUDIO, VIDEO 등)
+     * @return 업로드 결과 (URL, 파일명, 크기, MIME 타입)
+     * @throws FileInvalidMetadataException 파일이 비어있거나 메타데이터가 유효하지 않을 때
+     * @throws FileSizeExceededException 파일 크기가 제한을 초과할 때
+     * @throws FileStorageMigrationException 업로드에 실패한 경우
+     */
+    FileUploadResult upload(MultipartFile file, FileCategory category)
+            throws FileInvalidMetadataException, FileSizeExceededException, FileStorageMigrationException;
+
+    /**
+     * 파일 형식을 검증합니다.
+     *
+     * @param file 검증할 파일
+     * @param category 파일 카테고리
+     * @throws FileInvalidMetadataException MIME 타입 또는 확장자가 허용 목록에 없는 경우
+     */
+    void validateFormat(MultipartFile file, FileCategory category)
+            throws FileInvalidMetadataException;
+
+    /**
+     * 파일 크기를 검증합니다.
+     *
+     * @param file 검증할 파일
+     * @param category 파일 카테고리
+     * @throws FileSizeExceededException 파일 크기가 제한을 초과한 경우
+     */
+    void validateSize(MultipartFile file, FileCategory category)
+            throws FileSizeExceededException;
+}

--- a/src/main/java/com/ktb/file/service/impl/FileUploadServiceImpl.java
+++ b/src/main/java/com/ktb/file/service/impl/FileUploadServiceImpl.java
@@ -1,0 +1,179 @@
+package com.ktb.file.service.impl;
+
+import com.ktb.file.domain.File;
+import com.ktb.file.domain.FileCategory;
+import com.ktb.file.domain.StorageType;
+import com.ktb.file.dto.FileUploadResult;
+import com.ktb.file.exception.FileInvalidMetadataException;
+import com.ktb.file.exception.FileSizeExceededException;
+import com.ktb.file.repository.FileRepository;
+import com.ktb.file.service.FileUploadService;
+import com.ktb.file.util.SizeUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+/**
+ * 파일 업로드 서비스 구현체
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileUploadServiceImpl implements FileUploadService {
+
+    // ==================== 상수 정의 ====================
+
+    private static final String ERROR_MESSAGE_FILE_EMPTY = "파일이 비어있습니다";
+    private static final String ERROR_MESSAGE_MIME_TYPE_UNKNOWN = "MIME 타입을 확인할 수 없습니다";
+    private static final String ERROR_MESSAGE_EXTENSION_NOT_FOUND = "파일 확장자를 찾을 수 없습니다";
+    private static final String TEMP_URL_PREFIX = "https://example.com";
+
+    // ==================== 의존성 ====================
+
+    private final FileRepository fileRepository;
+
+    // TODO: S3 또는 파일 저장소 클라이언트 주입 필요
+    // private final S3Client s3Client;
+
+    // ==================== 공개 메서드 ====================
+
+    /**
+     * 파일을 업로드하고 저장합니다.
+     *
+     * @param file 업로드할 파일
+     * @param category 파일 카테고리 (AUDIO, VIDEO 등)
+     * @return 업로드 결과 (URL, 파일명, 크기, MIME 타입)
+     * @throws FileInvalidMetadataException 파일이 비어있거나 메타데이터가 유효하지 않을 때
+     * @throws FileSizeExceededException 파일 크기가 제한을 초과할 때
+     */
+    @Override
+    @Transactional
+    public FileUploadResult upload(MultipartFile file, FileCategory category) {
+        validateFormat(file, category);
+        validateSize(file, category);
+
+        String extension = extractExtension(file.getOriginalFilename());
+        String storedName = generateStoredName(extension);
+
+        // TODO: S3 업로드 후 실제 URL 받기
+        String tempPath = buildFilePath(category, storedName);
+        String tempUrl = TEMP_URL_PREFIX + tempPath;
+
+        File fileEntity = File.create(
+                file.getOriginalFilename(),
+                storedName,
+                tempPath,
+                extension,
+                file.getSize(),
+                file.getContentType(),
+                category,
+                StorageType.LOCAL  // TODO: S3 업로드 시 StorageType.S3로 변경
+        );
+
+        File savedFile = fileRepository.save(fileEntity);
+
+        log.info("File uploaded - ID: {}, Category: {}, Size: {}, URL: {}",
+                savedFile.getId(), category, savedFile.getReadableSize(), tempUrl);
+
+        return new FileUploadResult(
+                tempUrl,
+                savedFile.getOriginalName(),
+                savedFile.getSize(),
+                savedFile.getMimeType()
+        );
+    }
+
+    /**
+     * 파일 형식을 검증합니다.
+     *
+     * @param file 검증할 파일
+     * @param category 파일 카테고리
+     * @throws FileInvalidMetadataException MIME 타입 또는 확장자가 허용 목록에 없는 경우
+     */
+    @Override
+    public void validateFormat(MultipartFile file, FileCategory category) {
+        if (file == null || file.isEmpty()) {
+            throw new FileInvalidMetadataException(ERROR_MESSAGE_FILE_EMPTY);
+        }
+
+        String mimeType = file.getContentType();
+        if (mimeType == null) {
+            throw new FileInvalidMetadataException(ERROR_MESSAGE_MIME_TYPE_UNKNOWN);
+        }
+
+        if (!category.isAllowedMimeType(mimeType)) {
+            throw new FileInvalidMetadataException(
+                    "허용되지 않은 파일 형식입니다. 허용 형식: "
+                            + category.getAllowedMimeTypesAsString()
+            );
+        }
+
+        String extension = extractExtension(file.getOriginalFilename());
+        if (!category.isAllowedExtension(extension)) {
+            throw new FileInvalidMetadataException(
+                    "허용되지 않은 확장자입니다. 허용 확장자: "
+                            + category.getAllowedExtensionsAsString()
+            );
+        }
+    }
+
+    /**
+     * 파일 크기를 검증합니다.
+     *
+     * @param file 검증할 파일
+     * @param category 파일 카테고리
+     * @throws FileSizeExceededException 파일 크기가 제한을 초과한 경우
+     */
+    @Override
+    public void validateSize(MultipartFile file, FileCategory category) {
+        if (file == null || file.isEmpty()) {
+            throw new FileInvalidMetadataException(ERROR_MESSAGE_FILE_EMPTY);
+        }
+
+        long maxSize = category.getMaxSizeBytes();
+        if (file.getSize() > maxSize) {
+            throw new FileSizeExceededException(category, SizeUtil.getReadableSize(file.getSize()));
+        }
+    }
+
+    // ==================== 내부 헬퍼 메서드 ====================
+
+    /**
+     * 파일명에서 확장자를 추출합니다.
+     *
+     * @param originalFilename 원본 파일명
+     * @return 확장자 (소문자)
+     * @throws FileInvalidMetadataException 확장자를 찾을 수 없을 때
+     */
+    private String extractExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new FileInvalidMetadataException(ERROR_MESSAGE_EXTENSION_NOT_FOUND);
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    /**
+     * UUID 기반 저장 파일명을 생성합니다.
+     *
+     * @param extension 파일 확장자
+     * @return UUID + 확장자 형식의 파일명
+     */
+    private String generateStoredName(String extension) {
+        return UUID.randomUUID().toString() + "." + extension;
+    }
+
+    /**
+     * 카테고리별 파일 경로를 생성합니다.
+     *
+     * @param category 파일 카테고리
+     * @param storedName 저장 파일명
+     * @return 파일 경로
+     */
+    private String buildFilePath(FileCategory category, String storedName) {
+        return "/uploads/" + category.name().toLowerCase() + "/" + storedName;
+    }
+}

--- a/src/main/java/com/ktb/file/util/SizeUtil.java
+++ b/src/main/java/com/ktb/file/util/SizeUtil.java
@@ -1,0 +1,20 @@
+package com.ktb.file.util;
+
+public class SizeUtil {
+    private static final long KILOBYTE = 1024L;
+    private static final long MEGABYTE = KILOBYTE * 1024;
+    private static final long GIGABYTE = MEGABYTE * 1024;
+
+    public static String getReadableSize(Number number) {
+        long size = number.longValue();
+        if (size < KILOBYTE) {
+            return size + " B";
+        } else if (size < MEGABYTE) {
+            return String.format("%.2f KB", size / (double) KILOBYTE);
+        } else if (size < GIGABYTE) {
+            return String.format("%.2f MB", size / (double) MEGABYTE);
+        } else {
+            return String.format("%.2f GB", size / (double) GIGABYTE);
+        }
+    }
+}


### PR DESCRIPTION
## FileCategory enum 확장
- AUDIO, VIDEO 카테고리 추가 (10MB, 100MB)
- MIME 타입 필드 추가: allowedMimeTypes
- 메서드 추가: isAllowedMimeType(), getAllowedMimeTypesAsString()

## FileUploadService 생성
- 업로드 및 예외 검증

## FileRepository 생성
- JpaRepository<File, Long> 인터페이스

## SizeUtil 유틸리티 추가
- getReadableSize(long bytes): 파일 크기 변환 (KB, MB, GB)

## File 도메인 예외 개선
- Business Exception 사용 획일화