### PR TITLE
feat:[#59] STT 서비스 구현 및 onStatus 기반 에러 핸들링

### DIFF
--- a/src/main/java/com/ktb/ai/stt/client/SttClient.java
+++ b/src/main/java/com/ktb/ai/stt/client/SttClient.java
@@ -1,0 +1,106 @@
+package com.ktb.ai.stt.client;
+
+import com.ktb.ai.stt.dto.request.SttRequest;
+import com.ktb.ai.stt.dto.response.SttData;
+import com.ktb.ai.stt.exception.*;
+import com.ktb.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SttClient {
+
+    private static final int STATUS_AUDIO_TOO_LONG_OR_TOO_LARGE = 400;
+    private static final int STATUS_AUDIO_NOT_FOUND = 404;
+    private static final int STATUS_AUDIO_UNPROCESSABLE = 422;
+    private static final int STATUS_STT_TIMEOUT = 408;
+    private static final int STATUS_RATE_LIMIT_EXCEEDED = 429;
+
+    private final RestClient aiRestClient;
+
+    @Value("${ai.stt.base-url}")
+    private String baseUrl;
+
+    @Value("${ai.stt.endpoint}")
+    private String endpoint;
+
+    /**
+     * STT 변환 요청
+     *
+     * @param request STT 요청 DTO
+     * @return 변환된 텍스트
+     * @throws SttServiceException           STT 서버 호출 실패 시
+     * @throws AudioTooLongException         오디오 길이 초과
+     * @throws AudioTooLargeException        파일 크기 초과
+     * @throws AudioNotFoundException        오디오 파일 없음
+     * @throws AudioUnprocessableException   오디오 처리 불가
+     * @throws SttTimeoutException           변환 시간 초과
+     */
+    public String convert(SttRequest request) {
+        String url = baseUrl + endpoint;
+
+        log.info("Requesting STT conversion - URL: {}, userId: {}, sessionId: {}, audioUrl: {}",
+                url, request.userId(), request.sessionId(), request.audioUrl());
+
+        try {
+            ApiResponse<SttData> response = aiRestClient.post()
+                    .uri(url)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        handleClientError(res.getStatusCode().value(), request.audioUrl());
+                    })
+                    .body(new ParameterizedTypeReference<>() {
+                    });
+
+            boolean isNullResponse =
+                (response != null && response.data() != null)
+                    && response.data().text() != null;
+            String text =  isNullResponse ? response.data().text() : "";
+
+            log.info("STT conversion successful - userId: {}, sessionId: {}, textLength: {}",
+                    request.userId(), request.sessionId(), text.length());
+
+            return text;
+
+        } catch (RestClientException e) {
+            log.error("STT API call failed - URL: {}, error: {}", url, e.getMessage(), e);
+            throw new SttServiceException("STT 서버 호출 실패", e);
+        }
+    }
+
+    /**
+     * 4xx 클라이언트 에러 처리
+     *
+     * @param statusCode HTTP 상태 코드
+     * @param audioUrl   오디오 URL
+     */
+    private void handleClientError(int statusCode, String audioUrl) {
+        log.error("STT client error - statusCode: {}, audioUrl: {}", statusCode, audioUrl);
+
+        switch (statusCode) {
+            case STATUS_AUDIO_TOO_LONG_OR_TOO_LARGE:
+                throw new AudioTooLongException("오디오 길이가 최대 허용 길이(5분) 또는 파일 크기가 최대 허용 크기(25MB)를 초과했습니다");
+            case STATUS_AUDIO_NOT_FOUND:
+                throw new AudioNotFoundException(audioUrl);
+            case STATUS_STT_TIMEOUT:
+                throw new SttTimeoutException("STT 처리 시간이 초과되었습니다");
+            case STATUS_AUDIO_UNPROCESSABLE:
+                throw new AudioUnprocessableException("오디오 파일이 손상되었거나 인식할 수 없습니다");
+            case STATUS_RATE_LIMIT_EXCEEDED:
+                throw new SttServiceException("STT 요청 한도를 초과했습니다");
+            default:
+                throw new SttServiceException("STT 클라이언트 오류: " + statusCode);
+        }
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/dto/request/SttRequest.java
+++ b/src/main/java/com/ktb/ai/stt/dto/request/SttRequest.java
@@ -1,0 +1,27 @@
+package com.ktb.ai.stt.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "STT 변환 요청")
+public record SttRequest(
+
+        @JsonProperty("user_id")
+        @Schema(description = "사용자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+
+        @JsonProperty("session_id")
+        @Schema(description = "면접 세션 식별자", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long sessionId,
+
+        @JsonProperty("audio_url")
+        @Schema(description = "S3에 저장된 음성 파일 주소",
+                example = "https://qfeed-files.s3.amazonaws.com/uploads/audio/uuid.mp3",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "오디오 URL은 필수입니다")
+        String audioUrl
+) {
+}

--- a/src/main/java/com/ktb/ai/stt/dto/response/SttData.java
+++ b/src/main/java/com/ktb/ai/stt/dto/response/SttData.java
@@ -1,0 +1,14 @@
+package com.ktb.ai.stt.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "STT 변환 데이터")
+public record SttData(
+
+        @JsonProperty("text")
+        @Schema(description = "변환된 텍스트",
+                example = "RDBMS는 엄격한 스키마가 존재하고 SQL을 사용해 데이터를 관리하는 반면...")
+        String text
+) {
+}

--- a/src/main/java/com/ktb/ai/stt/exception/AudioNotFoundException.java
+++ b/src/main/java/com/ktb/ai/stt/exception/AudioNotFoundException.java
@@ -1,0 +1,18 @@
+package com.ktb.ai.stt.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AudioNotFoundException extends BusinessException {
+
+    public AudioNotFoundException() {
+        super(ErrorCode.AUDIO_NOT_FOUND, ErrorCode.AUDIO_NOT_FOUND.getMessage());
+    }
+
+    public AudioNotFoundException(String audioUrl) {
+        super(
+            ErrorCode.AUDIO_NOT_FOUND,
+            String.format("%s: %s", ErrorCode.AUDIO_NOT_FOUND.getCode(), audioUrl)
+        );
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/exception/AudioTooLargeException.java
+++ b/src/main/java/com/ktb/ai/stt/exception/AudioTooLargeException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.stt.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AudioTooLargeException extends BusinessException {
+
+    public AudioTooLargeException() {
+        super(ErrorCode.AUDIO_TOO_LARGE, ErrorCode.AUDIO_TOO_LARGE.getMessage());
+    }
+
+    public AudioTooLargeException(String message) {
+        super(ErrorCode.AUDIO_TOO_LARGE, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/exception/AudioTooLongException.java
+++ b/src/main/java/com/ktb/ai/stt/exception/AudioTooLongException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.stt.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AudioTooLongException extends BusinessException {
+
+    public AudioTooLongException() {
+        super(ErrorCode.AUDIO_TOO_LONG, ErrorCode.AUDIO_TOO_LONG.getMessage());
+    }
+
+    public AudioTooLongException(String message) {
+        super(ErrorCode.AUDIO_TOO_LONG, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/exception/AudioUnprocessableException.java
+++ b/src/main/java/com/ktb/ai/stt/exception/AudioUnprocessableException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.stt.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AudioUnprocessableException extends BusinessException {
+
+    public AudioUnprocessableException() {
+        super(ErrorCode.AUDIO_UNPROCESSABLE, ErrorCode.AUDIO_UNPROCESSABLE.getMessage());
+    }
+
+    public AudioUnprocessableException(String message) {
+        super(ErrorCode.AUDIO_UNPROCESSABLE, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/exception/SttServiceException.java
+++ b/src/main/java/com/ktb/ai/stt/exception/SttServiceException.java
@@ -1,0 +1,23 @@
+package com.ktb.ai.stt.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class SttServiceException extends BusinessException {
+
+    public SttServiceException() {
+        super(ErrorCode.STT_SERVICE_ERROR, ErrorCode.STT_SERVICE_ERROR.getMessage());
+    }
+
+    public SttServiceException(String message) {
+        super(ErrorCode.STT_SERVICE_ERROR, message);
+    }
+
+    public SttServiceException(Throwable cause) {
+        super(ErrorCode.STT_SERVICE_ERROR, ErrorCode.STT_SERVICE_ERROR.getMessage(), cause);
+    }
+
+    public SttServiceException(String message, Throwable cause) {
+        super(ErrorCode.STT_SERVICE_ERROR, message, cause);
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/exception/SttTimeoutException.java
+++ b/src/main/java/com/ktb/ai/stt/exception/SttTimeoutException.java
@@ -1,0 +1,19 @@
+package com.ktb.ai.stt.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class SttTimeoutException extends BusinessException {
+
+    public SttTimeoutException() {
+        super(ErrorCode.STT_TIMEOUT, ErrorCode.STT_TIMEOUT.getMessage());
+    }
+
+    public SttTimeoutException(String message) {
+        super(ErrorCode.STT_TIMEOUT, message);
+    }
+
+    public SttTimeoutException(Throwable cause) {
+        super(ErrorCode.STT_TIMEOUT, ErrorCode.STT_TIMEOUT.getMessage(), cause);
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/service/SttService.java
+++ b/src/main/java/com/ktb/ai/stt/service/SttService.java
@@ -1,0 +1,25 @@
+package com.ktb.ai.stt.service;
+
+/**
+ * STT 서비스 인터페이스
+ *
+ * <p>Speech-to-Text 변환 기능 제공
+ */
+public interface SttService {
+
+    /**
+     * 음성 파일 → 텍스트 변환
+     *
+     * @param userId    사용자 ID
+     * @param sessionId 세션 ID
+     * @param audioUrl  S3 오디오 파일 URL
+     * @return 변환된 텍스트
+     * @throws com.ktb.ai.stt.exception.SttServiceException           STT 서버 호출 실패 시
+     * @throws com.ktb.ai.stt.exception.AudioTooLongException         오디오 길이 초과
+     * @throws com.ktb.ai.stt.exception.AudioTooLargeException        파일 크기 초과
+     * @throws com.ktb.ai.stt.exception.AudioNotFoundException        오디오 파일 없음
+     * @throws com.ktb.ai.stt.exception.AudioUnprocessableException   오디오 처리 불가
+     * @throws com.ktb.ai.stt.exception.SttTimeoutException           변환 시간 초과
+     */
+    String convertToText(Long userId, Long sessionId, String audioUrl);
+}

--- a/src/main/java/com/ktb/ai/stt/service/impl/SttServiceImpl.java
+++ b/src/main/java/com/ktb/ai/stt/service/impl/SttServiceImpl.java
@@ -1,0 +1,31 @@
+package com.ktb.ai.stt.service.impl;
+
+import com.ktb.ai.stt.client.SttClient;
+import com.ktb.ai.stt.dto.request.SttRequest;
+import com.ktb.ai.stt.service.SttService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SttServiceImpl implements SttService {
+
+    private final SttClient sttClient;
+
+    @Override
+    public String convertToText(Long userId, Long sessionId, String audioUrl) {
+        log.debug("Converting audio to text - userId: {}, sessionId: {}, audioUrl: {}",
+                userId, sessionId, audioUrl);
+
+        SttRequest request = new SttRequest(userId, sessionId, audioUrl);
+
+        String convertedText = sttClient.convert(request);
+
+        log.info("STT conversion completed - userId: {}, sessionId: {}, textLength: {}",
+                userId, sessionId, convertedText.length());
+
+        return convertedText;
+    }
+}

--- a/src/main/java/com/ktb/common/domain/ErrorCode.java
+++ b/src/main/java/com/ktb/common/domain/ErrorCode.java
@@ -77,6 +77,15 @@ public enum ErrorCode {
     AI_FEEDBACK_LLM_SERVICE_UNAVAILABLE(422, "AI011", "LLM 서비스 연결에 실패했습니다"),
     AI_FEEDBACK_SERVICE_TEMPORARILY_UNAVAILABLE(422, "AI012", "AI 피드백 서비스를 일시적으로 사용할 수 없습니다"),
 
+    // ==================== STT 관련 ====================
+    STT_SERVICE_ERROR(422, "STT001", "STT 서비스 오류가 발생했습니다"),
+    AUDIO_TOO_LONG(400, "STT002", "오디오 길이가 최대 허용 길이를 초과했습니다"),
+    AUDIO_TOO_LARGE(400, "STT003", "오디오 파일 크기가 최대 허용 크기를 초과했습니다"),
+    AUDIO_NOT_FOUND(404, "STT004", "오디오 파일을 찾을 수 없습니다"),
+    AUDIO_UNPROCESSABLE(422, "STT005", "오디오 파일을 처리할 수 없습니다"),
+    STT_TIMEOUT(408, "STT006", "STT 변환 시간이 초과되었습니다"),
+    STT_REQUEST_FAILED(422, "STT007", "STT 요청에 실패했습니다"),
+
     // ==================== 공통 ====================
     INVALID_INPUT(400, "C001", "입력값이 올바르지 않습니다"),
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다"),


### PR DESCRIPTION
## 요약

STT(Text-to-Speech) 연동을 위한 **기본 인프라와 서비스 구조를 구축** 
`RestClient.onStatus`를 활용해 **STT 서버의 클라이언트 오류를 상태 코드별 도메인 예외로 세분화**
STT 처리 실패 원인을 명확히 구분하고 안정적인 오류 대응이 가능한 구조를 완성.

## 변경사항

### 1. STT 서비스 인프라 구성

- `SttService` 인터페이스 정의
    - 메서드: `convertToText`
- `SttServiceImpl` 구현
    - STT Client 호출
    - 요청/응답 로깅 처리

### 2. STT 요청/응답 DTO 추가

- `SttRequest`
- `SttApiResponse`

---

### 3. HTTP 클라이언트 구현 (`onStatus` 적용)

- `SttClient`
    - `RestClient` 기반 POST 요청 구현
- `onStatus(HttpStatusCode::is4xxClientError)` 적용
    - 400 / 404 / 408 / 422 / 429 상태 코드 처리
- `handleClientError()` 헬퍼 메서드 추가
    - `switch` 문을 통한 상태 코드별 예외 분기

### 4. STT 도메인 예외 클래스 추가 (총 6개)

- **400 에러**
    - `AudioTooLongException` (STT002)
        - 오디오 길이 초과 (5분)
    - `AudioTooLargeException` (STT003)
        - 파일 크기 초과 (25MB)
- **404**
    - `AudioNotFoundException` (STT004)
        - 오디오 파일 없음
- **408**
    - `SttTimeoutException` (STT006)
        - STT 처리 시간 초과
- **422**
    - `AudioUnprocessableException` (STT005)
        - 오디오 처리 불가
- **기본 예외**
    - `SttServiceException` (STT001)
        - STT 서비스 일반 오류

---

### 5. ErrorCode 확장

- STT 도메인 전용 에러 코드 추가
    - `STT001` ~ `STT007` (총 7개)

---

### 6. 하드코딩 제거 및 상수화

- 상태 코드/메시지 관련 상수 정의
    - `STATUS_AUDIO_TOO_LONG_OR_TOO_LARGE`
    - `STATUS_AUDIO_NOT_FOUND`
    - `STATUS_AUDIO_UNPROCESSABLE`
    - `STATUS_STT_TIMEOUT`
    - `STATUS_RATE_LIMIT_EXCEEDED`
    
## 관련 이슈
 - #59