### PR TITLE
feat: [#46] 평가지표 API 구현

### DIFF
--- a/src/main/java/com/ktb/common/domain/ErrorCode.java
+++ b/src/main/java/com/ktb/common/domain/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     METRIC_NAME_REQUIRED(400, "M001", "평가 지표 이름은 필수입니다"),
     METRIC_NAME_TOO_LONG(400, "M002", "평가 지표 이름은 100자를 초과할 수 없습니다"),
     METRIC_SCORE_INVALID_RANGE(400, "M003", "평가 점수는 0-100 사이여야 합니다"),
+    METRIC_NOT_FOUND(404, "M004", "평가 지표를 찾을 수 없습니다"),
 
     // ==================== Search 관련 ====================
     SEARCH_KEYWORD_TOO_SHORT(400, "S001", "검색어는 너무 짧습니다"),

--- a/src/main/java/com/ktb/metric/controller/MetricController.java
+++ b/src/main/java/com/ktb/metric/controller/MetricController.java
@@ -1,0 +1,97 @@
+package com.ktb.metric.controller;
+
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.metric.dto.MetricCreateRequest;
+import com.ktb.metric.dto.MetricDetailResponse;
+import com.ktb.metric.dto.MetricListResponse;
+import com.ktb.metric.dto.MetricUpdateRequest;
+import com.ktb.metric.service.MetricService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/metrics")
+@RequiredArgsConstructor
+@Validated
+public class MetricController {
+
+    private final MetricService metricService;
+
+    private static final String MESSAGE_METRIC_LIST_RETRIEVED = "metrics_retrieval_success";
+    private static final String MESSAGE_METRIC_DETAIL_RETRIEVED = "metric_retrieval_success";
+    private static final String MESSAGE_METRIC_CREATED = "metric_created_success";
+    private static final String MESSAGE_METRIC_UPDATED = "metric_updated_success";
+    private static final String MESSAGE_METRIC_DELETED = "metric_deleted_success";
+
+    /**
+     * 평가 지표 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<MetricListResponse>> getMetrics(
+            @RequestParam(required = false) Boolean useYn,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+    ) {
+        MetricListResponse result = metricService.getMetrics(useYn, cursor, size);
+        return ResponseEntity.ok(new ApiResponse<>(MESSAGE_METRIC_LIST_RETRIEVED, result));
+    }
+
+    /**
+     * 평가 지표 상세 조회
+     */
+    @GetMapping("/{metricId}")
+    public ResponseEntity<ApiResponse<MetricDetailResponse>> getMetric(
+            @PathVariable Long metricId
+    ) {
+        MetricDetailResponse result = metricService.getMetric(metricId);
+        return ResponseEntity.ok(new ApiResponse<>(MESSAGE_METRIC_DETAIL_RETRIEVED, result));
+    }
+
+    /**
+     * 평가 지표 생성
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<MetricDetailResponse>> createMetric(
+            @Valid @RequestBody MetricCreateRequest request
+    ) {
+        MetricDetailResponse result = metricService.createMetric(request);
+        return ResponseEntity.status(201)
+                .body(new ApiResponse<>(MESSAGE_METRIC_CREATED, result));
+    }
+
+    /**
+     * 평가 지표 수정
+     */
+    @PatchMapping("/{metricId}")
+    public ResponseEntity<ApiResponse<MetricDetailResponse>> updateMetric(
+            @PathVariable Long metricId,
+            @Valid @RequestBody MetricUpdateRequest request
+    ) {
+        MetricDetailResponse result = metricService.updateMetric(metricId, request);
+        return ResponseEntity.ok(new ApiResponse<>(MESSAGE_METRIC_UPDATED, result));
+    }
+
+    /**
+     * 평가 지표 삭제 (비활성화)
+     */
+    @DeleteMapping("/{metricId}")
+    public ResponseEntity<ApiResponse<Void>> deleteMetric(
+            @PathVariable Long metricId
+    ) {
+        metricService.deleteMetric(metricId);
+        return ResponseEntity.ok(new ApiResponse<>(MESSAGE_METRIC_DELETED, null));
+    }
+}

--- a/src/main/java/com/ktb/metric/domain/Metric.java
+++ b/src/main/java/com/ktb/metric/domain/Metric.java
@@ -60,6 +60,11 @@ public class Metric extends BaseUsableEntity {
         this.description = description;
     }
 
+    public void updateName(String name) {
+        validateName(name);
+        this.name = name;
+    }
+
     private void validateName(String name) {
         if (name == null || name.trim().isEmpty()) {
             throw new MetricRequiredNameException();

--- a/src/main/java/com/ktb/metric/dto/MetricCreateRequest.java
+++ b/src/main/java/com/ktb/metric/dto/MetricCreateRequest.java
@@ -1,0 +1,13 @@
+package com.ktb.metric.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MetricCreateRequest(
+        @NotBlank
+        @Size(max = 30)
+        String name,
+        @Size(max = 255)
+        String description
+) {
+}

--- a/src/main/java/com/ktb/metric/dto/MetricDetailResponse.java
+++ b/src/main/java/com/ktb/metric/dto/MetricDetailResponse.java
@@ -1,0 +1,13 @@
+package com.ktb.metric.dto;
+
+import java.time.LocalDateTime;
+
+public record MetricDetailResponse(
+        Long metricId,
+        String name,
+        String description,
+        boolean useYn,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/ktb/metric/dto/MetricListResponse.java
+++ b/src/main/java/com/ktb/metric/dto/MetricListResponse.java
@@ -1,0 +1,9 @@
+package com.ktb.metric.dto;
+
+import java.util.List;
+
+public record MetricListResponse(
+        List<MetricSummaryResponse> metrics,
+        MetricPaginationResponse pagination
+) {
+}

--- a/src/main/java/com/ktb/metric/dto/MetricPaginationResponse.java
+++ b/src/main/java/com/ktb/metric/dto/MetricPaginationResponse.java
@@ -1,0 +1,8 @@
+package com.ktb.metric.dto;
+
+public record MetricPaginationResponse(
+        Long nextCursor,
+        boolean hasNext,
+        int size
+) {
+}

--- a/src/main/java/com/ktb/metric/dto/MetricSummaryResponse.java
+++ b/src/main/java/com/ktb/metric/dto/MetricSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.ktb.metric.dto;
+
+public record MetricSummaryResponse(
+        Long metricId,
+        String name,
+        String description,
+        boolean useYn
+) {
+}

--- a/src/main/java/com/ktb/metric/dto/MetricUpdateRequest.java
+++ b/src/main/java/com/ktb/metric/dto/MetricUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.ktb.metric.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record MetricUpdateRequest(
+        @Size(max = 30)
+        String name,
+        @Size(max = 255)
+        String description,
+        Boolean useYn
+) {
+}

--- a/src/main/java/com/ktb/metric/exception/MetricNotFoundException.java
+++ b/src/main/java/com/ktb/metric/exception/MetricNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ktb.metric.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class MetricNotFoundException extends BusinessException {
+    public MetricNotFoundException(Long metricId) {
+        super(ErrorCode.METRIC_NOT_FOUND,
+                String.format("%s id=%d", ErrorCode.METRIC_NOT_FOUND.getMessage(), metricId));
+    }
+}

--- a/src/main/java/com/ktb/metric/repository/MetricRepository.java
+++ b/src/main/java/com/ktb/metric/repository/MetricRepository.java
@@ -1,0 +1,14 @@
+package com.ktb.metric.repository;
+
+import com.ktb.metric.domain.Metric;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MetricRepository extends JpaRepository<Metric, Long> {
+    Slice<Metric> findByUseYn(boolean useYn, Pageable pageable);
+
+    Slice<Metric> findByIdLessThan(Long cursor, Pageable pageable);
+
+    Slice<Metric> findByUseYnAndIdLessThan(boolean useYn, Long cursor, Pageable pageable);
+}

--- a/src/main/java/com/ktb/metric/service/MetricService.java
+++ b/src/main/java/com/ktb/metric/service/MetricService.java
@@ -1,0 +1,18 @@
+package com.ktb.metric.service;
+
+import com.ktb.metric.dto.MetricCreateRequest;
+import com.ktb.metric.dto.MetricDetailResponse;
+import com.ktb.metric.dto.MetricListResponse;
+import com.ktb.metric.dto.MetricUpdateRequest;
+
+public interface MetricService {
+    MetricListResponse getMetrics(Boolean useYn, Long cursor, int size);
+
+    MetricDetailResponse getMetric(Long metricId);
+
+    MetricDetailResponse createMetric(MetricCreateRequest request);
+
+    MetricDetailResponse updateMetric(Long metricId, MetricUpdateRequest request);
+
+    void deleteMetric(Long metricId);
+}

--- a/src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
+++ b/src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
@@ -1,0 +1,125 @@
+package com.ktb.metric.service.impl;
+
+import com.ktb.metric.domain.Metric;
+import com.ktb.metric.dto.MetricCreateRequest;
+import com.ktb.metric.dto.MetricDetailResponse;
+import com.ktb.metric.dto.MetricListResponse;
+import com.ktb.metric.dto.MetricPaginationResponse;
+import com.ktb.metric.dto.MetricSummaryResponse;
+import com.ktb.metric.dto.MetricUpdateRequest;
+import com.ktb.metric.exception.MetricNotFoundException;
+import com.ktb.metric.repository.MetricRepository;
+import com.ktb.metric.service.MetricService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MetricServiceImpl implements MetricService {
+
+    private final MetricRepository metricRepository;
+
+    @Override
+    public MetricListResponse getMetrics(Boolean useYn, Long cursor, int size) {
+        PageRequest pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
+        Slice<Metric> metrics = findMetrics(useYn, cursor, pageable);
+        return new MetricListResponse(
+                metrics.getContent().stream()
+                        .map(this::toSummaryResponse)
+                        .toList(),
+                toPaginationResponse(metrics)
+        );
+    }
+
+    @Override
+    public MetricDetailResponse getMetric(Long metricId) {
+        Metric metric = metricRepository.findById(metricId)
+                .orElseThrow(() -> new MetricNotFoundException(metricId));
+        return toDetailResponse(metric);
+    }
+
+    @Override
+    @Transactional
+    public MetricDetailResponse createMetric(MetricCreateRequest request) {
+        Metric metric = Metric.create(request.name(), request.description());
+        Metric saved = metricRepository.save(metric);
+        return toDetailResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public MetricDetailResponse updateMetric(Long metricId, MetricUpdateRequest request) {
+        Metric metric = metricRepository.findById(metricId)
+                .orElseThrow(() -> new MetricNotFoundException(metricId));
+
+        if (request.name() != null) {
+            metric.updateName(request.name());
+        }
+        if (request.description() != null) {
+            metric.updateDescription(request.description());
+        }
+        if (request.useYn() != null) {
+            if (request.useYn()) {
+                metric.enable();
+            } else {
+                metric.disable();
+            }
+        }
+
+        return toDetailResponse(metric);
+    }
+
+    @Override
+    @Transactional
+    public void deleteMetric(Long metricId) {
+        Metric metric = metricRepository.findById(metricId)
+                .orElseThrow(() -> new MetricNotFoundException(metricId));
+        metric.disable();
+    }
+
+    private MetricSummaryResponse toSummaryResponse(Metric metric) {
+        return new MetricSummaryResponse(
+                metric.getId(),
+                metric.getName(),
+                metric.getDescription(),
+                metric.isUseYn()
+        );
+    }
+
+    private MetricDetailResponse toDetailResponse(Metric metric) {
+        return new MetricDetailResponse(
+                metric.getId(),
+                metric.getName(),
+                metric.getDescription(),
+                metric.isUseYn(),
+                metric.getCreatedAt(),
+                metric.getUpdatedAt()
+        );
+    }
+
+    private MetricPaginationResponse toPaginationResponse(Slice<Metric> slice) {
+        Long nextCursor = null;
+        if (!slice.getContent().isEmpty()) {
+            Metric last = slice.getContent().get(slice.getContent().size() - 1);
+            nextCursor = slice.hasNext() ? last.getId() : null;
+        }
+        return new MetricPaginationResponse(nextCursor, slice.hasNext(), slice.getSize());
+    }
+
+    private Slice<Metric> findMetrics(Boolean useYn, Long cursor, PageRequest pageable) {
+        if (cursor == null) {
+            return (useYn == null)
+                    ? metricRepository.findAll(pageable)
+                    : metricRepository.findByUseYn(useYn, pageable);
+        }
+        return (useYn == null)
+                ? metricRepository.findByIdLessThan(cursor, pageable)
+                : metricRepository.findByUseYnAndIdLessThan(useYn, cursor, pageable);
+    }
+}


### PR DESCRIPTION
# Summary

  - 구현 기능
      - 평가 지표(Metric) CRUD API 추가
      - 목록 조회 커서 페이지네이션(기준: metricId DESC) + useYn 필터
      - 평가 지표 비활성화(soft delete) 처리
  - Added
      - src/main/java/com/ktb/metric/controller/MetricController.java
      - src/main/java/com/ktb/metric/service/MetricService.java
      - src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
      - src/main/java/com/ktb/metric/repository/MetricRepository.java
      - src/main/java/com/ktb/metric/dto/MetricCreateRequest.java
      - src/main/java/com/ktb/metric/dto/MetricUpdateRequest.java
      - src/main/java/com/ktb/metric/dto/MetricDetailResponse.java
      - src/main/java/com/ktb/metric/dto/MetricSummaryResponse.java
      - src/main/java/com/ktb/metric/dto/MetricListResponse.java
      - src/main/java/com/ktb/metric/dto/MetricPaginationResponse.java
      - src/main/java/com/ktb/metric/exception/MetricNotFoundException.java
  - Modified
      - src/main/java/com/ktb/metric/domain/Metric.java
      - src/main/java/com/ktb/common/domain/ErrorCode.java
      - src/main/java/com/ktb/metric/controller/MetricController.java
      - src/main/java/com/ktb/metric/service/MetricService.java
      - src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
      - src/main/java/com/ktb/metric/repository/MetricRepository.java
      - src/main/java/com/ktb/metric/dto/MetricListResponse.java
  - Deleted
      - 없음

  # Architecture / Flow

  ## 요청 흐름

  - 평가 지표 목록 조회 (GET /api/v1/metrics)
      - MetricController.getMetrics
        → MetricServiceImpl.getMetrics
        → MetricRepository.findByUseYnWithCursor
        → 커서 기반 pagination 반환
  - 평가 지표 상세 조회 (GET /api/v1/metrics/{metricId})
      - MetricServiceImpl.getMetric
        → MetricNotFoundException 처리
  - 평가 지표 생성/수정/삭제
      - 생성: Metric.create
      - 수정: Metric.updateName/updateDescription + useYn 토글
      - 삭제: useYn=false(비활성화)

  ## 주요 컴포넌트 역할

  - MetricController
      - API 요청/응답, 공통 메시지 상수화
  - MetricServiceImpl
      - CRUD 로직 + 커서 pagination 계산
  - MetricRepository
      - useYn 필터 + cursor 기반 조회
  - Metric
      - 이름 검증 로직, 업데이트 메서드 제공

  # Key Points

  - 핵심 구현
      - Metric CRUD + 커서 페이지네이션
      - soft delete(비활성화) 정책
  - 중요한 설계 판단
      - 목록 정렬/커서 기준: metricId DESC
      - 삭제는 물리 삭제가 아닌 useYn=false

  # Edge / Failure

  - 이름이 비거나 100자 초과 시 400
  - metricId 미존재 시 404 (METRIC_NOT_FOUND)
  - 삭제는 useYn=false 처리로만 반영

  # Review Focus

  - 커서 pagination이 metricId DESC 기준으로 정상 동작하는지
  - 삭제가 비활성화로 처리되는 정책이 의도와 일치하는지
  - name 수정 시 도메인 검증 로직 적용 여부