### PR TITLE
feat: [#68] API URL 내 'V1'제거

### DIFF
--- a/src/main/java/com/ktb/answer/controller/AnswerController.java
+++ b/src/main/java/com/ktb/answer/controller/AnswerController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Answer API", description = "답변 관리 API")
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Slf4j
 public class AnswerController {
@@ -67,7 +67,7 @@ public class AnswerController {
         // 4. Result를 Response DTO로 변환
         // 5. ApiResponse로 래핑하여 반환
 
-        log.info("GET /api/v1/answers - accountId: {}", accountId);
+        log.info("GET /api/answers - accountId: {}", accountId);
 
         // TODO: 임시 구현 (Service 연동 필요)
         return ResponseEntity.ok(
@@ -95,7 +95,7 @@ public class AnswerController {
         // 4. Result를 Response DTO로 변환
         // 5. ApiResponse로 래핑하여 반환
 
-        log.info("GET /api/v1/answers/{} - accountId: {}", answerId, accountId);
+        log.info("GET /api/answers/{} - accountId: {}", answerId, accountId);
 
         return ResponseEntity.ok(
                 new ApiResponse<>(MESSAGE_ANSWER_DETAIL_RETRIEVED, null)
@@ -118,7 +118,7 @@ public class AnswerController {
 
         AnswerSubmitResult submitResult = answerApplicationService.submit(accountId, command);
 
-        log.info("POST /api/v1/interview/answers - accountId: {}, questionId: {}",
+        log.info("POST /api/interview/answers - accountId: {}, questionId: {}",
                 accountId, request.questionId());
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -147,7 +147,7 @@ public class AnswerController {
         // 5. Result를 Response DTO로 변환
         // 6. ApiResponse로 래핑하여 201 Created 반환
 
-        log.info("POST /api/v1/interview/sessions/{}/answers - accountId: {}, questionId: {}",
+        log.info("POST /api/interview/sessions/{}/answers - accountId: {}, questionId: {}",
                 sessionId, accountId, request.questionId());
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -177,7 +177,7 @@ public class AnswerController {
         // 4. Result를 Response DTO로 변환
         // 5. ApiResponse로 래핑하여 반환
 
-        log.info("GET /api/v1/interviews/answers/{}/feedback - accountId: {}", answerId, accountId);
+        log.info("GET /api/interviews/answers/{}/feedback - accountId: {}", answerId, accountId);
 
         return ResponseEntity.ok(
                 new ApiResponse<>(MESSAGE_FEEDBACK_RETRIEVED, null)

--- a/src/main/java/com/ktb/auth/controller/OAuthController.java
+++ b/src/main/java/com/ktb/auth/controller/OAuthController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
  * OAuth 인증 Controller
  */
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Slf4j
 public class OAuthController {
@@ -39,7 +39,7 @@ public class OAuthController {
 
     /**
      * OAuth 인증 URL 생성
-     * GET /api/v1/auth/oauth/authorization-url?provider=kakao
+     * GET /api/auth/oauth/authorization-url?provider=kakao
      */
     @GetMapping("/oauth/authorization-url")
     public ResponseEntity<ApiResponse<AuthorizationUrlResult>> getAuthorizationUrl(
@@ -54,7 +54,7 @@ public class OAuthController {
 
     /**
      * OAuth 콜백 처리
-     * GET /api/v1/auth/oauth/{provider}/callback?code=xxx&state=yyy
+     * GET /api/auth/oauth/{provider}/callback?code=xxx&state=yyy
      */
     @GetMapping("/oauth/{provider}/callback")
     public ResponseEntity<ApiResponse<OAuthLoginResponseDto>> handleCallback(
@@ -88,7 +88,7 @@ public class OAuthController {
 
     /**
      * Token Refresh
-     * POST /api/v1/auth/tokens
+     * POST /api/auth/tokens
      */
     @PostMapping("/tokens")
     public ResponseEntity<ApiResponse<TokenRefreshResponseDto>> refreshTokens(
@@ -119,7 +119,7 @@ public class OAuthController {
 
     /**
      * 로그아웃 (단일 기기)
-     * POST /api/v1/auth/logout
+     * POST /api/auth/logout
      */
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
@@ -147,7 +147,7 @@ public class OAuthController {
 
     /**
      * 전체 기기 로그아웃
-     * POST /api/v1/auth/logout/all
+     * POST /api/auth/logout/all
      */
     @PostMapping("/logout/all")
     public ResponseEntity<ApiResponse<LogoutAllResponse>> logoutAll(

--- a/src/main/java/com/ktb/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/auth/security/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                                 "/",
                                 "/error",
                                 "/actuator/health",
-                                "/api/v1/auth/**",
+                                "/api/auth/**",
                                 "/h2-console/**"
                         ).permitAll()
 

--- a/src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
@@ -20,7 +20,7 @@ public class CookieServiceImpl implements CookieService {
         Cookie cookie = new Cookie(jwtProperties.getRefreshTokenCookieName(), refreshToken);
         cookie.setHttpOnly(true);
         cookie.setSecure(true); // HTTPS에서만 전송 (프로덕션)
-        cookie.setPath("/api/v1/auth");
+        cookie.setPath("/api/auth");
         cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000)); // 밀리초 → 초
         // cookie.setAttribute("SameSite", "Strict"); // Spring Boot 3.x+에서 지원
         return cookie;
@@ -31,7 +31,7 @@ public class CookieServiceImpl implements CookieService {
         Cookie cookie = new Cookie(jwtProperties.getRefreshTokenCookieName(), "");
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
-        cookie.setPath("/api/v1/auth");
+        cookie.setPath("/api/auth");
         cookie.setMaxAge(0); // 즉시 만료
         return cookie;
     }

--- a/src/main/java/com/ktb/file/controller/FileController.java
+++ b/src/main/java/com/ktb/file/controller/FileController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "File API", description = "파일 업로드 관리 API")
 @RestController
-@RequestMapping("/api/v1/files")
+@RequestMapping("/api/files")
 @RequiredArgsConstructor
 public class FileController {
 

--- a/src/main/java/com/ktb/metric/controller/MetricController.java
+++ b/src/main/java/com/ktb/metric/controller/MetricController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/metrics")
+@RequestMapping("/api/metrics")
 @RequiredArgsConstructor
 @Validated
 public class MetricController {

--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/questions")
+@RequestMapping("/api/questions")
 @RequiredArgsConstructor
 @Validated
 public class QuestionController {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,7 +61,7 @@ aws:
 ai:
   feedback:
     base-url: ${AI_FEEDBACK_BASE_URL}
-    endpoint: /api/v1/feedback/evaluate
+    endpoint: /api/feedback/evaluate
     timeout: 60000  # 60초
   stt:
     base-url: ${AI_STT_BASE_URL}

--- a/src/test/java/com/ktb/auth/controller/OAuthControllerTest.java
+++ b/src/test/java/com/ktb/auth/controller/OAuthControllerTest.java
@@ -49,7 +49,7 @@ class OAuthControllerTest {
         when(oauthApplicationService.getAuthorizationUrl("kakao")).thenReturn(result);
 
         // when & then
-        mockMvc.perform(get("/api/v1/auth/oauth/authorization-url")
+        mockMvc.perform(get("/api/auth/oauth/authorization-url")
                         .param("provider", "kakao"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.authorizationUrl").value("https://kauth.kakao.com/oauth/authorize?..."));
@@ -70,7 +70,7 @@ class OAuthControllerTest {
         when(cookieService.createRefreshTokenCookie(REFRESH_TOKEN)).thenReturn(mockCookie);
 
         // when & then
-        mockMvc.perform(get("/api/v1/auth/oauth/kakao/callback")
+        mockMvc.perform(get("/api/auth/oauth/kakao/callback")
                         .param("code", "auth-code")
                         .param("state", "state-123"))
                 .andExpect(status().isOk())
@@ -94,7 +94,7 @@ class OAuthControllerTest {
         when(cookieService.createRefreshTokenCookie(NEW_REFRESH_TOKEN)).thenReturn(newCookie);
 
         // when & then
-        mockMvc.perform(post("/api/v1/auth/tokens").with(csrf())
+        mockMvc.perform(post("/api/auth/tokens").with(csrf())
                         .cookie(new Cookie("refreshToken", REFRESH_TOKEN)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.accessToken").value("new.access.token"))
@@ -109,7 +109,7 @@ class OAuthControllerTest {
     @DisplayName("쿠키 없이 Refresh 요청 시 400 에러")
     void refreshTokens_WithoutCookie_ShouldReturnBadRequest() throws Exception {
         // when & then
-        mockMvc.perform(post("/api/v1/auth/tokens").with(csrf()))
+        mockMvc.perform(post("/api/auth/tokens").with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("missing_refresh_token"));
     }
@@ -124,7 +124,7 @@ class OAuthControllerTest {
         when(cookieService.createExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
 
         // when & then
-        mockMvc.perform(post("/api/v1/auth/logout").with(csrf())
+        mockMvc.perform(post("/api/auth/logout").with(csrf())
                         .cookie(new Cookie("refreshToken", REFRESH_TOKEN)))
                 .andExpect(status().isOk())
                 .andExpect(cookie().maxAge("refreshToken", 0));
@@ -143,7 +143,7 @@ class OAuthControllerTest {
         when(cookieService.createExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
 
         // when & then
-        mockMvc.perform(post("/api/v1/auth/logout/all").with(csrf()))
+        mockMvc.perform(post("/api/auth/logout/all").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.revokedSessionsCount").value(3))
                 .andExpect(cookie().maxAge("refreshToken", 0));

--- a/src/test/java/com/ktb/auth/service/CookieServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/CookieServiceTest.java
@@ -45,7 +45,7 @@ class CookieServiceTest {
         assertThat(cookie.getValue()).isEqualTo(SAMPLE_REFRESH_TOKEN);
         assertThat(cookie.isHttpOnly()).isTrue();
         assertThat(cookie.getSecure()).isTrue();
-        assertThat(cookie.getPath()).isEqualTo("/api/v1/auth");
+        assertThat(cookie.getPath()).isEqualTo("/api/auth");
         assertThat(cookie.getMaxAge()).isEqualTo((int) (REFRESH_TOKEN_EXPIRATION / 1000));
     }
 
@@ -71,7 +71,7 @@ class CookieServiceTest {
         assertThat(cookie.getValue()).isEmpty();
         assertThat(cookie.isHttpOnly()).isTrue();
         assertThat(cookie.getSecure()).isTrue();
-        assertThat(cookie.getPath()).isEqualTo("/api/v1/auth");
+        assertThat(cookie.getPath()).isEqualTo("/api/auth");
         assertThat(cookie.getMaxAge()).isZero();
     }
 


### PR DESCRIPTION
  ## 요약

  엔트리포인트 URL을 /api/v1에서 /api로 전역 변경했습니다.

  ## 변경사항

  - 컨트롤러 @RequestMapping 및 관련 URL 문자열 /api/v1 → /api 변경
  - 보안 설정, 쿠키 경로, 설정 파일의 엔드포인트 경로 변경
  - 문서 및 테스트 코드의 API 경로 예시/요청 경로 갱신

  ## 관련 Commit, Issue
- #68 

 ### 상세 변경 파일

  - src/main/java/com/ktb/answer/controller/AnswerController.java
  - src/main/java/com/ktb/auth/controller/OAuthController.java
  - src/main/java/com/ktb/auth/security/config/SecurityConfig.java
  - src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
  - src/main/java/com/ktb/file/controller/FileController.java
  - src/main/java/com/ktb/metric/controller/MetricController.java
  - src/main/java/com/ktb/question/controller/QuestionController.java
  - src/main/resources/application.yaml
  - src/test/java/com/ktb/auth/controller/OAuthControllerTest.java
  - src/test/java/com/ktb/auth/integration/OAuthIntegrationTest.java
  - src/test/java/com/ktb/auth/service/CookieServiceTest.java