### PR TITLE
refactor:[#18] RuntimeException을 BusinessException으로 전환

### DIFF
--- a/src/main/java/com/ktb/auth/exception/account/AccountInvalidNicknameException.java
+++ b/src/main/java/com/ktb/auth/exception/account/AccountInvalidNicknameException.java
@@ -1,0 +1,11 @@
+package com.ktb.auth.exception.account;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AccountInvalidNicknameException extends BusinessException {
+
+    public AccountInvalidNicknameException() {
+        super(ErrorCode.ACCOUNT_INVALID_NICKNAME);
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/account/AccountNotFoundException.java
+++ b/src/main/java/com/ktb/auth/exception/account/AccountNotFoundException.java
@@ -1,0 +1,14 @@
+package com.ktb.auth.exception.account;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AccountNotFoundException extends BusinessException {
+
+    public AccountNotFoundException(Long accountId) {
+        super(ErrorCode.ACCOUNT_NOT_FOUND,
+            String.format(
+                "%ss accountId=%d",ErrorCode.ACCOUNT_NOT_FOUND.getCode() , accountId
+            ));
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/family/FamilyOwnershipException.java
+++ b/src/main/java/com/ktb/auth/exception/family/FamilyOwnershipException.java
@@ -5,8 +5,11 @@ import com.ktb.common.exception.BusinessException;
 
 public class FamilyOwnershipException extends BusinessException {
 
+    public FamilyOwnershipException() {
+        super(ErrorCode.FAMILY_OWNERSHIP_MISMATCH);
+    }
     public FamilyOwnershipException(Long familyId, Long accountId) {
         super(ErrorCode.FAMILY_OWNERSHIP_MISMATCH,
-                String.format("세션 소유권이 일치하지 않습니다: familyId=%d, accountId=%d", familyId, accountId));
+                String.format("%s: familyId=%d, accountId=%d",ErrorCode.FAMILY_OWNERSHIP_MISMATCH.getMessage() , familyId, accountId));
     }
 }

--- a/src/main/java/com/ktb/auth/exception/family/FamilyRevokedException.java
+++ b/src/main/java/com/ktb/auth/exception/family/FamilyRevokedException.java
@@ -5,8 +5,13 @@ import com.ktb.common.exception.BusinessException;
 
 public class FamilyRevokedException extends BusinessException {
 
+    public FamilyRevokedException() {
+        super(ErrorCode.FAMILY_REVOKED);
+    }
+
     public FamilyRevokedException(Long familyId) {
         super(ErrorCode.FAMILY_REVOKED,
-                String.format("세션이 이미 종료되었습니다: familyId=%d", familyId));
+            String.format("%s: familyId=%d",ErrorCode.FAMILY_REVOKED.getMessage() , familyId)
+        );
     }
 }

--- a/src/main/java/com/ktb/auth/exception/family/TokenFamilyNotFoundException.java
+++ b/src/main/java/com/ktb/auth/exception/family/TokenFamilyNotFoundException.java
@@ -1,0 +1,20 @@
+package com.ktb.auth.exception.family;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class TokenFamilyNotFoundException extends BusinessException {
+
+    public TokenFamilyNotFoundException(Long familyId) {
+        super(ErrorCode.TOKEN_FAMILY_NOT_FOUND,
+            String.format(
+                "%s familyId=%d", ErrorCode.TOKEN_FAMILY_NOT_FOUND.getMessage(), familyId
+            ));
+    }
+
+    public TokenFamilyNotFoundException(String familyUuid) {
+        super(ErrorCode.TOKEN_FAMILY_NOT_FOUND,
+            String.format("%s familyUuid=%s",ErrorCode.TOKEN_FAMILY_NOT_FOUND.getMessage() , familyUuid)
+        );
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/OAuthAlreadyUnlinkedException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/OAuthAlreadyUnlinkedException.java
@@ -1,0 +1,13 @@
+package com.ktb.auth.exception.oauth;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class OAuthAlreadyUnlinkedException extends BusinessException {
+
+    public OAuthAlreadyUnlinkedException(Long oauthId) {
+        super(ErrorCode.OAUTH_ALREADY_UNLINKED,
+            String.format("%s oauthId=%d", ErrorCode.OAUTH_ALREADY_UNLINKED, oauthId)
+        );
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/OAuthConnectionNotFoundException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/OAuthConnectionNotFoundException.java
@@ -1,0 +1,14 @@
+package com.ktb.auth.exception.oauth;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class OAuthConnectionNotFoundException extends BusinessException {
+
+    public OAuthConnectionNotFoundException(Long oauthId) {
+        super(ErrorCode.OAUTH_CONNECTION_NOT_FOUND,
+            String.format("%s oauthId=%d", ErrorCode.OAUTH_CONNECTION_NOT_FOUND.getMessage(),
+                oauthId)
+        );
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/oauth/OAuthProviderException.java
+++ b/src/main/java/com/ktb/auth/exception/oauth/OAuthProviderException.java
@@ -5,6 +5,13 @@ import com.ktb.common.exception.BusinessException;
 
 public class OAuthProviderException extends BusinessException {
 
+    public OAuthProviderException() {
+        super(ErrorCode.OAUTH_PROVIDER_ERROR);
+    }
+    public OAuthProviderException(String message) {
+        super(ErrorCode.OAUTH_PROVIDER_ERROR, message);
+    }
+
     public OAuthProviderException(String provider, String reason) {
         super(ErrorCode.OAUTH_PROVIDER_ERROR,
                 String.format("OAuth 제공자 통신에 실패했습니다: provider=%s, reason=%s", provider, reason));

--- a/src/main/java/com/ktb/auth/exception/security/InvalidAuthenticatedUserException.java
+++ b/src/main/java/com/ktb/auth/exception/security/InvalidAuthenticatedUserException.java
@@ -1,0 +1,11 @@
+package com.ktb.auth.exception.security;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class InvalidAuthenticatedUserException extends BusinessException {
+
+    public InvalidAuthenticatedUserException(String userType) {
+        super(ErrorCode.INTERNAL_SERVER_ERROR, "지원하지 않는 인증 사용자 타입입니다. type=" + userType);
+    }
+}

--- a/src/main/java/com/ktb/auth/exception/token/TokenHashingFailedException.java
+++ b/src/main/java/com/ktb/auth/exception/token/TokenHashingFailedException.java
@@ -1,0 +1,15 @@
+package com.ktb.auth.exception.token;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class TokenHashingFailedException extends BusinessException {
+
+    public TokenHashingFailedException(String reason) {
+        super(ErrorCode.TOKEN_HASHING_FAILED, "토큰 해시 생성에 실패했습니다. reason=" + reason);
+    }
+
+    public TokenHashingFailedException(Throwable cause) {
+        super(ErrorCode.TOKEN_HASHING_FAILED, "토큰 해시 생성에 실패했습니다.", cause);
+    }
+}

--- a/src/main/java/com/ktb/common/domain/ErrorCode.java
+++ b/src/main/java/com/ktb/common/domain/ErrorCode.java
@@ -11,20 +11,25 @@ public enum ErrorCode {
     UNSUPPORTED_PROVIDER(400, "AUTH001", "지원하지 않는 OAuth 제공자입니다"),
     INVALID_STATE(401, "AUTH002", "state 검증에 실패했습니다"),
     INVALID_AUTHORIZATION_CODE(401, "AUTH003", "authorization code가 유효하지 않습니다"),
-    OAUTH_PROVIDER_ERROR(502, "AUTH004", "OAuth 제공자 통신에 실패했습니다"),
+    OAUTH_PROVIDER_ERROR(422, "AUTH004", "OAuth 제공자 통신에 실패했습니다"),
+    OAUTH_CONNECTION_NOT_FOUND(404, "AUTH005", "OAuth 연동 정보를 찾을 수 없습니다"),
+    OAUTH_ALREADY_UNLINKED(409, "AUTH006", "이미 연동 해제된 OAuth입니다"),
 
     // ==================== Token 관련 ====================
     INVALID_ACCESS_TOKEN(401, "AUTH011", "Access Token이 유효하지 않습니다"),
     INVALID_REFRESH_TOKEN(401, "AUTH012", "Refresh Token이 유효하지 않습니다"),
     MISSING_REFRESH_TOKEN(400, "AUTH013", "Refresh Token이 누락되었습니다"),
     TOKEN_REUSE_DETECTED(403, "AUTH014", "토큰 재사용이 탐지되었습니다"),
+    TOKEN_HASHING_FAILED(422, "AUTH015", "토큰 해시 생성에 실패했습니다"),
 
     // ==================== Family/Session 관련 ====================
     FAMILY_REVOKED(401, "AUTH021", "세션이 이미 종료되었습니다"),
     FAMILY_OWNERSHIP_MISMATCH(403, "AUTH022", "세션 소유권이 일치하지 않습니다"),
+    TOKEN_FAMILY_NOT_FOUND(404, "AUTH023", "토큰 패밀리를 찾을 수 없습니다"),
 
     // ==================== Account 관련 ====================
     ACCOUNT_NOT_FOUND(404, "AUTH031", "계정을 찾을 수 없습니다"),
+    ACCOUNT_INVALID_NICKNAME(400, "AUTH032", "닉네임이 올바르지 않습니다"),
 
     // ==================== Question 관련 ====================
     QUESTION_NOT_FOUND(404, "Q001", "질문을 찾을 수 없습니다"),
@@ -96,7 +101,7 @@ public enum ErrorCode {
 
     // ==================== 공통 ====================
     INVALID_INPUT(400, "C001", "입력값이 올바르지 않습니다"),
-    INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다"),
+    INTERNAL_SERVER_ERROR(422, "C002", "서버 내부 오류가 발생했습니다"),
     FORBIDDEN(403, "C004", "접근 권한이 없습니다"),
     UNAUTHORIZED(401, "AUTH901", "인증이 필요합니다"),
     TOO_MANY_REQUESTS(429, "AUTH903", "요청이 너무 많습니다");


### PR DESCRIPTION
  ### 요약

  RuntimeException을 BusinessException으로 전환하여 모든 도메인 예외를 통일하고, ErrorCode로 중앙 관리하여 유지보수성을
  향상시켰습니다.

  ### 변경사항

  1. ErrorCode 추가 (5개)

  - OAUTH_CONNECTION_NOT_FOUND (404, AUTH005): OAuth 연동 정보를 찾을 수 없음
  - OAUTH_ALREADY_UNLINKED (409, AUTH006): 이미 연동 해제된 OAuth
  - TOKEN_HASHING_FAILED (422, AUTH015): 토큰 해시 생성 실패
  - TOKEN_FAMILY_NOT_FOUND (404, AUTH023): 토큰 패밀리를 찾을 수 없음
  - ACCOUNT_INVALID_NICKNAME (400, AUTH032): 닉네임 형식 오류

  2. ErrorCode HTTP 상태 코드 수정

  - OAUTH_PROVIDER_ERROR: 502 → 422 (외부 API 실패 정책에 맞춰 수정)
  - INTERNAL_SERVER_ERROR: 500 → 422

  3. 신규 BusinessException 추가 (7개)

  Account 관련:
  - AccountNotFoundException: 계정을 찾을 수 없음
  - AccountInvalidNicknameException: 닉네임이 올바르지 않음

  TokenFamily 관련:
  - TokenFamilyNotFoundException: 토큰 패밀리를 찾을 수 없음

  OAuth 관련:
  - OAuthConnectionNotFoundException: OAuth 연동 정보 없음
  - OAuthAlreadyUnlinkedException: 이미 연동 해제됨

  Security 관련:
  - InvalidAuthenticatedUserException: 인증 사용자 정보 유효하지 않음

  Token 관련:
  - TokenHashingFailedException: 토큰 해시 생성 실패

  4. 기존 예외 수정 (3개)

  - FamilyOwnershipException: ErrorCode만 사용하도록 수정
  - FamilyRevokedException: ErrorCode만 사용하도록 수정
  - OAuthProviderException: ErrorCode만 사용하도록 수정

  5. 영향 및 효과

  - 모든 예외가 BusinessException 하위 클래스로 통일
  - GlobalExceptionHandler에서 일관된 에러 응답 제공
  - 에러 메시지를 ErrorCode에서 중앙 관리하여 유지보수성 향상
  - 다국어 지원 시 ErrorCode만 수정하면 됨
  ## 관련 이슈
  - #18