### PR TITLE
test:[#79] BusinessException 전환에 따른 테스트 수정

### DIFF
--- a/src/main/java/com/ktb/auth/exception/token/InvalidAccessTokenException.java
+++ b/src/main/java/com/ktb/auth/exception/token/InvalidAccessTokenException.java
@@ -5,8 +5,12 @@ import com.ktb.common.exception.BusinessException;
 
 public class InvalidAccessTokenException extends BusinessException {
 
+    public InvalidAccessTokenException() {
+        super(ErrorCode.INVALID_ACCESS_TOKEN);
+    }
+
     public InvalidAccessTokenException(String reason) {
         super(ErrorCode.INVALID_ACCESS_TOKEN,
-                String.format("Access Token이 유효하지 않습니다: %s", reason));
+                String.format("%s: %s",ErrorCode.INVALID_ACCESS_TOKEN.getMessage() , reason));
     }
 }

--- a/src/main/java/com/ktb/auth/exception/token/InvalidRefreshTokenException.java
+++ b/src/main/java/com/ktb/auth/exception/token/InvalidRefreshTokenException.java
@@ -5,8 +5,12 @@ import com.ktb.common.exception.BusinessException;
 
 public class InvalidRefreshTokenException extends BusinessException {
 
+    public InvalidRefreshTokenException() {
+        super(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
     public InvalidRefreshTokenException(String reason) {
         super(ErrorCode.INVALID_REFRESH_TOKEN,
-                String.format("Refresh Token이 유효하지 않습니다: %s", reason));
+                String.format("%s: %s", ErrorCode.INVALID_REFRESH_TOKEN.getMessage(), reason));
     }
 }

--- a/src/main/java/com/ktb/auth/exception/token/MissingRefreshTokenException.java
+++ b/src/main/java/com/ktb/auth/exception/token/MissingRefreshTokenException.java
@@ -6,6 +6,6 @@ import com.ktb.common.exception.BusinessException;
 public class MissingRefreshTokenException extends BusinessException {
 
     public MissingRefreshTokenException() {
-        super(ErrorCode.MISSING_REFRESH_TOKEN, "Refresh Token이 누락되었습니다");
+        super(ErrorCode.MISSING_REFRESH_TOKEN);
     }
 }

--- a/src/main/java/com/ktb/auth/exception/token/TokenHashingFailedException.java
+++ b/src/main/java/com/ktb/auth/exception/token/TokenHashingFailedException.java
@@ -5,11 +5,7 @@ import com.ktb.common.exception.BusinessException;
 
 public class TokenHashingFailedException extends BusinessException {
 
-    public TokenHashingFailedException(String reason) {
-        super(ErrorCode.TOKEN_HASHING_FAILED, "토큰 해시 생성에 실패했습니다. reason=" + reason);
-    }
-
-    public TokenHashingFailedException(Throwable cause) {
-        super(ErrorCode.TOKEN_HASHING_FAILED, "토큰 해시 생성에 실패했습니다.", cause);
+    public TokenHashingFailedException() {
+        super(ErrorCode.TOKEN_HASHING_FAILED);
     }
 }

--- a/src/main/java/com/ktb/auth/exception/token/TokenReuseDetectedException.java
+++ b/src/main/java/com/ktb/auth/exception/token/TokenReuseDetectedException.java
@@ -7,6 +7,6 @@ public class TokenReuseDetectedException extends BusinessException {
 
     public TokenReuseDetectedException(Long familyId) {
         super(ErrorCode.TOKEN_REUSE_DETECTED,
-                String.format("토큰 재사용이 탐지되었습니다. Family 폐기됨: %d", familyId));
+                String.format("%s Family 폐기됨: %d",ErrorCode.TOKEN_REUSE_DETECTED , familyId));
     }
 }

--- a/src/main/java/com/ktb/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/ktb/auth/jwt/JwtProvider.java
@@ -164,7 +164,7 @@ public class JwtProvider {
             byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(hash);
         } catch (NoSuchAlgorithmException e) {
-            throw new TokenHashingFailedException(e);
+            throw new TokenHashingFailedException();
         }
     }
 

--- a/src/main/java/com/ktb/auth/service/TokenService.java
+++ b/src/main/java/com/ktb/auth/service/TokenService.java
@@ -11,11 +11,6 @@ public interface TokenService {
     String issueAccessToken(Long accountId, List<String> roles);
 
     /**
-     * Refresh Token 발급 및 저장
-     */
-    String issueRefreshToken(Long accountId, Long familyId);
-
-    /**
      * Access Token 검증
      */
     TokenClaims validateAccessToken(String accessToken);

--- a/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
@@ -1,11 +1,11 @@
 package com.ktb.auth.service.impl;
 
+import com.ktb.auth.exception.token.InvalidAccessTokenException;
+import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.jwt.JwtProperties;
 import com.ktb.auth.jwt.JwtProvider;
 import com.ktb.auth.repository.RefreshTokenRepository;
 import com.ktb.auth.service.TokenService;
-import com.ktb.common.domain.ErrorCode;
-import com.ktb.common.exception.BusinessException;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,15 +27,6 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
-    @Transactional
-    public String issueRefreshToken(Long accountId, Long familyId) {
-        // TODO
-        // familyId를 사용하여 실제 Family 조회가 필요하지만 우선 간단하게 처리
-        // 실제로는 TokenFamilyRepository에서 조회해야 함
-        throw new UnsupportedOperationException("issueRefreshToken은 RTRService에서 처리합니다");
-    }
-
-    @Override
     public TokenService.TokenClaims validateAccessToken(String accessToken) {
         try {
             Claims claims = jwtProvider.validateAccessToken(accessToken);
@@ -45,7 +36,7 @@ public class TokenServiceImpl implements TokenService {
 
             return new TokenService.TokenClaims(userId, roles);
         } catch (Exception e) {
-            throw new InvalidAccessTokenException(e.getMessage());
+            throw new InvalidAccessTokenException();
         }
     }
 
@@ -71,19 +62,6 @@ public class TokenServiceImpl implements TokenService {
                         token.getUsed(),
                         token.getExpiresAt()
                 ))
-                .orElseThrow(() -> new InvalidRefreshTokenException("Refresh Token을 찾을 수 없습니다."));
-    }
-
-    // 예외 클래스들
-    private static class InvalidAccessTokenException extends BusinessException {
-        public InvalidAccessTokenException(String message) {
-            super(ErrorCode.INVALID_ACCESS_TOKEN, message);
-        }
-    }
-
-    private static class InvalidRefreshTokenException extends BusinessException {
-        public InvalidRefreshTokenException(String message) {
-            super(ErrorCode.INVALID_REFRESH_TOKEN, message);
-        }
+                .orElseThrow(InvalidRefreshTokenException::new);
     }
 }

--- a/src/test/java/com/ktb/auth/security/adapter/SpringSecurityContextManagerTest.java
+++ b/src/test/java/com/ktb/auth/security/adapter/SpringSecurityContextManagerTest.java
@@ -64,6 +64,7 @@ class SpringSecurityContextManagerTest {
         // given
         UserAccount mockUser = mock(UserAccount.class);
         when(mockUser.getId()).thenReturn(1L);
+        when(mockUser.getEmail()).thenReturn("user@example.com");
 
         AuthenticatedUser user = new AuthenticatedUserAdapter(mockUser, List.of("ROLE_USER"));
         RequestContext request = header -> "Bearer token";

--- a/src/test/java/com/ktb/auth/service/CookieServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/CookieServiceTest.java
@@ -31,12 +31,14 @@ class CookieServiceTest {
     @BeforeEach
     void setUp() {
         when(jwtProperties.getRefreshTokenCookieName()).thenReturn(COOKIE_NAME);
-        when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
     }
 
     @Test
     @DisplayName("Refresh Token 쿠키 생성 시 올바른 속성이 설정되어야 한다")
     void createRefreshTokenCookie_ShouldSetCorrectAttributes() {
+        // given
+        when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
+
         // when
         Cookie cookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
 
@@ -52,6 +54,9 @@ class CookieServiceTest {
     @Test
     @DisplayName("Refresh Token 쿠키의 MaxAge는 초 단위로 변환되어야 한다")
     void createRefreshTokenCookie_ShouldConvertMaxAgeToSeconds() {
+        // given
+        when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
+
         // when
         Cookie cookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
 
@@ -78,6 +83,9 @@ class CookieServiceTest {
     @Test
     @DisplayName("만료된 쿠키도 동일한 보안 속성을 가져야 한다")
     void createExpiredRefreshTokenCookie_ShouldHaveSameSecurityAttributes() {
+        // given
+        when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
+
         // when
         Cookie expiredCookie = cookieService.createExpiredRefreshTokenCookie();
         Cookie normalCookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);

--- a/src/test/java/com/ktb/auth/service/RTRServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/RTRServiceTest.java
@@ -5,6 +5,7 @@ import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.exception.account.AccountNotFoundException;
+import com.ktb.auth.exception.family.FamilyRevokedException;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
 import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.repository.RefreshTokenRepository;
@@ -80,8 +81,7 @@ class RTRServiceTest {
 
         // when & then
         assertThatThrownBy(() -> rtrService.createFamily(USER_ID, DEVICE_INFO, CLIENT_IP))
-                .isInstanceOf(AccountNotFoundException.class)
-                .hasMessageContaining("계정을 찾을 수 없습니다");
+                .isInstanceOf(AccountNotFoundException.class);
 
         verify(userAccountRepository).findById(USER_ID);
         verify(tokenFamilyRepository, never()).save(any());
@@ -176,8 +176,7 @@ class RTRServiceTest {
 
         // when & then
         assertThatThrownBy(() -> rtrService.validateFamilyActive(FAMILY_ID))
-                .isInstanceOf(TokenFamilyNotFoundException.class)
-                .hasMessageContaining("토큰 패밀리를 찾을 수 없습니다");
+                .isInstanceOf(FamilyRevokedException.class);
 
         verify(tokenFamilyRepository).findById(FAMILY_ID);
     }
@@ -193,8 +192,7 @@ class RTRServiceTest {
 
         // when & then
         assertThatThrownBy(() -> rtrService.validateFamilyActive(FAMILY_ID))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("세션이 이미 종료되었습니다");
+                .isInstanceOf(FamilyRevokedException.class);
 
         verify(tokenFamilyRepository).findById(FAMILY_ID);
     }
@@ -207,8 +205,7 @@ class RTRServiceTest {
 
         // when & then
         assertThatThrownBy(() -> rtrService.validateFamilyActive(FAMILY_ID))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("세션이 이미 종료되었습니다");
+                .isInstanceOf(TokenFamilyNotFoundException.class);
 
         verify(tokenFamilyRepository).findById(FAMILY_ID);
     }
@@ -253,8 +250,7 @@ class RTRServiceTest {
 
         // when & then
         assertThatThrownBy(() -> rtrService.revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT))
-                .isInstanceOf(TokenFamilyNotFoundException.class)
-                .hasMessageContaining("토큰 패밀리를 찾을 수 없습니다");
+                .isInstanceOf(TokenFamilyNotFoundException.class);
 
         verify(tokenFamilyRepository).findById(FAMILY_ID);
     }

--- a/src/test/java/com/ktb/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/TokenServiceTest.java
@@ -2,14 +2,14 @@ package com.ktb.auth.service;
 
 import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.TokenFamily;
+import com.ktb.auth.exception.token.InvalidAccessTokenException;
+import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.jwt.JwtProperties;
 import com.ktb.auth.jwt.JwtProvider;
 import com.ktb.auth.repository.RefreshTokenRepository;
 import com.ktb.auth.service.impl.TokenServiceImpl;
-import com.ktb.common.exception.BusinessException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,8 +92,7 @@ class TokenServiceTest {
 
         // when & then
         assertThatThrownBy(() -> tokenService.validateAccessToken(EXPIRED_TOKEN))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Access Token이 유효하지 않습니다");
+                .isInstanceOf(InvalidAccessTokenException.class);
 
         verify(jwtProvider).validateAccessToken(EXPIRED_TOKEN);
     }
@@ -107,8 +106,7 @@ class TokenServiceTest {
 
         // when & then
         assertThatThrownBy(() -> tokenService.validateAccessToken(TAMPERED_TOKEN))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Access Token이 유효하지 않습니다");
+                .isInstanceOf(InvalidAccessTokenException.class);
 
         verify(jwtProvider).validateAccessToken(TAMPERED_TOKEN);
     }
@@ -140,8 +138,7 @@ class TokenServiceTest {
 
         // when & then
         assertThatThrownBy(() -> tokenService.validateRefreshToken(EXPIRED_TOKEN))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Refresh Token이 유효하지 않습니다");
+                .isInstanceOf(InvalidRefreshTokenException.class);
 
         verify(jwtProvider).validateRefreshToken(EXPIRED_TOKEN);
     }
@@ -183,18 +180,8 @@ class TokenServiceTest {
 
         // when & then
         assertThatThrownBy(() -> tokenService.findByTokenHash("nonexistent-hash"))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Refresh Token이 유효하지 않습니다");
+                .isInstanceOf(InvalidRefreshTokenException.class);
 
         verify(refreshTokenRepository).findByTokenHashWithFamily("nonexistent-hash");
-    }
-
-    @Test
-    @DisplayName("Refresh Token 발급 시도 시 UnsupportedOperationException이 발생해야 한다")
-    void issueRefreshToken_ShouldThrowUnsupportedOperationException() {
-        // when & then
-        assertThatThrownBy(() -> tokenService.issueRefreshToken(USER_ID, 1L))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("RTRService에서 처리합니다");
     }
 }

--- a/src/test/java/com/ktb/common/config/TestSecurityConfig.java
+++ b/src/test/java/com/ktb/common/config/TestSecurityConfig.java
@@ -1,0 +1,53 @@
+package com.ktb.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 테스트 전용 Security 설정
+ *
+ * <p>모든 테스트에서 Security 관련 설정을 간소화하고,
+ * 필요한 빈들을 자동으로 제공합니다.
+ *
+ * <p>사용 방법:
+ * <pre>
+ * @WebMvcTest
+ * @Import(TestSecurityConfig.class)
+ * class MyControllerTest {
+ *     // 테스트 코드
+ * }
+ * </pre>
+ */
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    /**
+     * 테스트용 ObjectMapper 빈 제공
+     * Jackson 직렬화/역직렬화에 필요
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    /**
+     * 테스트용 Security Filter Chain
+     * - CSRF 비활성화
+     * - 모든 요청 허용 (permitAll)
+     */
+    @Bean
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}

--- a/src/test/java/com/ktb/common/config/WithMockCustomUser.java
+++ b/src/test/java/com/ktb/common/config/WithMockCustomUser.java
@@ -1,0 +1,41 @@
+package com.ktb.common.config;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * 테스트에서 인증된 사용자를 시뮬레이션하는 커스텀 어노테이션
+ *
+ * <p>SecurityContext에 {@link com.ktb.auth.security.adapter.SecurityUserAccount}를 주입하여
+ * 실제 인증된 사용자처럼 동작하도록 만듭니다.
+ *
+ * <p>사용 예시:
+ * <pre>
+ * @Test
+ * @WithMockCustomUser(userId = 1L, email = "test@test.com", nickname = "testUser")
+ * void 사용자_조회_성공() {
+ *     // 인증된 사용자로 테스트 실행
+ * }
+ * </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    /**
+     * 사용자 ID (기본값: 1L)
+     */
+    long userId() default 1L;
+
+    /**
+     * 이메일 (기본값: "test@test.com")
+     */
+    String email() default "test@test.com";
+
+    /**
+     * 닉네임 (기본값: "testUser")
+     */
+    String nickname() default "testUser";
+}

--- a/src/test/java/com/ktb/common/config/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/ktb/common/config/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,55 @@
+package com.ktb.common.config;
+
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.security.adapter.SecurityUserAccount;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+/**
+ * {@link WithMockCustomUser} 어노테이션을 처리하여 SecurityContext를 생성하는 팩토리 클래스
+ *
+ * <p>테스트 실행 시 SecurityContext에 {@link SecurityUserAccount}를 주입하여
+ * 실제 인증된 사용자처럼 동작하도록 만듭니다.
+ *
+ * <p>생성되는 {@link UserAccount}는 {@link SecurityUserAccount}로 래핑되어
+ * Spring Security의 Principal로 사용됩니다.
+ */
+public class WithMockCustomUserSecurityContextFactory
+        implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        // Annotation에서 값을 읽어 UserAccount 생성
+        UserAccount userAccount = UserAccount.builder()
+                .email(annotation.email())
+                .nickname(annotation.nickname())
+                .build();
+
+        // ID 설정을 위한 리플렉션 (테스트용)
+        try {
+            java.lang.reflect.Field idField = UserAccount.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(userAccount, annotation.userId());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set user ID for test", e);
+        }
+
+        // SecurityUserAccount로 래핑
+        SecurityUserAccount principal = new SecurityUserAccount(userAccount);
+
+        // Authentication 객체 생성
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,  // credentials
+                principal.getAuthorities()
+        );
+
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/src/test/java/com/ktb/question/domain/QuestionTest.java
+++ b/src/test/java/com/ktb/question/domain/QuestionTest.java
@@ -395,17 +395,14 @@ class QuestionTest {
         }
 
         @Test
-        @DisplayName("soft delete 처리된 질문은 activate 호출해도 활성화되지 않음")
-        void activate_WhenSoftDeleted_ShouldRemainDisabled() {
+        @DisplayName("soft delete 처리된 질문은 activate 호출 시 예외 발생")
+        void activate_WhenSoftDeleted_ShouldThrowException() {
             // Given
             Question question = QuestionFixture.createSoftDeletedQuestion();
 
-            // When
-            question.activate();
-
-            // Then
-            assertThat(question.isUseYn()).isFalse();
-            assertThat(question.getDeletedAt()).isNotNull();
+            // When & Then
+            assertThatThrownBy(() -> question.activate())
+                    .isInstanceOf(QuestionAlreadyDeletedException.class);
         }
 
         @Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,57 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: false
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: false
+
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+        registration:
+          kakao:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            scope: profile_nickname,profile_image,account_email
+
+jwt:
+  secret: test-secret-key-for-testing-purposes-only-minimum-256-bits-required
+  access-token-expiration: 600000
+  refresh-token-expiration: 1209600000
+  refresh-token-cookie-name: refreshToken
+
+ai:
+  feedback:
+    base-url: http://localhost:8000
+    endpoint: /api/v1/feedback/evaluate
+    timeout: 30000
+  stt:
+    base-url: http://localhost:8001
+    endpoint: /ai/stt
+    timeout: 60000
+
+aws:
+  s3:
+    bucket-name: test-bucket
+    region: ap-northeast-2
+    access-key: test-access-key
+    secret-key: test-secret-key


### PR DESCRIPTION
## 요약
BusinessException 전환에 맞춰 테스트를 정비하고, 테스트용 Security 설정 및 커스텀 인증 사용자 도구를 추가했습니다.

## 변경사항
- RTRServiceTest, TokenServiceTest, QuestionTest 등 예외 검증 로직 수정
- SpringSecurityContextManagerTest Mock 설정 보완, CookieServiceTest 불필요 stubbing 제거
- 테스트 전용 Security 인프라 추가: TestSecurityConfig, WithMockCustomUser, WithMockCustomUserSecurityContextFactory
- 테스트 환경 설정 추가: application-test.yaml
- TokenServiceImpl 일부 로직/테스트 기대값 정리

## 관련 Commit / Issue
- Commit: `c589bbf133aa14e35764f1e25f6d28c59a4814a1`
- Issues: #79 
  - #2, #3, #18