### PR TITLE
feat:[#43] Answer 도메인 전체 API 뼈대 구성

### DIFF
--- a/src/main/java/com/ktb/answer/controller/AnswerController.java
+++ b/src/main/java/com/ktb/answer/controller/AnswerController.java
@@ -1,0 +1,184 @@
+package com.ktb.answer.controller;
+
+import com.ktb.answer.dto.request.AnswerDetailRequest;
+import com.ktb.answer.dto.request.AnswerListRequest;
+import com.ktb.answer.dto.request.AnswerSubmitRequest;
+import com.ktb.answer.dto.request.SessionAnswerSubmitRequest;
+import com.ktb.answer.dto.response.AnswerDetailResponse;
+import com.ktb.answer.dto.response.AnswerListResponse;
+import com.ktb.answer.dto.response.AnswerSubmitResponse;
+import com.ktb.answer.dto.response.FeedbackResponse;
+import com.ktb.answer.dto.response.SessionAnswerSubmitResponse;
+import com.ktb.answer.service.AnswerApplicationService;
+import com.ktb.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Answer API", description = "답변 관리 API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Slf4j
+public class AnswerController {
+
+    private final AnswerApplicationService answerApplicationService;
+
+    private static final String MESSAGE_ANSWER_LIST_RETRIEVED = "learning_records_retrieval_success";
+    private static final String MESSAGE_ANSWER_DETAIL_RETRIEVED = "record_retrieval_success";
+    private static final String MESSAGE_ANSWER_SUBMITTED = "answer_submitted_success";
+    private static final String MESSAGE_FEEDBACK_RETRIEVED = "feedback_retrieval_success";
+
+    @Operation(summary = "답변 목록 조회", description = "사용자의 학습 기록 목록을 조회합니다 (본인만)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @GetMapping("/answers")
+    public ResponseEntity<ApiResponse<AnswerListResponse>> getAnswerList(
+            @Parameter(hidden = true) Long accountId,  // TODO: Spring Security에서 주입
+            @Valid @ModelAttribute AnswerListRequest request
+    ) {
+        // TODO: 구현 필요
+        // 1. accountId 추출 (Spring Security Authentication)
+        // 2. Request DTO를 Command로 변환
+        // 3. Service 호출
+        // 4. Result를 Response DTO로 변환
+        // 5. ApiResponse로 래핑하여 반환
+
+        log.info("GET /api/v1/answers - accountId: {}", accountId);
+
+        // TODO: 임시 구현 (Service 연동 필요)
+        return ResponseEntity.ok(
+                new ApiResponse<>(MESSAGE_ANSWER_LIST_RETRIEVED, null)
+        );
+    }
+
+    @Operation(summary = "답변 상세 조회", description = "특정 답변의 상세 정보를 조회합니다 (본인만)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "답변을 찾을 수 없음")
+    })
+    @GetMapping("/answers/{answerId}")
+    public ResponseEntity<ApiResponse<AnswerDetailResponse>> getAnswerDetail(
+            @Parameter(hidden = true) Long accountId,  // TODO: Spring Security에서 주입
+            @Parameter(description = "답변 ID", example = "1")
+            @PathVariable Long answerId,
+            @Valid @ModelAttribute AnswerDetailRequest request
+    ) {
+        // TODO: 구현 필요
+        // 1. accountId 추출
+        // 2. Service 호출 (소유권 검증 포함)
+        // 3. expand 파라미터 처리
+        // 4. Result를 Response DTO로 변환
+        // 5. ApiResponse로 래핑하여 반환
+
+        log.info("GET /api/v1/answers/{} - accountId: {}", answerId, accountId);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>(MESSAGE_ANSWER_DETAIL_RETRIEVED, null)
+        );
+    }
+
+    @Operation(summary = "답변 제출 (연습/단일)", description = "텍스트 또는 음성 답변을 제출합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "제출 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문을 찾을 수 없음")
+    })
+    @PostMapping(value = "/interview/answers", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<AnswerSubmitResponse>> submitAnswer(
+            @Parameter(hidden = true) Long accountId,  // TODO: Spring Security에서 주입
+            @Valid @ModelAttribute AnswerSubmitRequest request
+    ) {
+        // TODO: 구현 필요
+        // 1. accountId 추출
+        // 2. Request DTO를 Command로 변환
+        // 3. Service 호출 (파일 업로드, STT, 즉각 피드백, AI 피드백 이벤트)
+        // 4. Result를 Response DTO로 변환
+        // 5. ApiResponse로 래핑하여 201 Created 반환
+
+        log.info("POST /api/v1/interview/answers - accountId: {}, questionId: {}",
+                accountId, request.questionId());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse<>(MESSAGE_ANSWER_SUBMITTED, null));
+    }
+
+    @Operation(summary = "실전 세션 기반 답변 제출", description = "실전 모드 세션에서 비디오 답변을 제출합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "제출 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "세션 접근 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "세션을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "세션 상태 오류 또는 중복 답변")
+    })
+    @PostMapping(value = "/interview/sessions/{sessionId}/answers", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<SessionAnswerSubmitResponse>> submitSessionAnswer(
+            @Parameter(hidden = true) Long accountId,  // TODO: Spring Security에서 주입
+            @Parameter(description = "세션 ID", example = "uuid-string")
+            @PathVariable String sessionId,
+            @Valid @ModelAttribute SessionAnswerSubmitRequest request
+    ) {
+        // TODO: 구현 필요
+        // 1. accountId 추출
+        // 2. 세션 소유권 검증
+        // 3. Request DTO를 Command로 변환
+        // 4. Service 호출 (파일 업로드, 즉각 피드백, 세션 업데이트, 다음 질문 생성)
+        // 5. Result를 Response DTO로 변환
+        // 6. ApiResponse로 래핑하여 201 Created 반환
+
+        log.info("POST /api/v1/interview/sessions/{}/answers - accountId: {}, questionId: {}",
+                sessionId, accountId, request.questionId());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ApiResponse<>(MESSAGE_ANSWER_SUBMITTED, null));
+    }
+
+    @Operation(summary = "AI 피드백 조회", description = "답변에 대한 AI 피드백을 조회합니다")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "피드백 완료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "피드백 처리 중"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "답변을 찾을 수 없음")
+    })
+    @GetMapping("/interviews/answers/{answerId}/feedback")
+    public ResponseEntity<ApiResponse<FeedbackResponse>> getFeedback(
+            @Parameter(hidden = true) Long accountId,  // TODO: Spring Security에서 주입
+            @Parameter(description = "답변 ID", example = "1")
+            @PathVariable Long answerId
+    ) {
+        // TODO: 구현 필요
+        // 1. accountId 추출
+        // 2. Service 호출 (소유권 검증 포함)
+        // 3. Answer 상태에 따라 응답 분기
+        //    - PROCESSING: 202 Accepted (retry_after 포함)
+        //    - COMPLETED: 200 OK (레이더 차트, 피드백 포함)
+        //    - FAILED: 200 OK (실패 사유 포함)
+        // 4. Result를 Response DTO로 변환
+        // 5. ApiResponse로 래핑하여 반환
+
+        log.info("GET /api/v1/interviews/answers/{}/feedback - accountId: {}", answerId, accountId);
+
+        return ResponseEntity.ok(
+                new ApiResponse<>(MESSAGE_FEEDBACK_RETRIEVED, null)
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AiFeedbackSummary.java
+++ b/src/main/java/com/ktb/answer/dto/AiFeedbackSummary.java
@@ -1,0 +1,10 @@
+package com.ktb.answer.dto;
+
+import java.util.Map;
+
+public record AiFeedbackSummary(
+        FeedbackStatus status,
+        Map<String, Integer> radarChart,
+        String comment
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerContentResult.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerContentResult.java
@@ -1,0 +1,11 @@
+package com.ktb.answer.dto;
+
+import java.time.Instant;
+
+public record AnswerContentResult(
+        String answerText,
+        String audioUrl,
+        String videoUrl,
+        Instant answeredAt
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerDetailExpand.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerDetailExpand.java
@@ -1,0 +1,23 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.exception.InvalidExpandException;
+import java.util.Locale;
+
+public enum AnswerDetailExpand {
+    QUESTION,
+    FEEDBACK,
+    IMMEDIATE_FEEDBACK;
+
+    public static AnswerDetailExpand from(String value) {
+        if (value == null) {
+            throw new InvalidExpandException(null);
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        for (AnswerDetailExpand expand : values()) {
+            if (expand.name().equals(normalized)) {
+                return expand;
+            }
+        }
+        throw new InvalidExpandException(value);
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerDetailQuery.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerDetailQuery.java
@@ -1,0 +1,46 @@
+package com.ktb.answer.dto;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public record AnswerDetailQuery(Set<AnswerDetailExpand> expands) {
+
+    public AnswerDetailQuery {
+        if (expands == null || expands.isEmpty()) {
+            expands = EnumSet.noneOf(AnswerDetailExpand.class);
+        } else {
+            expands = EnumSet.copyOf(expands);
+        }
+    }
+
+    public boolean includeQuestion() {
+        return expands.contains(AnswerDetailExpand.QUESTION);
+    }
+
+    public boolean includeFeedback() {
+        return expands.contains(AnswerDetailExpand.FEEDBACK);
+    }
+
+    public boolean includeImmediateFeedback() {
+        return expands.contains(AnswerDetailExpand.IMMEDIATE_FEEDBACK);
+    }
+
+    public static AnswerDetailQuery of(Iterable<String> values) {
+        if (values == null) {
+            return new AnswerDetailQuery(Collections.emptySet());
+        }
+        EnumSet<AnswerDetailExpand> resolved = EnumSet.noneOf(AnswerDetailExpand.class);
+        for (String value : values) {
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            resolved.add(AnswerDetailExpand.from(value));
+        }
+        return new AnswerDetailQuery(resolved);
+    }
+
+    public static AnswerDetailQuery empty() {
+        return new AnswerDetailQuery(Collections.emptySet());
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerDetailResult.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerDetailResult.java
@@ -1,0 +1,13 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.domain.AnswerType;
+
+public record AnswerDetailResult(
+        Long answerId,
+        AnswerType type,
+        QuestionSummary question,
+        AnswerContentResult answer,
+        ImmediateFeedbackResult immediateFeedback,
+        AiFeedbackSummary aiFeedback
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerSubmitCommand.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerSubmitCommand.java
@@ -1,0 +1,25 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.domain.AnswerType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+import org.springframework.web.multipart.MultipartFile;
+
+public record AnswerSubmitCommand(
+        @NotNull Long questionId,
+        @Size(max = MAX_ANSWER_TEXT_LENGTH) String answerText,
+        MultipartFile audioFile,
+        AnswerType answerType
+) {
+
+    public static final int MAX_ANSWER_TEXT_LENGTH = 5_000;
+
+    public boolean hasAudio() {
+        return audioFile != null && !audioFile.isEmpty();
+    }
+
+    public boolean hasText() {
+        return Objects.nonNull(answerText) && !answerText.isBlank();
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerSubmitResult.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerSubmitResult.java
@@ -1,0 +1,16 @@
+package com.ktb.answer.dto;
+
+public record AnswerSubmitResult(
+        Long answerId,
+        String transcribedText,
+        String audioUrl,
+        ImmediateFeedbackResult immediateFeedback,
+        FeedbackStatus aiFeedbackStatus
+) {
+
+    private static final FeedbackStatus DEFAULT_FEEDBACK_STATUS = FeedbackStatus.PROCESSING;
+
+    public static AnswerSubmitResult processing(Long answerId, ImmediateFeedbackResult feedback) {
+        return new AnswerSubmitResult(answerId, null, null, feedback, DEFAULT_FEEDBACK_STATUS);
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/FeedbackResult.java
+++ b/src/main/java/com/ktb/answer/dto/FeedbackResult.java
@@ -1,0 +1,13 @@
+package com.ktb.answer.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record FeedbackResult(
+        FeedbackStatus status,
+        Integer estimatedTimeSeconds,
+        Map<String, Integer> metrics,
+        String comment,
+        Instant completedAt
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/FeedbackStatus.java
+++ b/src/main/java/com/ktb/answer/dto/FeedbackStatus.java
@@ -1,0 +1,7 @@
+package com.ktb.answer.dto;
+
+public enum FeedbackStatus {
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/ktb/answer/dto/ImmediateFeedbackResult.java
+++ b/src/main/java/com/ktb/answer/dto/ImmediateFeedbackResult.java
@@ -1,0 +1,11 @@
+package com.ktb.answer.dto;
+
+import java.util.Collections;
+import java.util.List;
+
+public record ImmediateFeedbackResult(List<KeywordCheckResult> keywords) {
+
+    public ImmediateFeedbackResult {
+        keywords = keywords == null ? Collections.emptyList() : List.copyOf(keywords);
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/KeywordCheckResult.java
+++ b/src/main/java/com/ktb/answer/dto/KeywordCheckResult.java
@@ -1,0 +1,7 @@
+package com.ktb.answer.dto;
+
+public record KeywordCheckResult(
+        String keyword,
+        boolean included
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/QuestionSummary.java
+++ b/src/main/java/com/ktb/answer/dto/QuestionSummary.java
@@ -1,0 +1,8 @@
+package com.ktb.answer.dto;
+
+public record QuestionSummary(
+        Long questionId,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java
@@ -1,0 +1,22 @@
+package com.ktb.answer.dto.request;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 답변 상세 조회 요청 DTO
+ */
+@Schema(description = "답변 상세 조회 요청")
+public record AnswerDetailRequest(
+
+        @Parameter(description = "확장 필드 (쉼표 구분: question,feedback,immediate_feedback)",
+                   example = "question,feedback,immediate_feedback")
+        @Schema(description = "응답에 포함할 확장 필드 (question: 질문 정보, feedback: AI 피드백, immediate_feedback: 즉각 피드백)",
+                example = "question,feedback,immediate_feedback")
+        String expand
+) {
+
+    private static final String EXPAND_QUESTION = "question";
+    private static final String EXPAND_FEEDBACK = "feedback";
+    private static final String EXPAND_IMMEDIATE_FEEDBACK = "immediate_feedback";
+}

--- a/src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
@@ -1,0 +1,55 @@
+package com.ktb.answer.dto.request;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.question.domain.QuestionCategory;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+
+/**
+ * 답변 목록 조회 요청 DTO
+ */
+@Schema(description = "답변 목록 조회 요청")
+public record AnswerListRequest(
+
+        @Parameter(description = "답변 타입 필터", example = "PRACTICE_INTERVIEW")
+        @Schema(description = "답변 타입 (PRACTICE_INTERVIEW, REAL_INTERVIEW, PORTFOLIO_INTERVIEW)", example = "PRACTICE_INTERVIEW")
+        AnswerType type,
+
+        @Parameter(description = "질문 카테고리 필터", example = "OS")
+        @Schema(description = "질문 카테고리 (OS, NETWORK, DB, DATA_STRUCTURE, ALGORITHM)", example = "OS")
+        QuestionCategory category,
+
+        @Parameter(description = "조회 시작 날짜 (YYYY-MM-DD)", example = "2026-01-01")
+        @Schema(description = "조회 시작 날짜", example = "2026-01-01", format = "date")
+        LocalDate dateFrom,
+
+        @Parameter(description = "조회 종료 날짜 (YYYY-MM-DD)", example = "2026-01-31")
+        @Schema(description = "조회 종료 날짜", example = "2026-01-31", format = "date")
+        LocalDate dateTo,
+
+        @Parameter(description = "페이지 크기 (1-50)", example = "10")
+        @Schema(description = "페이지 크기 (기본값: 10, 최대: 50)", example = "10", minimum = "1", maximum = "50")
+        @Min(1) @Max(50)
+        Integer limit,
+
+        @Parameter(description = "다음 페이지 커서 (Base64 인코딩)", example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
+        @Schema(description = "페이지네이션 커서 (이전 응답의 nextCursor 값)", example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
+        String cursor,
+
+        @Parameter(description = "확장 필드 (쉼표 구분: question,feedback)", example = "question,feedback")
+        @Schema(description = "응답에 포함할 확장 필드 (question: 질문 정보, feedback: 피드백 요약)", example = "question,feedback")
+        String expand
+) {
+
+    private static final int DEFAULT_LIMIT = 10;
+    private static final int MAX_LIMIT = 50;
+
+    public AnswerListRequest {
+        if (limit == null) {
+            limit = DEFAULT_LIMIT;
+        }
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/request/AnswerSubmitRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerSubmitRequest.java
@@ -1,0 +1,50 @@
+package com.ktb.answer.dto.request;
+
+import com.ktb.answer.domain.AnswerType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 답변 제출 요청 DTO (연습/단일 답변)
+ */
+@Schema(description = "답변 제출 요청 (연습/단일 답변)")
+public record AnswerSubmitRequest(
+
+        @Schema(description = "질문 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "질문 ID는 필수입니다")
+        Long questionId,
+
+        @Schema(description = "답변 텍스트 (최대 5,000자, answerText 또는 audioFile 중 최소 1개 필수)",
+                example = "프로세스는 실행 중인 프로그램의 인스턴스이며...",
+                maxLength = 5000)
+        @Size(max = MAX_ANSWER_TEXT_LENGTH, message = "답변 텍스트는 {max}자를 초과할 수 없습니다")
+        String answerText,
+
+        @Schema(description = "음성 파일 (최대 10MB, audio/* 형식)",
+                type = "string",
+                format = "binary")
+        MultipartFile audioFile,
+
+        @Schema(description = "답변 타입 (기본값: PRACTICE_INTERVIEW)",
+                example = "PRACTICE_INTERVIEW",
+                allowableValues = {"PRACTICE_INTERVIEW", "REAL_INTERVIEW", "PORTFOLIO_INTERVIEW"})
+        AnswerType answerType
+) {
+
+    public static final int MAX_ANSWER_TEXT_LENGTH = 5_000;
+    public static final long MAX_AUDIO_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    public boolean hasAudio() {
+        return audioFile != null && !audioFile.isEmpty();
+    }
+
+    public boolean hasText() {
+        return answerText != null && !answerText.isBlank();
+    }
+
+    public boolean hasContent() {
+        return hasText() || hasAudio();
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/request/SessionAnswerSubmitRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/SessionAnswerSubmitRequest.java
@@ -1,0 +1,39 @@
+package com.ktb.answer.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 실전 세션 기반 답변 제출 요청 DTO
+ */
+@Schema(description = "실전 세션 기반 답변 제출 요청")
+public record SessionAnswerSubmitRequest(
+
+        @Schema(description = "질문 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "질문 ID는 필수입니다")
+        Long questionId,
+
+        @Schema(description = "답변 텍스트 (최대 5,000자, 필수)",
+                example = "프로세스는 실행 중인 프로그램의 인스턴스입니다...",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                maxLength = 5000)
+        @NotBlank(message = "답변 텍스트는 필수입니다")
+        @Size(max = MAX_ANSWER_TEXT_LENGTH, message = "답변 텍스트는 {max}자를 초과할 수 없습니다")
+        String answerText,
+
+        @Schema(description = "비디오 파일 (최대 100MB, video/* 형식, 선택)",
+                type = "string",
+                format = "binary")
+        MultipartFile videoFile
+) {
+
+    public static final int MAX_ANSWER_TEXT_LENGTH = 5_000;
+    public static final long MAX_VIDEO_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+    public boolean hasVideo() {
+        return videoFile != null && !videoFile.isEmpty();
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/AnswerDetailResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/AnswerDetailResponse.java
@@ -1,0 +1,96 @@
+package com.ktb.answer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * 답변 상세 조회 응답 DTO
+ */
+@Schema(description = "답변 상세 조회 응답")
+public record AnswerDetailResponse(
+
+        @Schema(description = "답변 ID", example = "1")
+        Long answerId,
+
+        @Schema(description = "답변 내용", example = "프로세스는 실행 중인 프로그램의 인스턴스이며...")
+        String content,
+
+        @Schema(description = "답변 타입", example = "PRACTICE_INTERVIEW")
+        String type,
+
+        @Schema(description = "답변 상태", example = "COMPLETED",
+                allowableValues = {"SUBMITTED", "TRANSCRIBING", "IMMEDIATE_FEEDBACK_READY",
+                                   "AI_FEEDBACK_PROCESSING", "COMPLETED", "FAILED_RETRYABLE", "FAILED"})
+        String status,
+
+        @Schema(description = "답변 작성 시각", example = "2026-01-22T10:30:00")
+        String createdAt,
+
+        @Schema(description = "질문 상세 정보 (expand=question 시 포함)")
+        QuestionDetail question,
+
+        @Schema(description = "즉각 피드백 정보 (expand=immediate_feedback 시 포함)")
+        ImmediateFeedbackDetail immediateFeedback,
+
+        @Schema(description = "AI 피드백 정보 (expand=feedback 시 포함)")
+        AiFeedbackDetail aiFeedback
+) {
+
+    @Schema(description = "질문 상세 정보")
+    public record QuestionDetail(
+            @Schema(description = "질문 ID", example = "10")
+            Long questionId,
+
+            @Schema(description = "질문 내용", example = "프로세스와 스레드의 차이를 설명해주세요")
+            String content,
+
+            @Schema(description = "질문 카테고리", example = "OS")
+            String category,
+
+            @Schema(description = "질문 타입", example = "TECHNICAL")
+            String type
+    ) {
+    }
+
+    @Schema(description = "즉각 피드백 상세")
+    public record ImmediateFeedbackDetail(
+            @Schema(description = "키워드 체크 결과 목록")
+            List<KeywordCheck> keywords
+    ) {
+    }
+
+    @Schema(description = "키워드 체크 결과")
+    public record KeywordCheck(
+            @Schema(description = "키워드", example = "프로세스")
+            String keyword,
+
+            @Schema(description = "포함 여부", example = "true")
+            boolean included
+    ) {
+    }
+
+    @Schema(description = "AI 피드백 상세")
+    public record AiFeedbackDetail(
+            @Schema(description = "피드백 상태", example = "COMPLETED",
+                    allowableValues = {"PROCESSING", "COMPLETED", "FAILED"})
+            String status,
+
+            @Schema(description = "AI 종합 평가 피드백",
+                    example = "전반적으로 프로세스와 스레드의 개념을 잘 이해하고 있습니다...")
+            String feedback,
+
+            @Schema(description = "평가 지표 점수 목록 (레이더 차트)")
+            List<MetricScore> metrics
+    ) {
+    }
+
+    @Schema(description = "평가 지표 점수")
+    public record MetricScore(
+            @Schema(description = "평가 지표명", example = "논리 구조")
+            String metricName,
+
+            @Schema(description = "점수 (0-100)", example = "85", minimum = "0", maximum = "100")
+            int score
+    ) {
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/AnswerListResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/AnswerListResponse.java
@@ -1,0 +1,75 @@
+package com.ktb.answer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * 답변 목록 조회 응답 DTO
+ */
+@Schema(description = "답변 목록 조회 응답")
+public record AnswerListResponse(
+
+        @Schema(description = "답변 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<AnswerSummary> records,
+
+        @Schema(description = "페이지네이션 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+        PaginationInfo pagination
+) {
+
+    @Schema(description = "답변 요약 정보")
+    public record AnswerSummary(
+            @Schema(description = "답변 ID", example = "1")
+            Long answerId,
+
+            @Schema(description = "답변 타입", example = "PRACTICE_INTERVIEW")
+            String type,
+
+            @Schema(description = "답변 작성 시각", example = "2026-01-22T10:30:00")
+            String answeredAt,
+
+            @Schema(description = "질문 정보 (expand=question 시 포함)")
+            QuestionInfo question,
+
+            @Schema(description = "피드백 요약 정보 (expand=feedback 시 포함)")
+            FeedbackInfo feedback
+    ) {
+    }
+
+    @Schema(description = "질문 요약 정보")
+    public record QuestionInfo(
+            @Schema(description = "질문 ID", example = "10")
+            Long questionId,
+
+            @Schema(description = "질문 내용", example = "프로세스와 스레드의 차이를 설명해주세요")
+            String content,
+
+            @Schema(description = "질문 카테고리", example = "OS")
+            String category
+    ) {
+    }
+
+    @Schema(description = "피드백 요약 정보")
+    public record FeedbackInfo(
+            @Schema(description = "피드백 제공 여부", example = "true")
+            boolean feedbackAvailable,
+
+            @Schema(description = "AI 피드백 상태", example = "COMPLETED",
+                    allowableValues = {"PROCESSING", "COMPLETED", "FAILED"})
+            String aiFeedbackStatus
+    ) {
+    }
+
+    @Schema(description = "페이지네이션 정보")
+    public record PaginationInfo(
+            @Schema(description = "페이지 크기", example = "10")
+            int limit,
+
+            @Schema(description = "다음 페이지 존재 여부", example = "true")
+            boolean hasNext,
+
+            @Schema(description = "다음 페이지 커서 (hasNext=true 시에만 제공)",
+                    example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
+            String nextCursor
+    ) {
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/AnswerSubmitResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/AnswerSubmitResponse.java
@@ -1,0 +1,58 @@
+package com.ktb.answer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * 답변 제출 응답 DTO (연습/단일 답변)
+ */
+@Schema(description = "답변 제출 응답 (연습/단일 답변)")
+public record AnswerSubmitResponse(
+
+        @Schema(description = "생성된 답변 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long answerId,
+
+        @Schema(description = "음성 변환 텍스트 (음성 파일 제출 시)", example = "프로세스는 실행 중인 프로그램의 인스턴스이며...")
+        String transcribedText,
+
+        @Schema(description = "음성 파일 URL (음성 파일 제출 시)", example = "https://cdn.example.com/audio/123.mp3")
+        String audioUrl,
+
+        @Schema(description = "즉각 피드백 (키워드 체크)", requiredMode = Schema.RequiredMode.REQUIRED)
+        ImmediateFeedback immediateFeedback,
+
+        @Schema(description = "AI 피드백 처리 상태", example = "processing",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"processing", "completed", "failed"})
+        String aiFeedbackStatus
+) {
+
+    @Schema(description = "즉각 피드백 정보")
+    public record ImmediateFeedback(
+            @Schema(description = "키워드 체크 결과 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+            List<KeywordCheck> keywords
+    ) {
+    }
+
+    @Schema(description = "키워드 체크 결과")
+    public record KeywordCheck(
+            @Schema(description = "키워드", example = "프로세스")
+            String keyword,
+
+            @Schema(description = "답변에 포함 여부", example = "true")
+            boolean included
+    ) {
+    }
+
+    private static final String DEFAULT_AI_FEEDBACK_STATUS = "processing";
+
+    public static AnswerSubmitResponse processing(Long answerId, ImmediateFeedback immediateFeedback) {
+        return new AnswerSubmitResponse(
+                answerId,
+                null,
+                null,
+                immediateFeedback,
+                DEFAULT_AI_FEEDBACK_STATUS
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java
@@ -1,0 +1,75 @@
+package com.ktb.answer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * AI 피드백 조회 응답 DTO
+ */
+@Schema(description = "AI 피드백 조회 응답")
+public record FeedbackResponse(
+
+        @Schema(description = "피드백 처리 상태", example = "COMPLETED",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"PROCESSING", "COMPLETED", "FAILED"})
+        String status,
+
+        @Schema(description = "AI 종합 평가 피드백 (status=COMPLETED 시)",
+                example = "전반적으로 프로세스와 스레드의 개념을 잘 이해하고 계십니다. 특히 메모리 공간의 차이에 대해 명확히 설명하셨습니다...")
+        String feedback,
+
+        @Schema(description = "레이더 차트 데이터 (status=COMPLETED 시)")
+        List<RadarChartMetric> radarChart,
+
+        @Schema(description = "재시도 권장 시간 (초, status=PROCESSING 시)", example = "5")
+        Integer retryAfter
+) {
+
+    @Schema(description = "레이더 차트 평가 지표")
+    public record RadarChartMetric(
+            @Schema(description = "평가 지표명", example = "논리 구조")
+            String metricName,
+
+            @Schema(description = "평가 지표 설명", example = "답변의 논리적 흐름과 구조")
+            String metricDescription,
+
+            @Schema(description = "획득 점수", example = "85", minimum = "0", maximum = "100")
+            int score,
+
+            @Schema(description = "최대 점수", example = "100")
+            int maxScore
+    ) {
+    }
+
+    private static final String STATUS_PROCESSING = "PROCESSING";
+    private static final String STATUS_COMPLETED = "COMPLETED";
+    private static final String STATUS_FAILED = "FAILED";
+    private static final int DEFAULT_RETRY_AFTER_SECONDS = 5;
+
+    public static FeedbackResponse processing() {
+        return new FeedbackResponse(
+                STATUS_PROCESSING,
+                null,
+                null,
+                DEFAULT_RETRY_AFTER_SECONDS
+        );
+    }
+
+    public static FeedbackResponse completed(String feedback, List<RadarChartMetric> radarChart) {
+        return new FeedbackResponse(
+                STATUS_COMPLETED,
+                feedback,
+                radarChart,
+                null
+        );
+    }
+
+    public static FeedbackResponse failed(String reason) {
+        return new FeedbackResponse(
+                STATUS_FAILED,
+                reason,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/SessionAnswerSubmitResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/SessionAnswerSubmitResponse.java
@@ -1,0 +1,75 @@
+package com.ktb.answer.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * 실전 세션 기반 답변 제출 응답 DTO
+ */
+@Schema(description = "실전 세션 기반 답변 제출 응답")
+public record SessionAnswerSubmitResponse(
+
+        @Schema(description = "생성된 답변 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long answerId,
+
+        @Schema(description = "비디오 파일 URL (비디오 파일 제출 시)", example = "https://cdn.example.com/video/123.mp4")
+        String videoUrl,
+
+        @Schema(description = "즉각 피드백 (키워드 체크)", requiredMode = Schema.RequiredMode.REQUIRED)
+        ImmediateFeedback immediateFeedback,
+
+        @Schema(description = "AI 피드백 처리 상태", example = "processing",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"processing", "completed", "failed"})
+        String aiFeedbackStatus,
+
+        @Schema(description = "다음 질문 정보 (세션 계속 진행 시)")
+        NextQuestion nextQuestion
+) {
+
+    @Schema(description = "즉각 피드백 정보")
+    public record ImmediateFeedback(
+            @Schema(description = "키워드 체크 결과 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+            List<KeywordCheck> keywords
+    ) {
+    }
+
+    @Schema(description = "키워드 체크 결과")
+    public record KeywordCheck(
+            @Schema(description = "키워드", example = "프로세스")
+            String keyword,
+
+            @Schema(description = "답변에 포함 여부", example = "true")
+            boolean included
+    ) {
+    }
+
+    @Schema(description = "다음 질문 정보")
+    public record NextQuestion(
+            @Schema(description = "다음 질문 ID", example = "15")
+            Long questionId,
+
+            @Schema(description = "다음 질문 내용", example = "동기화 기법에 대해 설명해주세요")
+            String content,
+
+            @Schema(description = "다음 질문 카테고리", example = "OS")
+            String category
+    ) {
+    }
+
+    private static final String DEFAULT_AI_FEEDBACK_STATUS = "processing";
+
+    public static SessionAnswerSubmitResponse processing(
+            Long answerId,
+            ImmediateFeedback immediateFeedback,
+            NextQuestion nextQuestion
+    ) {
+        return new SessionAnswerSubmitResponse(
+                answerId,
+                null,
+                immediateFeedback,
+                DEFAULT_AI_FEEDBACK_STATUS,
+                nextQuestion
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/exception/AnswerNotFoundException.java
+++ b/src/main/java/com/ktb/answer/exception/AnswerNotFoundException.java
@@ -8,4 +8,9 @@ public class AnswerNotFoundException extends BusinessException {
     public AnswerNotFoundException() {
         super(ErrorCode.ANSWER_NOT_FOUND);
     }
+
+    public AnswerNotFoundException(Long answerId) {
+        String errMsg = String.format("%s answerId = %d", ErrorCode.ANSWER_NOT_FOUND.getMessage(), answerId);
+        super(ErrorCode.ANSWER_NOT_FOUND, errMsg);
+    }
 }

--- a/src/main/java/com/ktb/answer/exception/InvalidAnswerContentException.java
+++ b/src/main/java/com/ktb/answer/exception/InvalidAnswerContentException.java
@@ -1,0 +1,12 @@
+package com.ktb.answer.exception;
+
+import static com.ktb.common.domain.ErrorCode.ANSWER_INVALID_CONTENT;
+
+import com.ktb.common.exception.BusinessException;
+
+public class InvalidAnswerContentException extends BusinessException {
+    public InvalidAnswerContentException(Long contentSize) {
+        String errMsg = String.format("%s content string length : %d", ANSWER_INVALID_CONTENT.getMessage(), contentSize);
+        super(ANSWER_INVALID_CONTENT, errMsg);
+    }
+}

--- a/src/main/java/com/ktb/answer/exception/InvalidExpandException.java
+++ b/src/main/java/com/ktb/answer/exception/InvalidExpandException.java
@@ -1,0 +1,12 @@
+package com.ktb.answer.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class InvalidExpandException extends BusinessException {
+
+    public InvalidExpandException(String value) {
+        String errMsg = String.format("%s value={%s}",ErrorCode.INVALID_INPUT.getMessage() ,value);
+        super(ErrorCode.INVALID_INPUT, errMsg);
+    }
+}

--- a/src/main/java/com/ktb/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/ktb/answer/repository/AnswerRepository.java
@@ -1,0 +1,70 @@
+package com.ktb.answer.repository;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.question.domain.QuestionCategory;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    /**
+     * 답변 목록 조회 (본인 소유 + 필터링 + 커서 페이지네이션)
+     * 정렬: created_at DESC, answer_id DESC
+     */
+    @Query("""
+            SELECT a FROM Answer a
+            JOIN FETCH a.question q
+            WHERE a.deletedAt IS NULL
+            AND a.account.id = :accountId
+            AND (:type IS NULL OR a.type = :type)
+            AND (:category IS NULL OR q.category = :category)
+            AND (:dateFrom IS NULL OR a.createdAt >= :dateFrom)
+            AND (:dateTo IS NULL OR a.createdAt <= :dateTo)
+            AND (:cursorCreatedAt IS NULL OR a.createdAt < :cursorCreatedAt
+                 OR (a.createdAt = :cursorCreatedAt AND a.id < :cursorAnswerId))
+            ORDER BY a.createdAt DESC, a.id DESC
+            """)
+    Slice<Answer> findByAccountIdWithFilters(
+            @Param("accountId") Long accountId,
+            @Param("type") AnswerType type,
+            @Param("category") QuestionCategory category,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo,
+            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            @Param("cursorAnswerId") Long cursorAnswerId,
+            Pageable pageable
+    );
+
+    /**
+     * 답변 상세 조회 (본인 소유 확인용)
+     */
+    @Query("""
+            SELECT a FROM Answer a
+            JOIN FETCH a.question
+            WHERE a.id = :answerId
+            AND a.deletedAt IS NULL
+            """)
+    Answer findByIdWithQuestion(@Param("answerId") Long answerId);
+
+    /**
+     * 세션 내 중복 답변 체크
+     * TODO: ANSWER_SESSION 엔티티 구현 후 활성화
+     */
+    // @Query("""
+    //         SELECT COUNT(a) > 0 FROM Answer a
+    //         WHERE a.session.id = :sessionId
+    //         AND a.question.id = :questionId
+    //         AND a.deletedAt IS NULL
+    //         """)
+    // boolean existsBySessionIdAndQuestionId(
+    //         @Param("sessionId") String sessionId,
+    //         @Param("questionId") Long questionId
+    // );
+}

--- a/src/main/java/com/ktb/answer/service/AiFeedbackOrchestrator.java
+++ b/src/main/java/com/ktb/answer/service/AiFeedbackOrchestrator.java
@@ -1,0 +1,34 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.FeedbackStatus;
+
+/**
+ * AI 피드백 오케스트레이터 인터페이스
+ * 비동기 AI 피드백 생성 파이프라인 관리 (Kafka 이벤트 기반)
+ */
+public interface AiFeedbackOrchestrator {
+
+    /**
+     * AI 피드백 생성 이벤트 발행 (Kafka)
+     *
+     * @param answerId 피드백 생성 대상 답변 ID
+     * @throws RuntimeException 이벤트 발행에 실패한 경우
+     */
+    void enqueue(Long answerId);
+
+    /**
+     * 피드백 처리 상태 조회
+     *
+     * @param answerId 답변 ID
+     * @return PROCESSING, COMPLETED, FAILED, FAILED_RETRYABLE 중 하나
+     */
+    FeedbackStatus getStatus(Long answerId);
+
+    /**
+     * 피드백 재시도 요청
+     *
+     * @param answerId 답변 ID
+     * @throws RuntimeException 재시도가 허용되지 않는 경우
+     */
+    void requestRetry(Long answerId);
+}

--- a/src/main/java/com/ktb/answer/service/AnswerApplicationService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerApplicationService.java
@@ -1,0 +1,101 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerSubmitCommand;
+import com.ktb.answer.dto.AnswerSubmitResult;
+import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.file.exception.FileAlreadyDeletedException;
+import com.ktb.file.exception.FileExtensionNotAllowedException;
+import com.ktb.file.exception.FileNotFoundException;
+import com.ktb.file.exception.FileSizeExceededException;
+import com.ktb.file.exception.FileStorageMigrationException;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.exception.QuestionDisabledException;
+import com.ktb.question.exception.QuestionNotFoundException;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public interface AnswerApplicationService {
+
+    /**
+     * 답변 목록 조회 (본인 답변만)
+     *
+     * @param accountId       현재 사용자 ID
+     * @param type            답변 타입 필터 (선택)
+     * @param category        질문 카테고리 필터 (선택)
+     * @param dateFrom        시작 날짜 (선택)
+     * @param dateTo          종료 날짜 (선택)
+     * @param cursorCreatedAt 커서 생성 시각 (페이지네이션)
+     * @param cursorAnswerId  커서 답변 ID (페이지네이션)
+     * @param limit           조회 개수
+     * @param expand          확장 필드 (question, feedback)
+     * @return 답변 목록 (Slice)
+     */
+    Slice<?> getList(
+            Long accountId,
+            AnswerType type,
+            QuestionCategory category,
+            LocalDateTime dateFrom,
+            LocalDateTime dateTo,
+            LocalDateTime cursorCreatedAt,
+            Long cursorAnswerId,
+            int limit,
+            String expand
+    );
+
+    /**
+     * 답변 제출 (연습/단일 답변)
+     *
+     * @throws QuestionNotFoundException        질문이 존재하지 않는 경우 (404)
+     * @throws QuestionDisabledException        질문이 비활성화된 경우 (400)
+     * @throws FileSizeExceededException        파일 크기가 초과된 경우 (422)
+     * @throws FileExtensionNotAllowedException 지원하지 않는 파일 형식 (400)
+     * @throws FileNotFoundException            업로드에 참조된 파일을 찾을 수 없는 경우 (404)
+     * @throws FileAlreadyDeletedException      업로드 파일이 이미 삭제된 경우 (409)
+     * @throws FileStorageMigrationException    저장소 이동 중 장애가 발생한 경우 (422)
+     */
+    @Transactional
+    AnswerSubmitResult submit(Long accountId, AnswerSubmitCommand command)
+            throws QuestionNotFoundException, QuestionDisabledException,
+            FileSizeExceededException, FileExtensionNotAllowedException,
+            FileNotFoundException, FileAlreadyDeletedException, FileStorageMigrationException;
+
+    /**
+     * 세션 기반 답변 제출 (실전 모드)
+     *
+     * @param accountId 현재 사용자 ID
+     * @param sessionId 세션 ID
+     * @param command   답변 제출 정보
+     * @return 답변 제출 결과
+     * @throws QuestionNotFoundException 질문이 존재하지 않는 경우
+     * TODO: 세션 관련 Exception 추가 필요
+     */
+    @Transactional
+    AnswerSubmitResult submitWithSession(Long accountId, String sessionId, AnswerSubmitCommand command)
+            throws QuestionNotFoundException;
+
+    /**
+     * 답변 상세 조회
+     *
+     * @throws AnswerNotFoundException     답변이 존재하지 않는 경우 (404)
+     * @throws AnswerAccessDeniedException 본인 답변이 아닌 경우 (403)
+     */
+    AnswerDetailResult getDetail(Long accountId, Long answerId, AnswerDetailQuery query)
+            throws AnswerNotFoundException, AnswerAccessDeniedException;
+
+    /**
+     * AI 피드백 조회
+     *
+     * @throws AnswerNotFoundException     답변이 존재하지 않는 경우 (404)
+     * @throws AnswerAccessDeniedException 본인 답변이 아닌 경우 (403)
+     */
+    FeedbackResult getFeedback(Long accountId, Long answerId)
+            throws AnswerNotFoundException, AnswerAccessDeniedException;
+}

--- a/src/main/java/com/ktb/answer/service/AnswerDomainService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerDomainService.java
@@ -1,0 +1,48 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.DuplicateAnswerException;
+import com.ktb.answer.exception.InvalidAnswerContentException;
+import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface AnswerDomainService {
+    /**
+     * 답변 생성
+     * @return 생성된 Answer 엔티티
+     */
+    public Answer createAnswer(Long accountId, Long questionId, String answerContent,
+                               String audioUrl, String videoUrl, AnswerType type);
+
+    /**
+     * 답변 소유권 검증
+     * @throws AnswerAccessDeniedException 본인 답변이 아닌 경우
+     */
+    public void validateOwnership(Answer answer, Long accountId)
+        throws AnswerAccessDeniedException;
+
+    /**
+     * 답변 상태 전이
+     * @throws InvalidAnswerStatusTransitionException 허용되지 않는 상태 전이인 경우
+     */
+    public void transitionStatus(Answer answer, AnswerStatus nextStatus)
+        throws InvalidAnswerStatusTransitionException;
+
+    /**
+     * 중복 답변 검증 (세션 내 동일 질문)
+     * @throws DuplicateAnswerException 이미 답변이 존재하는 경우
+     */
+    public void checkDuplicateAnswer(String sessionId, Long questionId)
+        throws DuplicateAnswerException;
+
+    /**
+     * 답변 텍스트 유효성 검증
+     * @throws InvalidAnswerContentException 답변 내용이 유효하지 않은 경우
+     */
+    public void validateAnswerContent(String answerText, String audioUrl)
+        throws InvalidAnswerContentException;
+}

--- a/src/main/java/com/ktb/answer/service/ImmediateFeedbackService.java
+++ b/src/main/java/com/ktb/answer/service/ImmediateFeedbackService.java
@@ -1,0 +1,30 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.dto.response.AnswerSubmitResponse.ImmediateFeedback;
+import com.ktb.hashtag.domain.Hashtag;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ImmediateFeedbackService {
+    /**
+     * 즉각 피드백 생성 (동기 처리)
+     * @param questionId 질문 ID
+     * @param answerText 답변 텍스트
+     * @return 키워드 체크리스트 기반 즉각 피드백
+     */
+    ImmediateFeedback evaluate(Long questionId, String answerText);
+
+    /**
+     * 핵심 키워드 추출
+     * @return 질문별 핵심 키워드 목록
+     */
+    List<Hashtag> extractKeywords(Long questionId);
+
+    /**
+     * 키워드 포함 여부 체크
+     * @return 키워드별 포함 여부 결과
+     */
+    List<KeywordCheckResult> checkKeywords(String answerText, List<Hashtag> keywords);
+}

--- a/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
@@ -1,0 +1,79 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AiFeedbackOrchestrator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
+
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public void enqueue(Long answerId) {
+        // TODO: MVP V2 구현 필요
+        // 1. Kafka Producer 구성
+        // 2. ANSWER_AI_FEEDBACK_REQUESTED 이벤트 발행
+        // 3. 이벤트 payload: { answerId, questionId, answerContent }
+        // 4. 발행 실패 시 예외 처리 (재시도 정책)
+
+        log.info("Enqueueing AI feedback request for answerId: {}", answerId);
+
+        // TODO: Kafka 연동 후 활성화
+        // kafkaTemplate.send("answer-feedback-requests", answerId.toString(), event);
+
+        log.warn("AI feedback enqueue not implemented yet (Kafka integration required)");
+    }
+
+    @Override
+    public FeedbackStatus getStatus(Long answerId) {
+        // TODO: 구현 필요
+        // 1. Answer 조회
+        // 2. Answer.status를 FeedbackStatus로 매핑
+        //    - AI_FEEDBACK_PROCESSING -> PROCESSING
+        //    - COMPLETED -> COMPLETED
+        //    - FAILED -> FAILED
+        //    - FAILED_RETRYABLE -> FAILED_RETRYABLE
+        // 3. FeedbackStatus 반환
+
+        log.debug("Getting feedback status for answerId: {}", answerId);
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+        return mapAnswerStatusToFeedbackStatus(answer.getStatus());
+    }
+
+    @Override
+    public void requestRetry(Long answerId) {
+        // TODO: MVP V2 구현 필요
+        // 1. Answer 조회
+        // 2. 상태 검증 (FAILED_RETRYABLE만 허용)
+        // 3. 재시도 횟수 체크 (최대 3회)
+        // 4. Kafka 이벤트 재발행
+        // 5. Answer 상태를 AI_FEEDBACK_PROCESSING으로 전이
+
+        log.info("Requesting feedback retry for answerId: {}", answerId);
+
+        // TODO: 재시도 정책 구현 후 활성화
+        throw new UnsupportedOperationException("Feedback retry not yet implemented");
+    }
+
+    private FeedbackStatus mapAnswerStatusToFeedbackStatus(AnswerStatus answerStatus) {
+        return switch (answerStatus) {
+            case AI_FEEDBACK_PROCESSING -> FeedbackStatus.PROCESSING;
+            case COMPLETED -> FeedbackStatus.COMPLETED;
+            case FAILED -> FeedbackStatus.FAILED;
+            case FAILED_RETRYABLE -> FeedbackStatus.FAILED_RETRYABLE;
+            default -> FeedbackStatus.NOT_AVAILABLE;
+        };
+    }
+}

--- a/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
@@ -1,0 +1,231 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerSubmitCommand;
+import com.ktb.answer.dto.AnswerSubmitResult;
+import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerInvalidContentException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AnswerApplicationService;
+import com.ktb.answer.service.ImmediateFeedbackService;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.repository.UserAccountRepository;
+import com.ktb.file.exception.FileAlreadyDeletedException;
+import com.ktb.file.exception.FileExtensionNotAllowedException;
+import com.ktb.file.exception.FileNotFoundException;
+import com.ktb.file.exception.FileSizeExceededException;
+import com.ktb.file.exception.FileStorageMigrationException;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.exception.QuestionDisabledException;
+import com.ktb.question.exception.QuestionNotFoundException;
+import com.ktb.question.repository.QuestionRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class AnswerApplicationServiceImpl implements AnswerApplicationService {
+
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final UserAccountRepository userAccountRepository;
+    private final ImmediateFeedbackService immediateFeedbackService;
+
+    @Override
+    public Slice<?> getList(
+            Long accountId,
+            AnswerType type,
+            QuestionCategory category,
+            LocalDateTime dateFrom,
+            LocalDateTime dateTo,
+            LocalDateTime cursorCreatedAt,
+            Long cursorAnswerId,
+            int limit,
+            String expand
+    ) {
+        // TODO: 구현 필요
+        // 1. Repository에서 답변 목록 조회 (커서 페이지네이션)
+        // 2. expand 파라미터에 따라 추가 데이터 조회 (question, feedback)
+        // 3. DTO로 변환하여 반환
+
+        log.debug("Retrieving answer list for accountId: {}", accountId);
+
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+
+        Slice<Answer> answers = answerRepository.findByAccountIdWithFilters(
+                accountId,
+                type,
+                category,
+                dateFrom,
+                dateTo,
+                cursorCreatedAt,
+                cursorAnswerId,
+                pageRequest
+        );
+
+        // TODO: expand 처리 및 DTO 변환
+        return answers;
+    }
+
+    @Override
+    @Transactional
+    public AnswerSubmitResult submit(Long accountId, AnswerSubmitCommand command)
+            throws QuestionNotFoundException, QuestionDisabledException,
+            FileSizeExceededException, FileExtensionNotAllowedException,
+            FileNotFoundException, FileAlreadyDeletedException, FileStorageMigrationException {
+
+        // TODO: 구현 필요
+        // 1. 입력 검증 (answer_text 또는 audio_file 중 최소 1개 필수)
+        // 2. Question 존재 및 활성화 검증
+        // 3. 파일 업로드 처리 (있는 경우)
+        // 4. STT 처리 (음성 파일인 경우)
+        // 5. Answer 엔티티 생성 및 저장
+        // 6. 즉각 피드백 생성 (동기)
+        // 7. AI 피드백 요청 이벤트 발행 (비동기)
+        // 8. 결과 반환
+
+        log.info("Submitting answer for questionId: {}, accountId: {}", command.questionId(), accountId);
+
+        validateSubmitCommand(command);
+
+        Question question = findQuestionById(command.questionId());
+        validateQuestionEnabled(question);
+
+        UserAccount account = userAccountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+
+        // TODO: 파일 업로드 및 STT 처리
+
+        Answer answer = Answer.create(
+                question,
+                account,
+                command.answerText(),
+                command.answerType()
+        );
+
+        Answer savedAnswer = answerRepository.save(answer);
+
+        ImmediateFeedbackResult immediateFeedback = immediateFeedbackService.evaluate(
+                question.getId(),
+                savedAnswer.getContent()
+        );
+
+        // TODO: MVP V2 AI 피드백 이벤트 발행
+
+        return AnswerSubmitResult.processing(savedAnswer.getId(), immediateFeedback);
+    }
+
+    @Override
+    @Transactional
+    public AnswerSubmitResult submitWithSession(Long accountId, String sessionId, AnswerSubmitCommand command)
+            throws QuestionNotFoundException {
+
+        // TODO: MVP V2 구현 필요
+        // 1. 세션 존재 및 소유권 검증
+        // 2. 세션 상태 검증 (IN_PROGRESS만 허용)
+        // 3. 중복 답변 검증 (동일 질문에 대한 답변)
+        // 4. 파일 업로드 처리 (비디오 파일)
+        // 5. Answer 생성 및 저장
+        // 6. 즉각 피드백 생성
+        // 7. 세션 depth 증가
+        // 8. AI 피드백 이벤트 발행
+        // 9. 다음 질문 생성 (필요 시)
+        // 10. 결과 반환
+
+        log.info("Submitting session answer for sessionId: {}, questionId: {}, accountId: {}",
+                sessionId, command.questionId(), accountId);
+
+        // TODO: ANSWER_SESSION 엔티티 구현 후 활성화
+        throw new UnsupportedOperationException("Session-based answer submission not yet implemented");
+    }
+
+    @Override
+    public AnswerDetailResult getDetail(Long accountId, Long answerId, AnswerDetailQuery query)
+            throws AnswerNotFoundException, AnswerAccessDeniedException {
+
+        // TODO: 구현 필요
+        // 1. Answer 조회
+        // 2. 소유권 검증
+        // 3. expand 파라미터에 따라 추가 데이터 조회
+        //    - expand=question: Question 정보 포함
+        //    - expand=feedback: ANSWER_METRIC, AI 피드백 포함
+        //    - expand=immediate_feedback: 즉각 피드백 포함
+        // 4. DTO로 변환하여 반환
+
+        log.debug("Retrieving answer detail for answerId: {}, accountId: {}", answerId, accountId);
+
+        Answer answer = findAnswerById(answerId);
+        validateOwnership(answer, accountId);
+
+        // TODO: expand 처리 및 DTO 변환
+        return null;
+    }
+
+    @Override
+    public FeedbackResult getFeedback(Long accountId, Long answerId)
+            throws AnswerNotFoundException, AnswerAccessDeniedException {
+
+        // TODO: 구현 필요
+        // 1. Answer 조회
+        // 2. 소유권 검증
+        // 3. Answer 상태에 따라 응답 분기
+        //    - AI_FEEDBACK_PROCESSING: 202 응답 (retry_after 포함)
+        //    - COMPLETED: 200 응답 (레이더 차트, AI 피드백 포함)
+        //    - FAILED: 200 응답 (실패 사유 포함)
+        // 4. ANSWER_METRIC 조회 (레이더 차트 데이터)
+        // 5. DTO로 변환하여 반환
+
+        log.debug("Retrieving feedback for answerId: {}, accountId: {}", answerId, accountId);
+
+        Answer answer = findAnswerById(answerId);
+        validateOwnership(answer, accountId);
+
+        // TODO: 상태별 응답 처리 및 DTO 변환
+        return null;
+    }
+
+    private void validateSubmitCommand(AnswerSubmitCommand command) {
+        if (!command.hasText() && !command.hasAudio()) {
+            throw new AnswerInvalidContentException();
+        }
+    }
+
+    private Question findQuestionById(Long questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionNotFoundException(questionId));
+    }
+
+    private void validateQuestionEnabled(Question question) {
+        if (!question.isEnabled()) {
+            throw new QuestionDisabledException(question.getId());
+        }
+    }
+
+    private Answer findAnswerById(Long answerId) {
+        Answer answer = answerRepository.findByIdWithQuestion(answerId);
+        if (answer == null) {
+            throw new AnswerNotFoundException(answerId);
+        }
+        return answer;
+    }
+
+    private void validateOwnership(Answer answer, Long accountId) {
+        if (!answer.isOwnedBy(accountId)) {
+            throw new AnswerAccessDeniedException(answer.getId(), accountId);
+        }
+    }
+}

--- a/src/main/java/com/ktb/answer/service/impl/AnswerDomainServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerDomainServiceImpl.java
@@ -1,0 +1,118 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerInvalidContentException;
+import com.ktb.answer.exception.DuplicateAnswerException;
+import com.ktb.answer.exception.InvalidAnswerContentException;
+import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AnswerDomainService;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.repository.UserAccountRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnswerDomainServiceImpl implements AnswerDomainService {
+
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final UserAccountRepository userAccountRepository;
+
+    private static final int MAX_ANSWER_CONTENT_LENGTH = 1_500;
+
+    @Override
+    public Answer createAnswer(Long accountId, Long questionId, String answerContent,
+                               String audioUrl, String videoUrl, AnswerType type) {
+        // TODO: 구현 필요
+        // 1. UserAccount 조회
+        // 2. Question 조회
+        // 3. Answer.create() 호출
+        // 4. Answer 반환 (저장은 Application Service에서 수행)
+
+        log.debug("Creating answer for accountId: {}, questionId: {}", accountId, questionId);
+
+        UserAccount account = userAccountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found: " + accountId));
+
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+
+        return Answer.create(question, account, answerContent, type);
+    }
+
+    @Override
+    public void validateOwnership(Answer answer, Long accountId)
+            throws AnswerAccessDeniedException {
+        // TODO: 구현 필요
+        // 1. answer.isOwnedBy(accountId) 호출
+        // 2. false면 AnswerAccessDeniedException 발생
+
+        log.debug("Validating ownership for answerId: {}, accountId: {}", answer.getId(), accountId);
+
+        if (!answer.isOwnedBy(accountId)) {
+            throw new AnswerAccessDeniedException(answer.getId(), accountId);
+        }
+    }
+
+    @Override
+    public void transitionStatus(Answer answer, AnswerStatus nextStatus)
+            throws InvalidAnswerStatusTransitionException {
+        // TODO: 구현 필요
+        // 1. answer.transitionTo(nextStatus) 호출
+        // 2. 상태 전이 규칙은 Answer 엔티티에 위임
+
+        log.debug("Transitioning answer status: answerId={}, from={}, to={}",
+                answer.getId(), answer.getStatus(), nextStatus);
+
+        answer.transitionTo(nextStatus);
+    }
+
+    @Override
+    public void checkDuplicateAnswer(String sessionId, Long questionId)
+            throws DuplicateAnswerException {
+        // TODO: MVP V2 구현 필요
+        // 1. ANSWER_SESSION 엔티티 구현 후 활성화
+        // 2. AnswerRepository.existsBySessionIdAndQuestionId() 호출
+        // 3. 존재하면 DuplicateAnswerException 발생
+
+        log.debug("Checking duplicate answer for sessionId: {}, questionId: {}", sessionId, questionId);
+
+        // TODO: ANSWER_SESSION 엔티티 구현 후 활성화
+        // boolean exists = answerRepository.existsBySessionIdAndQuestionId(sessionId, questionId);
+        // if (exists) {
+        //     throw new DuplicateAnswerException(sessionId, questionId);
+        // }
+    }
+
+    @Override
+    public void validateAnswerContent(String answerText, String audioUrl)
+            throws InvalidAnswerContentException {
+        // TODO: 구현 필요
+        // 1. answerText와 audioUrl 중 최소 1개 필수
+        // 2. answerText가 있으면 길이 제한 검증 (1,500자)
+        // 3. 유효하지 않으면 InvalidAnswerContentException 발생
+
+        log.debug("Validating answer content: hasText={}, hasAudio={}",
+                answerText != null && !answerText.isBlank(), audioUrl != null && !audioUrl.isBlank());
+
+        boolean hasText = answerText != null && !answerText.isBlank();
+        boolean hasAudio = audioUrl != null && !audioUrl.isBlank();
+
+        if (!hasText && !hasAudio) {
+            throw new AnswerInvalidContentException();
+        }
+
+        if (hasText && answerText.length() > MAX_ANSWER_CONTENT_LENGTH) {
+            throw new AnswerInvalidContentException();
+        }
+    }
+}

--- a/src/main/java/com/ktb/answer/service/impl/ImmediateFeedbackServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/ImmediateFeedbackServiceImpl.java
@@ -1,0 +1,72 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.dto.response.AnswerSubmitResponse.ImmediateFeedback;
+import com.ktb.answer.service.ImmediateFeedbackService;
+import com.ktb.hashtag.domain.Hashtag;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImmediateFeedbackServiceImpl implements ImmediateFeedbackService {
+
+    private static final List<String> DEFAULT_KEYWORDS = List.of(
+            "프로세스", "스레드", "메모리", "CPU", "동기화"
+    );
+
+    @Override
+    public ImmediateFeedback evaluate(Long questionId, String answerText) {
+        // TODO: 구현 필요
+        // 1. questionId로 질문별 핵심 키워드 조회 (현재는 하드코딩)
+        // 2. answerText에서 키워드 포함 여부 체크
+        // 3. KeywordCheckResult 리스트 생성
+        // 4. ImmediateFeedbackResult 반환
+
+        log.debug("Evaluating immediate feedback for questionId: {}", questionId);
+
+        List<KeywordCheckResult> keywordChecks = new ArrayList<>();
+
+        for (String keyword : DEFAULT_KEYWORDS) {
+            boolean included = answerText != null && answerText.contains(keyword);
+            keywordChecks.add(new KeywordCheckResult(keyword, included));
+        }
+
+        return new ImmediateFeedback(keywordChecks);
+    }
+
+    @Override
+    public List<Hashtag> extractKeywords(Long questionId) {
+        // TODO: 구현 필요
+        // 1. questionId로 질문별 핵심 키워드 조회
+        // 2. QUESTION_HASHTAG 조인 또는 별도 키워드 테이블 조회
+        // 3. Hashtag 리스트 반환
+        // 현재는 빈 리스트 반환 (추후 Question-Hashtag 연관 구현 후 활성화)
+
+        log.debug("Extracting keywords for questionId: {}", questionId);
+        return List.of();
+    }
+
+    @Override
+    public List<KeywordCheckResult> checkKeywords(String answerText, List<Hashtag> keywords) {
+        // TODO: 구현 필요
+        // 1. answerText에서 각 keyword 포함 여부 체크
+        // 2. 대소문자 무시 또는 형태소 분석 적용 (선택)
+        // 3. KeywordCheckResult 리스트 생성 및 반환
+
+        log.debug("Checking keywords in answer text: keywordCount={}", keywords.size());
+
+        List<KeywordCheckResult> results = new ArrayList<>();
+        for (Hashtag hashtag : keywords) {
+            boolean included = answerText != null && answerText.contains(hashtag.getName());
+            results.add(new KeywordCheckResult(hashtag.getName(), included));
+        }
+
+        return results;
+    }
+}

--- a/src/main/java/com/ktb/common/domain/BaseActivatableEntity.java
+++ b/src/main/java/com/ktb/common/domain/BaseActivatableEntity.java
@@ -1,0 +1,57 @@
+package com.ktb.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseActivatableEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "use_yn", nullable = false)
+    private boolean useYn = true;
+
+    public boolean isDeleted() {
+        return deletedAt == null;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+        this.useYn = false;  // 삭제 시 자동으로 비활성화
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
+
+    public boolean isEnabled() {
+        return useYn && isDeleted();
+    }
+
+    public void enable() {
+        if (isDeleted()) {
+            this.useYn = true;
+        }
+    }
+
+    public void disable() {
+        this.useYn = false;
+    }
+}

--- a/src/main/java/com/ktb/common/exception/BusinessException.java
+++ b/src/main/java/com/ktb/common/exception/BusinessException.java
@@ -18,6 +18,11 @@ public abstract class BusinessException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    protected BusinessException(ErrorCode errorCode, String customMessage, Throwable cause) {
+        super(customMessage, cause);
+        this.errorCode = errorCode;
+    }
+
     public int getStatus() {
         return errorCode.getStatus();
     }

--- a/src/main/java/com/ktb/question/exception/QuestionDisabledException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionDisabledException.java
@@ -1,0 +1,12 @@
+package com.ktb.question.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class QuestionDisabledException extends BusinessException {
+
+    public QuestionDisabledException(Long questionId) {
+        String errMsg = String.format("%s: %d", ErrorCode.QUESTION_DISABLED.getMessage(), questionId);
+        super(ErrorCode.QUESTION_DISABLED, errMsg);
+    }
+}

--- a/src/main/java/com/ktb/question/exception/QuestionNotFoundException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionNotFoundException.java
@@ -7,6 +7,6 @@ public class QuestionNotFoundException extends BusinessException {
 
     public QuestionNotFoundException(Long questionId) {
         super(ErrorCode.QUESTION_NOT_FOUND,
-                String.format("질문을 찾을 수 없습니다: %d", questionId));
+                String.format("[%d] %s", questionId, ErrorCode.QUESTION_NOT_FOUND.getMessage()));
     }
 }


### PR DESCRIPTION
## 변경 사항
### 1. Answer 도메인 뼈대 구성
- **5개 API 엔드포인트** 구현 (스켈레톤)
  - `GET /api/v1/answers` - 답변 목록 조회 (커서 페이지네이션, 필터링)
  - `GET /api/v1/answers/{answerId}` - 답변 상세 조회 (expand 파라미터 지원)
  - `POST /api/v1/interview/answers` - 답변 제출 (연습/단일 답변)
  - `POST /api/v1/interview/sessions/{sessionId}/answers` - 세션 기반 답변 제출 (실전 모드)
  - `GET /api/v1/interviews/answers/{answerId}/feedback` - AI 피드백 조회

- **서비스 레이어** 구성
  - `AnswerApplicationService`: 오케스트레이션 (Controller ↔ Domain 중재)
  - `AnswerDomainService`: 도메인 로직 (상태 전환, 검증)
  - `ImmediateFeedbackService`: 즉각 피드백 (키워드 체크)
  - `AiFeedbackOrchestrator`: AI 피드백 파이프라인 관리 (비동기)

- **Repository**
  - 커서 기반 페이지네이션 (`created_at DESC, answer_id DESC`)
  - 필터링 쿼리 (type, category, dateFrom, dateTo)
                                                                                                                         
- **DTO**                                                                                                           
  - Request: `AnswerListRequest`, `AnswerDetailRequest`, `AnswerSubmitRequest`, `SessionAnswerSubmitRequest`
  - Response: `AnswerListResponse`, `AnswerDetailResponse`, `AnswerSubmitResponse`, `SessionAnswerSubmitResponse`, `FeedbackResponse`
  - Swagger 문서화 완료 (`@Schema`, `@Operation`)

- **Exception**
  - `AnswerNotFoundException`, `InvalidAnswerContentException`, `InvalidExpandException`
### 2. 공통 도메인
- **BaseActivatableEntity**
  - Soft Delete (`deletedAt`) + 활성화 상태 (`useYn`) 통합 관리
  - Question 도메인에서 사용 예정
### 3. 기타
- **ErrorCode enum 확장**: Answer, File 도메인 에러 코드 추가
- **협업을 위한 TODO 주석**: S3 업로드, Kafka 통합, Question-Hashtag 관계 등
  - 구현 시 삭제 필요