### PR TITLE
feat:[#81] 해시태그 조회 시 SQL 문법 에러 수정

### DIFF
--- a/src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
+++ b/src/main/java/com/ktb/hashtag/repository/QuestionHashtagRepository.java
@@ -13,8 +13,7 @@ public interface QuestionHashtagRepository extends JpaRepository<QuestionHashtag
     @Query("""
             SELECT qh
             FROM QuestionHashtag qh
-            INNER JOIN FETCH qh.hashtag h
-                on h.tag_id = qh.tag_id
+            JOIN FETCH qh.hashtag h
             WHERE qh.question.id = :questionId
             """)
     List<QuestionHashtag> findKeywordNamesByQuestionId(@Param("questionId") Long questionId);


### PR DESCRIPTION
## 요약
Hibernate 7에서 fetch join에 `ON` 절을 사용할 수 없어 발생한 SQL/JPQL 문법 오류를 수정했습니다.

## 변경사항
- `QuestionHashtagRepository` 쿼리에서 `INNER JOIN FETCH ... ON` 제거
- 연관관계 기준 `JOIN FETCH qh.hashtag`로 변경해 쿼리 검증 오류 해결

## 관련 Commit / Issue
- Issue: #81 