### PR TITLE
test: [#63] 면접 질문 도메인 단위 테스트 코드 작성

### DIFF
--- a/src/main/java/com/ktb/common/domain/ErrorCode.java
+++ b/src/main/java/com/ktb/common/domain/ErrorCode.java
@@ -31,6 +31,12 @@ public enum ErrorCode {
     QUESTION_DISABLED(400, "Q002", "비활성화된 질문입니다"),
     QUESTION_ALREADY_DELETED(400, "Q003", "이미 삭제된 질문입니다"),
     QUESTION_INVALID_CONTENT(400, "Q004", "질문 내용이 올바르지 않습니다"),
+    QUESTION_TYPE_REQUIRED(400, "Q005", "질문 유형은 필수입니다"),
+    QUESTION_CATEGORY_REQUIRED(400, "Q006", "질문 카테고리는 필수입니다"),
+    QUESTION_CONTENT_REQUIRED(400, "Q007", "질문 내용은 필수입니다"),
+    QUESTION_CONTENT_HAS_SPACES(400, "Q008", "질문 내용은 앞뒤 공백을 포함할 수 없습니다"),
+    QUESTION_CONTENT_TOO_SHORT(400, "Q009", "질문 내용은 2자 이상이어야 합니다"),
+    QUESTION_CONTENT_TOO_LONG(400, "Q010", "질문 내용은 200자를 초과할 수 없습니다"),
 
     // ==================== Answer 관련 ====================
     ANSWER_NOT_FOUND(404, "A001", "답변을 찾을 수 없습니다"),

--- a/src/main/java/com/ktb/question/exception/QuestionInvalidContentException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionInvalidContentException.java
@@ -5,7 +5,7 @@ import com.ktb.common.exception.BusinessException;
 
 public class QuestionInvalidContentException extends BusinessException {
 
-    public QuestionInvalidContentException(String detail) {
-        super(ErrorCode.QUESTION_INVALID_CONTENT, detail);
+    public QuestionInvalidContentException(ErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/com/ktb/question/exception/QuestionRequiredCategoryException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionRequiredCategoryException.java
@@ -1,0 +1,10 @@
+package com.ktb.question.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class QuestionRequiredCategoryException extends BusinessException {
+    public QuestionRequiredCategoryException() {
+        super(ErrorCode.QUESTION_CATEGORY_REQUIRED);
+    }
+}

--- a/src/main/java/com/ktb/question/exception/QuestionRequiredTypeException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionRequiredTypeException.java
@@ -1,0 +1,10 @@
+package com.ktb.question.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class QuestionRequiredTypeException extends BusinessException {
+    public QuestionRequiredTypeException() {
+        super(ErrorCode.QUESTION_TYPE_REQUIRED);
+    }
+}

--- a/src/test/java/com/ktb/fixture/QuestionFixture.java
+++ b/src/test/java/com/ktb/fixture/QuestionFixture.java
@@ -1,0 +1,66 @@
+package com.ktb.fixture;
+
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+
+public class QuestionFixture {
+
+    private static final String DEFAULT_CONTENT = "프로세스와 스레드의 차이를 설명해주세요.";
+    private static final QuestionType DEFAULT_TYPE = QuestionType.CS;
+    private static final QuestionCategory DEFAULT_CATEGORY = QuestionCategory.OS;
+    private static final int MAX_CONTENT_LENGTH = 200;
+    private static final int MIN_CONTENT_LENGTH = 2;
+
+    public static Question createQuestion() {
+        return Question.create(DEFAULT_CONTENT, DEFAULT_TYPE, DEFAULT_CATEGORY);
+    }
+
+    public static Question createQuestion(String content) {
+        return Question.create(content, DEFAULT_TYPE, DEFAULT_CATEGORY);
+    }
+
+    public static Question createQuestion(QuestionType type) {
+        return Question.create(DEFAULT_CONTENT, type, DEFAULT_CATEGORY);
+    }
+
+    public static Question createQuestion(QuestionCategory category) {
+        return Question.create(DEFAULT_CONTENT, DEFAULT_TYPE, category);
+    }
+
+    public static String createContentWithMaxLength() {
+        return "A".repeat(MAX_CONTENT_LENGTH);
+    }
+
+    public static String createContentWithMinLength() {
+        return "A".repeat(MIN_CONTENT_LENGTH);
+    }
+
+    public static String createContentExceedingMaxLength() {
+        return "A".repeat(MAX_CONTENT_LENGTH + 1);
+    }
+
+    public static String createNullContent() {
+        return null;
+    }
+
+    public static String createEmptyContent() {
+        return "";
+    }
+
+    public static String createBlankContent() {
+        return "   ";
+    }
+
+    public static Question createDisabledQuestion() {
+        Question question = createQuestion();
+        question.disable();
+        return question;
+    }
+
+    public static Question createSoftDeletedQuestion() {
+        Question question = createQuestion();
+        question.delete();
+        return question;
+    }
+}

--- a/src/test/java/com/ktb/question/domain/QuestionTest.java
+++ b/src/test/java/com/ktb/question/domain/QuestionTest.java
@@ -1,0 +1,423 @@
+package com.ktb.question.domain;
+
+import com.ktb.fixture.QuestionFixture;
+import com.ktb.question.exception.QuestionAlreadyDeletedException;
+import com.ktb.question.exception.QuestionInvalidContentException;
+import com.ktb.question.exception.QuestionRequiredCategoryException;
+import com.ktb.question.exception.QuestionRequiredTypeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Question 도메인 테스트")
+class QuestionTest {
+
+    @Nested
+    @DisplayName("Question 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 값으로 Question 생성 성공")
+        void create_WithValidData_ShouldSucceed() {
+            // Given
+            String content = "프로세스와 스레드의 차이를 설명해주세요.";
+            QuestionType type = QuestionType.CS;
+            QuestionCategory category = QuestionCategory.OS;
+
+            // When
+            Question question = Question.create(content, type, category);
+
+            // Then
+            assertThat(question).isNotNull();
+            assertThat(question.getContent()).isEqualTo(content);
+            assertThat(question.getType()).isEqualTo(type);
+            assertThat(question.getCategory()).isEqualTo(category);
+        }
+
+        @Test
+        @DisplayName("질문 유형이 null이면 QuestionRequiredTypeException 발생")
+        void create_WithNullType_ShouldThrowException() {
+            // Given
+            String content = QuestionFixture.createContentWithMinLength();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(content, null, QuestionCategory.OS))
+                    .isInstanceOf(QuestionRequiredTypeException.class);
+        }
+
+        @Test
+        @DisplayName("질문 카테고리가 null이면 QuestionRequiredCategoryException 발생")
+        void create_WithNullCategory_ShouldThrowException() {
+            // Given
+            String content = QuestionFixture.createContentWithMinLength();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(content, QuestionType.CS, null))
+                    .isInstanceOf(QuestionRequiredCategoryException.class);
+        }
+
+        @Test
+        @DisplayName("null 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithNullContent_ShouldThrowException() {
+            // Given
+            String nullContent = QuestionFixture.createNullContent();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(nullContent, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithEmptyContent_ShouldThrowException() {
+            // Given
+            String emptyContent = QuestionFixture.createEmptyContent();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(emptyContent, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("공백만 있는 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithOnlySpaces_ShouldThrowException() {
+            // Given
+            String blankContent = QuestionFixture.createBlankContent();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(blankContent, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("200자 내용으로 생성 성공")
+        void create_WithMaxLength_ShouldSucceed() {
+            // Given
+            String content = QuestionFixture.createContentWithMaxLength();
+
+            // When
+            Question question = Question.create(content, QuestionType.CS, QuestionCategory.OS);
+
+            // Then
+            assertThat(question.getContent()).hasSize(200);
+        }
+
+        @Test
+        @DisplayName("2자 내용으로 생성 성공")
+        void create_WithMinLength_ShouldSucceed() {
+            // Given
+            String content = QuestionFixture.createContentWithMinLength();
+
+            // When
+            Question question = Question.create(content, QuestionType.CS, QuestionCategory.OS);
+
+            // Then
+            assertThat(question.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("1자 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithBelowMinLength_ShouldThrowException() {
+            // Given
+            String content = "A";
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(content, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("201자 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithExceedingMaxLength_ShouldThrowException() {
+            // Given
+            String content = QuestionFixture.createContentExceedingMaxLength();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(content, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("앞 공백이 포함된 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithLeadingSpaces_ShouldThrowException() {
+            // Given
+            String content = "  질문 내용";
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(content, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("뒤 공백이 포함된 내용으로 생성 시 QuestionInvalidContentException 발생")
+        void create_WithTrailingSpaces_ShouldThrowException() {
+            // Given
+            String content = "질문 내용  ";
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(content, QuestionType.CS, QuestionCategory.OS))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Question 업데이트 테스트")
+    class UpdateTest {
+
+        @Test
+        @DisplayName("내용 업데이트 성공")
+        void updateContent_WithValidContent_ShouldSucceed() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String newContent = "새로운 질문 내용입니다.";
+
+            // When
+            question.updateContent(newContent);
+
+            // Then
+            assertThat(question.getContent()).isEqualTo(newContent);
+        }
+
+        @Test
+        @DisplayName("200자 내용으로 업데이트 성공")
+        void updateContent_WithMaxLength_ShouldSucceed() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = QuestionFixture.createContentWithMaxLength();
+
+            // When
+            question.updateContent(content);
+
+            // Then
+            assertThat(question.getContent()).hasSize(200);
+        }
+
+        @Test
+        @DisplayName("2자 내용으로 업데이트 성공")
+        void updateContent_WithMinLength_ShouldSucceed() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = QuestionFixture.createContentWithMinLength();
+
+            // When
+            question.updateContent(content);
+
+            // Then
+            assertThat(question.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("1자 내용으로 업데이트 시 QuestionInvalidContentException 발생")
+        void updateContent_WithBelowMinLength_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = "A";
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("201자 내용으로 업데이트 시 QuestionInvalidContentException 발생")
+        void updateContent_WithExceedingMaxLength_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = QuestionFixture.createContentExceedingMaxLength();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("null 내용으로 업데이트 시 QuestionInvalidContentException 발생")
+        void updateContent_WithNullContent_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = QuestionFixture.createNullContent();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("공백 내용으로 업데이트 시 QuestionInvalidContentException 발생")
+        void updateContent_WithBlankContent_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = QuestionFixture.createBlankContent();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("앞 공백이 포함된 내용으로 업데이트 시 QuestionInvalidContentException 발생")
+        void updateContent_WithLeadingSpaces_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = "  질문 내용";
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("뒤 공백이 포함된 내용으로 업데이트 시 QuestionInvalidContentException 발생")
+        void updateContent_WithTrailingSpaces_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+            String content = "질문 내용  ";
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("질문 유형 업데이트 성공")
+        void updateType_WithValidType_ShouldSucceed() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+
+            // When
+            question.updateType(QuestionType.SYSTEM_DESIGN);
+
+            // Then
+            assertThat(question.getType()).isEqualTo(QuestionType.SYSTEM_DESIGN);
+        }
+
+        @Test
+        @DisplayName("질문 유형이 null이면 QuestionRequiredTypeException 발생")
+        void updateType_WithNull_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateType(null))
+                    .isInstanceOf(QuestionRequiredTypeException.class);
+        }
+
+        @Test
+        @DisplayName("soft delete 처리된 질문은 유형 업데이트 불가")
+        void updateType_WhenSoftDeleted_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createSoftDeletedQuestion();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateType(QuestionType.SYSTEM_DESIGN))
+                    .isInstanceOf(QuestionAlreadyDeletedException.class);
+        }
+
+        @Test
+        @DisplayName("질문 카테고리 업데이트 성공")
+        void updateCategory_WithValidCategory_ShouldSucceed() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+
+            // When
+            question.updateCategory(QuestionCategory.NETWORK);
+
+            // Then
+            assertThat(question.getCategory()).isEqualTo(QuestionCategory.NETWORK);
+        }
+
+        @Test
+        @DisplayName("질문 카테고리가 null이면 QuestionRequiredCategoryException 발생")
+        void updateCategory_WithNull_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateCategory(null))
+                    .isInstanceOf(QuestionRequiredCategoryException.class);
+        }
+
+        @Test
+        @DisplayName("soft delete 처리된 질문은 카테고리 업데이트 불가")
+        void updateCategory_WhenSoftDeleted_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createSoftDeletedQuestion();
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateCategory(QuestionCategory.NETWORK))
+                    .isInstanceOf(QuestionAlreadyDeletedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Question 삭제/활성화 테스트")
+    class StateTest {
+
+        @Test
+        @DisplayName("활성 상태에서 삭제 시 soft delete 처리")
+        void delete_WhenEnabled_ShouldSoftDelete() {
+            // Given
+            Question question = QuestionFixture.createQuestion();
+
+            // When
+            question.delete();
+
+            // Then
+            assertThat(question.isUseYn()).isFalse();
+            assertThat(question.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("soft delete 처리된 질문을 다시 삭제하면 QuestionAlreadyDeletedException 발생")
+        void delete_WhenAlreadySoftDeleted_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createSoftDeletedQuestion();
+
+            // When & Then
+            assertThatThrownBy(question::delete)
+                    .isInstanceOf(QuestionAlreadyDeletedException.class);
+        }
+
+        @Test
+        @DisplayName("비활성 상태에서 activate 호출 시 활성화")
+        void activate_WhenDisabled_ShouldEnable() {
+            // Given
+            Question question = QuestionFixture.createDisabledQuestion();
+
+            // When
+            question.activate();
+
+            // Then
+            assertThat(question.isUseYn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("soft delete 처리된 질문은 activate 호출해도 활성화되지 않음")
+        void activate_WhenSoftDeleted_ShouldRemainDisabled() {
+            // Given
+            Question question = QuestionFixture.createSoftDeletedQuestion();
+
+            // When
+            question.activate();
+
+            // Then
+            assertThat(question.isUseYn()).isFalse();
+            assertThat(question.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("soft delete 처리된 질문은 내용 업데이트 불가")
+        void updateContent_WhenSoftDeleted_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createSoftDeletedQuestion();
+            String content = "새로운 질문 내용입니다.";
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateContent(content))
+                    .isInstanceOf(QuestionAlreadyDeletedException.class);
+        }
+    }
+}


### PR DESCRIPTION
# Summary #63 

  - 구현 기능
      - Question 도메인 검증 강화: content 최소 길이(2자) + 앞/뒤 공백 금지
      - type/category null 금지 및 도메인 예외 추가
      - soft delete 된 엔티티는 수정/활성화 불가하도록 가드 추가
      - Question 도메인 단위 테스트 및 Fixture 추가/보강
  - Added
      - src/test/java/com/ktb/fixture/QuestionFixture.java
      - src/test/java/com/ktb/question/domain/QuestionTest.java
      - src/main/java/com/ktb/question/exception/QuestionRequiredTypeException.java
      - src/main/java/com/ktb/question/exception/QuestionRequiredCategoryException.java
  - Modified
      - src/main/java/com/ktb/question/domain/Question.java
      - src/main/java/com/ktb/common/domain/ErrorCode.java
  - Deleted
      - 없음

  # Architecture / Flow

  ## 요청 흐름

  - Question 생성/수정
      - Question.create, updateContent, updateType, updateCategory
        → content/type/category 검증
        → soft delete 상태면 변경 차단
  - Question 삭제
      - Question.delete
        → 이미 삭제된 경우 예외
        → 활성 상태는 soft delete 처리

  ## 주요 컴포넌트 역할

  - Question
      - content 최소 길이(2자), 앞/뒤 공백 금지, 200자 이하
      - type/category 필수 검증
      - soft delete 후 변경 차단
  - QuestionFixture
      - 테스트 Given 단순화
  - QuestionTest
      - 도메인 정책/경계값 테스트 문서화

  # Key Points

  - 핵심 구현
      - content 정책: 2자 이상, 앞/뒤 공백 금지, 200자 이하
      - type/category null 불가
      - soft delete된 엔티티는 변경/활성화 불가
  - 중요한 설계 판단
      - 내용 검증은 단일 예외(QuestionInvalidContentException)로 메시지로 구분
      - 삭제 정책은 “활성 상태 삭제 성공 / 이미 삭제된 경우 예외”로 정리

  # Test Coverage (Detailed)

  ## 생성(Create)

  - 정상 생성: content/type/category 유효
  - content null → QuestionInvalidContentException
  - content 빈 문자열/공백만 → QuestionInvalidContentException
  - content 2자(min) → 성공
  - content 1자(min-1) → QuestionInvalidContentException
  - content 200자(max) → 성공
  - content 201자(max+1) → QuestionInvalidContentException
  - content 앞/뒤 공백 포함 → QuestionInvalidContentException
  - type null → QuestionRequiredTypeException
  - category null → QuestionRequiredCategoryException

  ## 수정(Update)

  - content 정상 업데이트 → 성공
  - content 2자(min) → 성공
  - content 1자(min-1) → QuestionInvalidContentException
  - content 200자(max) → 성공
  - content 201자(max+1) → QuestionInvalidContentException
  - content null/blank → QuestionInvalidContentException
  - content 앞/뒤 공백 포함 → QuestionInvalidContentException
  - type 업데이트 → 성공
  - type null → QuestionRequiredTypeException
  - category 업데이트 → 성공
  - category null → QuestionRequiredCategoryException
  - soft delete 상태에서 content/type/category 업데이트 → QuestionAlreadyDeletedException

  ## 삭제(Delete) / 상태

  - 활성 상태에서 delete → soft delete 처리
  - soft delete 상태에서 delete 재호출 → QuestionAlreadyDeletedException
  - soft delete 상태에서 activate → 비활성 상태 유지 (deletedAt 유지)

  # Edge / Failure

  - content < 2, 앞/뒤 공백 포함, 200자 초과 → QuestionInvalidContentException
  - type/category null → QuestionRequiredTypeException, QuestionRequiredCategoryException
  - soft delete 후 update/activate/delete 시도 → QuestionAlreadyDeletedException

  # Review Focus

  - content 공백 정책이 서비스/도메인 책임 분리에 맞는지
  - soft delete 가드가 모든 변경 경로에 적용됐는지
  - 예외 코드(Q005/Q006) 추가가 전체 에러 규칙과 충돌 없는지