### PR TITLE
feat: [#50] 질문 도메인 + 질문 핵심 키워드 병합

### DIFF
--- a/src/main/java/com/ktb/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/com/ktb/hashtag/repository/HashtagRepository.java
@@ -1,0 +1,16 @@
+package com.ktb.hashtag.repository;
+
+import com.ktb.hashtag.domain.Hashtag;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    Optional<Hashtag> findByName(String name);
+
+    List<Hashtag> findByNameIn(Collection<String> names);
+}

--- a/src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
+++ b/src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
@@ -19,4 +19,14 @@ public interface QuestionHashtagRepository extends JpaRepository<QuestionHashtag
     List<String> findKeywordNamesByQuestionId(@Param("questionId") Long questionId);
 
     boolean existsByQuestion_IdAndHashtag_NameIgnoreCase(Long questionId, String name);
+
+    void deleteByQuestion_Id(Long questionId);
+
+    @Query("""
+            SELECT qh.question.id AS questionId, h.name AS keyword
+            FROM QuestionHashtag qh
+            JOIN qh.hashtag h
+            WHERE qh.question.id IN :questionIds
+            """)
+    List<QuestionKeywordRow> findKeywordRowsByQuestionIdIn(@Param("questionIds") List<Long> questionIds);
 }

--- a/src/main/java/com/ktb/hashtag/repository/QuestionKeywordRow.java
+++ b/src/main/java/com/ktb/hashtag/repository/QuestionKeywordRow.java
@@ -1,0 +1,10 @@
+package com.ktb.hashtag.repository;
+
+/**
+ * N+1 방지 목적 경량 조회 인터페이스
+ */
+public interface QuestionKeywordRow {
+    Long getQuestionId();
+
+    String getKeyword();
+}

--- a/src/main/java/com/ktb/question/dto/QuestionCreateRequest.java
+++ b/src/main/java/com/ktb/question/dto/QuestionCreateRequest.java
@@ -5,6 +5,7 @@ import com.ktb.question.domain.QuestionType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 
 public record QuestionCreateRequest(
         @NotBlank
@@ -13,6 +14,8 @@ public record QuestionCreateRequest(
         @NotNull
         QuestionType type,
         @NotNull
-        QuestionCategory category
+        QuestionCategory category,
+        @Size(max = 5)
+        List<@NotBlank @Size(max = 100) String> keywords
 ) {
 }

--- a/src/main/java/com/ktb/question/dto/QuestionDetailResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionDetailResponse.java
@@ -3,12 +3,14 @@ package com.ktb.question.dto;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record QuestionDetailResponse(
         Long questionId,
         String content,
         QuestionType type,
         QuestionCategory category,
+        List<String> keywords,
         boolean useYn,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,

--- a/src/main/java/com/ktb/question/dto/QuestionKeywordCheckRequest.java
+++ b/src/main/java/com/ktb/question/dto/QuestionKeywordCheckRequest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record QuestionKeywordCheckRequest(
         @NotEmpty
+        @Size(max = 5)
         List<@NotBlank @Size(max = 100) String> keywords
 ) {
 }

--- a/src/main/java/com/ktb/question/dto/QuestionSummaryResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionSummaryResponse.java
@@ -2,11 +2,13 @@ package com.ktb.question.dto;
 
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
+import java.util.List;
 
 public record QuestionSummaryResponse(
         Long questionId,
         String content,
         QuestionType type,
-        QuestionCategory category
+        QuestionCategory category,
+        List<String> keywords
 ) {
 }

--- a/src/main/java/com/ktb/question/dto/QuestionUpdateRequest.java
+++ b/src/main/java/com/ktb/question/dto/QuestionUpdateRequest.java
@@ -2,11 +2,16 @@ package com.ktb.question.dto;
 
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 
 public record QuestionUpdateRequest(
         String content,
         QuestionType type,
         QuestionCategory category,
-        Boolean useYn
+        Boolean useYn,
+        @Size(max = 5)
+        List<@NotBlank @Size(max = 100) String> keywords
 ) {
 }


### PR DESCRIPTION
# Summary

  - 구현 기능
      - 질문 생성/수정 시 핵심 키워드 입력 및 매핑 생성
      - 질문 목록/검색/상세 응답에 키워드 포함
      - 질문 키워드 조회 시 N+1 방지를 위한 경량 조회 추가
  - Added
      - src/main/java/com/ktb/hashtag/repository/HashtagRepository.java
      - src/main/java/com/ktb/hashtag/repository/QuestionKeywordRow.java
  - Modified
      - src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
      - src/main/java/com/ktb/question/dto/QuestionCreateRequest.java
      - src/main/java/com/ktb/question/dto/QuestionDetailResponse.java
      - src/main/java/com/ktb/question/dto/QuestionKeywordCheckRequest.java
      - src/main/java/com/ktb/question/dto/QuestionSummaryResponse.java
      - src/main/java/com/ktb/question/dto/QuestionUpdateRequest.java
      - src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
  - Deleted
      - 없음


  # Architecture / Flow

  ## 요청 흐름

  - 질문 생성 (POST /api/v1/questions)
      - QuestionServiceImpl.createQuestion
        → attachKeywords에서 HASHTAG 생성/재사용
        → QUESTION_HASHTAG 매핑 생성
  - 질문 수정 (PATCH /api/v1/questions/{questionId})
      - QuestionServiceImpl.updateQuestion
        → replaceKeywords로 기존 키워드 삭제 후 재매핑
  - 질문 목록/검색/상세
      - QuestionServiceImpl.getQuestions / search / getQuestionDetail
        → QuestionHashtagRepository.findKeywordRowsByQuestionIdIn로 키워드 일괄 조회
        → 각 응답 DTO에 키워드 포함

  ## 주요 컴포넌트 역할

  - HashtagRepository
      - 기존 키워드 재사용/신규 생성 위한 조회
  - QuestionKeywordRow
      - questionId, keyword만 조회하는 projection
      - N+1 방지용 경량 조회
  - QuestionServiceImpl
      - 키워드 생성/매핑/교체, 응답 키워드 포함 로직 담당

  # Key Points

  - 핵심 구현
      - 질문 생성/수정에서 핵심 키워드 처리
      - 질문 목록/검색/상세 응답에 키워드 포함
      - 키워드 조회를 QuestionKeywordRow로 묶어 N+1 최소화
  - 중요한 설계 판단
      - 키워드 수는 최대 5개로 제한
      - 키워드 매핑은 생성 시 중복 조회 생략
      - 수정 시 제공된 키워드로 전체 교체

  # Edge / Failure

  - 키워드가 비어 있거나 5개 초과면 요청 검증 실패 (400)
  - 질문이 없으면 QuestionNotFoundException
  - 키워드에 공백 포함 시 Hashtag 검증에서 예외 가능

  # Review Focus

  - 키워드 교체 시 기존 매핑 삭제 후 재생성 로직의 부작용 여부
  - QuestionKeywordRow 기반 키워드 일괄 조회가 의도한 N+1 방지에 충분한지