### PR TITLE
feat: [#69] Swagger API 명세서 작성

### DIFF
--- a/src/main/java/com/ktb/auth/controller/OAuthController.java
+++ b/src/main/java/com/ktb/auth/controller/OAuthController.java
@@ -10,6 +10,12 @@ import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.auth.service.CookieService;
 import com.ktb.auth.service.OAuthApplicationService;
 import com.ktb.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * OAuth 인증 Controller
  */
+@Tag(name = "OAuth API", description = "OAuth 인증 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -42,7 +49,14 @@ public class OAuthController {
      * GET /api/auth/oauth/authorization-url?provider=kakao
      */
     @GetMapping("/oauth/authorization-url")
+    @Operation(summary = "OAuth 로그인 시작", description = "OAuth 인증 URL을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "지원하지 않는 provider",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<AuthorizationUrlResult>> getAuthorizationUrl(
+            @Parameter(description = "OAuth 제공자", example = "kakao")
             @RequestParam String provider
     ) {
         AuthorizationUrlResult result = oauthApplicationService.getAuthorizationUrl(provider);
@@ -57,9 +71,18 @@ public class OAuthController {
      * GET /api/auth/oauth/{provider}/callback?code=xxx&state=yyy
      */
     @GetMapping("/oauth/{provider}/callback")
+    @Operation(summary = "OAuth 콜백", description = "OAuth 콜백을 처리하고 토큰을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<OAuthLoginResponse>> handleCallback(
+            @Parameter(description = "OAuth 제공자", example = "kakao")
             @PathVariable String provider,
+            @Parameter(description = "Authorization code")
             @RequestParam String code,
+            @Parameter(description = "CSRF state")
             @RequestParam String state,
             HttpServletRequest request,
             HttpServletResponse response
@@ -91,7 +114,16 @@ public class OAuthController {
      * POST /api/auth/tokens
      */
     @PostMapping("/tokens")
+    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 Access Token을 재발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "갱신 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Refresh Token 누락",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshTokens(
+            @Parameter(hidden = true)
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
             HttpServletResponse response
     ) {
@@ -122,8 +154,16 @@ public class OAuthController {
      * POST /api/auth/logout
      */
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "단일 기기 로그아웃을 수행합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<Void>> logout(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal SecurityUserAccount principal,
+            @Parameter(hidden = true)
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
             HttpServletResponse response
     ) {
@@ -150,7 +190,14 @@ public class OAuthController {
      * POST /api/auth/logout/all
      */
     @PostMapping("/logout/all")
+    @Operation(summary = "전체 로그아웃", description = "모든 기기 로그아웃을 수행합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<LogoutAllResponse>> logoutAll(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal SecurityUserAccount principal,
             HttpServletResponse response
     ) {

--- a/src/main/java/com/ktb/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/auth/security/config/SecurityConfig.java
@@ -49,7 +49,13 @@ public class SecurityConfig {
                                 "/error",
                                 "/actuator/health",
                                 "/api/auth/**",
-                                "/h2-console/**"
+                                "/h2-console/**",
+
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**", // 기본값 (springdoc 내부 일부가 쓰는 경우 대비)
+                                "/v3/api-docs/swagger-config",
+                                "/api-docs/**"
                         ).permitAll()
 
                         // Actuator Admin 전용

--- a/src/main/java/com/ktb/metric/controller/MetricController.java
+++ b/src/main/java/com/ktb/metric/controller/MetricController.java
@@ -6,6 +6,12 @@ import com.ktb.metric.dto.MetricDetailResponse;
 import com.ktb.metric.dto.MetricListResponse;
 import com.ktb.metric.dto.MetricUpdateRequest;
 import com.ktb.metric.service.MetricService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -22,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Metric API", description = "평가 지표 관리 API")
 @RestController
 @RequestMapping("/api/metrics")
 @RequiredArgsConstructor
@@ -40,9 +47,16 @@ public class MetricController {
      * 평가 지표 목록 조회
      */
     @GetMapping
+    @Operation(summary = "평가 지표 목록 조회", description = "평가 지표 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<MetricListResponse>> getMetrics(
-            @RequestParam(required = false) Boolean useYn,
-            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "활성 여부") @RequestParam(required = false) Boolean useYn,
+            @Parameter(description = "커서") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "사이즈", example = "10")
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
     ) {
         MetricListResponse result = metricService.getMetrics(useYn, cursor, size);
@@ -53,7 +67,14 @@ public class MetricController {
      * 평가 지표 상세 조회
      */
     @GetMapping("/{metricId}")
+    @Operation(summary = "평가 지표 상세 조회", description = "평가 지표 상세를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "평가 지표 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<MetricDetailResponse>> getMetric(
+            @Parameter(description = "평가 지표 ID", example = "1")
             @PathVariable Long metricId
     ) {
         MetricDetailResponse result = metricService.getMetric(metricId);
@@ -64,6 +85,12 @@ public class MetricController {
      * 평가 지표 생성
      */
     @PostMapping
+    @Operation(summary = "평가 지표 생성", description = "새 평가 지표를 생성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<MetricDetailResponse>> createMetric(
             @Valid @RequestBody MetricCreateRequest request
     ) {
@@ -76,7 +103,14 @@ public class MetricController {
      * 평가 지표 수정
      */
     @PatchMapping("/{metricId}")
+    @Operation(summary = "평가 지표 수정", description = "평가 지표를 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "평가 지표 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<MetricDetailResponse>> updateMetric(
+            @Parameter(description = "평가 지표 ID", example = "1")
             @PathVariable Long metricId,
             @Valid @RequestBody MetricUpdateRequest request
     ) {
@@ -88,7 +122,14 @@ public class MetricController {
      * 평가 지표 삭제 (비활성화)
      */
     @DeleteMapping("/{metricId}")
+    @Operation(summary = "평가 지표 삭제", description = "평가 지표를 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "평가 지표 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<Void>> deleteMetric(
+            @Parameter(description = "평가 지표 ID", example = "1")
             @PathVariable Long metricId
     ) {
         metricService.deleteMetric(metricId);

--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -12,6 +12,12 @@ import com.ktb.question.dto.QuestionListResponse;
 import com.ktb.question.dto.QuestionSearchResponse;
 import com.ktb.question.dto.QuestionUpdateRequest;
 import com.ktb.question.service.QuestionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -28,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Question API", description = "질문 관리 API")
 @RestController
 @RequestMapping("/api/questions")
 @RequiredArgsConstructor
@@ -40,10 +47,17 @@ public class QuestionController {
      * 질문 목록 조회
      */
     @GetMapping
+    @Operation(summary = "질문 목록 조회", description = "질문 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionListResponse>> getQuestions(
-            @RequestParam(required = false) QuestionCategory category,
-            @RequestParam(required = false) QuestionType type,
-            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "카테고리") @RequestParam(required = false) QuestionCategory category,
+            @Parameter(description = "질문 유형") @RequestParam(required = false) QuestionType type,
+            @Parameter(description = "커서") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "사이즈", example = "10")
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
     ) {
         QuestionListResponse result = questionService.getQuestions(category, type, cursor, size);
@@ -54,7 +68,14 @@ public class QuestionController {
      * 질문 상세 조회
      */
     @GetMapping("/{questionId}")
+    @Operation(summary = "질문 상세 조회", description = "질문 상세를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> getQuestionDetail(
+            @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId
     ) {
         QuestionDetailResponse result = questionService.getQuestionDetail(questionId);
@@ -65,11 +86,18 @@ public class QuestionController {
      * 질문 검색
      */
     @GetMapping("/search")
+    @Operation(summary = "질문 검색", description = "키워드로 질문을 검색합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionSearchResponse>> searchQuestions(
-            @RequestParam(name = "q") String keyword,
-            @RequestParam(name = "category", required = false) QuestionCategory category,
-            @RequestParam(name = "type", required = false) QuestionType type,
-            @RequestParam(name = "cursor", required = false) Long cursor,
+            @Parameter(description = "검색어") @RequestParam(name = "q") String keyword,
+            @Parameter(description = "카테고리") @RequestParam(name = "category", required = false) QuestionCategory category,
+            @Parameter(description = "질문 유형") @RequestParam(name = "type", required = false) QuestionType type,
+            @Parameter(description = "커서") @RequestParam(name = "cursor", required = false) Long cursor,
+            @Parameter(description = "사이즈", example = "10")
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
     ) {
         QuestionSearchResponse result = questionService.search(keyword, category, type, cursor, size);
@@ -80,6 +108,12 @@ public class QuestionController {
      * 질문 생성
      */
     @PostMapping
+    @Operation(summary = "질문 생성", description = "새 질문을 생성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> createQuestion(
             @Valid @RequestBody QuestionCreateRequest request
     ) {
@@ -92,7 +126,14 @@ public class QuestionController {
      * 질문 수정
      */
     @PatchMapping("/{questionId}")
+    @Operation(summary = "질문 수정", description = "질문을 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> updateQuestion(
+            @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId,
             @RequestBody QuestionUpdateRequest request
     ) {
@@ -104,7 +145,14 @@ public class QuestionController {
      * 질문 삭제 (Soft Delete)
      */
     @DeleteMapping("/{questionId}")
+    @Operation(summary = "질문 삭제", description = "질문을 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+            @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId
     ) {
         questionService.deleteQuestion(questionId);
@@ -115,7 +163,14 @@ public class QuestionController {
      * 질문 핵심 키워드 조회
      */
     @GetMapping("/{questionId}/keywords")
+    @Operation(summary = "질문 키워드 조회", description = "질문 키워드 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionKeywordListResponse>> getQuestionKeywords(
+            @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId
     ) {
         QuestionKeywordListResponse result = questionService.getQuestionKeywords(questionId);
@@ -126,7 +181,14 @@ public class QuestionController {
      * 질문 핵심 키워드 포함 여부 확인
      */
     @PostMapping("/{questionId}/keyword-checks")
+    @Operation(summary = "질문 키워드 체크", description = "질문 키워드 포함 여부를 확인합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
     public ResponseEntity<ApiResponse<QuestionKeywordCheckResponse>> checkQuestionKeyword(
+            @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId,
             @Valid @RequestBody QuestionKeywordCheckRequest request
     ) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,3 +78,13 @@ management:
   endpoint:
     health:
       show-details: never
+
+springdoc:
+  api-docs:
+    path: /api-docs     # 기본 /v3/api-docs → /api-docs 로 변경
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true


### PR DESCRIPTION
## 요약

  OAuth/Question/Metric 컨트롤러에 Swagger 어노테이션을 추가하여 문서화를 보강했습니다. Answer/File 컨트롤러는 기존에 이미 Swagger 어노테이션이 적용되어 있어 추가 변경이 없습니다.
  또한 Spring Boot 4.x에서 경로 매칭/정적 리소스/필터 체인 동작이 엄격해지면서 Swagger UI 접근을 위해 설정을 명시화했습니다.

  ## 변경사항

  - Swagger 어노테이션 추가
      - src/main/java/com/ktb/auth/controller/OAuthController.java
      - src/main/java/com/ktb/question/controller/QuestionController.java
      - src/main/java/com/ktb/metric/controller/MetricController.java
  - Swagger 설정/보안 반영
      - src/main/resources/application.yaml
      - src/main/java/com/ktb/auth/security/config/SecurityConfig.java
  - 기존 적용 상태(변경 없음)
      - src/main/java/com/ktb/answer/controller/AnswerController.java
      - src/main/java/com/ktb/file/controller/FileController.java

  ## 관련 Commit, Issue

  - #69

  ### 관련 이슈 배경

  - Spring Boot 4.x에서 경로 매칭이 엄격해지면서 정적 리소스와 보안 필터 체인의 동작이 명확해짐
  - 기존 Auto-Configuration 설정만으로 Swagger UI가 노출되지 않아 경로/보안 설정을 명시적으로 추가