### PR TITLE
feat/#78-fix-jackson-compile-error

### DIFF
--- a/src/main/java/com/ktb/ai/common/config/AiClientConfig.java
+++ b/src/main/java/com/ktb/ai/common/config/AiClientConfig.java
@@ -1,5 +1,6 @@
 package com.ktb.ai.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,5 +20,10 @@ public class AiClientConfig {
         return RestClient.builder()
                 .requestFactory(requestFactory)
                 .build();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }


### PR DESCRIPTION
## 요약
Jackson ObjectMapper 빈 초기화 오류를 해결하기 위해 AI 클라이언트 설정에 필요한 설정을 보완했습니다.

## 변경사항
- `AiClientConfig`에 ObjectMapper 관련 초기화 보완(6줄 추가)

## 관련 Commit / Issue
- Issue: #78