### PR TITLE
feat: [#87] 오늘의 추천 질문 API 구현

### DIFF
--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -105,6 +105,21 @@ public class QuestionController {
     }
 
     /**
+     * 오늘의 추천 질문 조회
+     */
+    @GetMapping("/recommendation")
+    @Operation(summary = "오늘의 추천 질문", description = "오늘의 추천 질문을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
+    public ResponseEntity<ApiResponse<QuestionDetailResponse>> getDailyRecommendation() {
+        QuestionDetailResponse result = questionService.getDailyRecommendation();
+        return ResponseEntity.ok(new ApiResponse<>("question_recommendation_success", result));
+    }
+
+    /**
      * 질문 생성
      */
     @PostMapping

--- a/src/main/java/com/ktb/question/repository/QuestionRepository.java
+++ b/src/main/java/com/ktb/question/repository/QuestionRepository.java
@@ -46,4 +46,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    java.util.Optional<Question> findFirstByDeletedAtIsNullAndUseYnTrueOrderByIdDesc();
 }

--- a/src/main/java/com/ktb/question/service/QuestionService.java
+++ b/src/main/java/com/ktb/question/service/QuestionService.java
@@ -18,6 +18,8 @@ public interface QuestionService {
 
     void deleteQuestion(Long questionId);
 
+    QuestionDetailResponse getDailyRecommendation();
+
     QuestionKeywordListResponse getQuestionKeywords(Long questionId);
 
     QuestionKeywordCheckResponse checkQuestionKeywords(Long questionId, java.util.List<String> keywords);

--- a/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
@@ -82,6 +82,14 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    public QuestionDetailResponse getDailyRecommendation() {
+        Question question = questionRepository
+                .findFirstByDeletedAtIsNullAndUseYnTrueOrderByIdDesc()
+                .orElseThrow(() -> new QuestionNotFoundException(0L));
+        return toDetailResponse(question);
+    }
+
+    @Override
     @Transactional
     public QuestionDetailResponse createQuestion(QuestionCreateRequest request) {
         Question question = Question.create(request.content(), request.type(), request.category());


### PR DESCRIPTION
 ## 요약

  오늘의 추천 질문 API를 추가하고, 추천 기준을 “가장 최신 질문 1개”로 설정했습니다. (추천 기준이 모호함)

  ## 변경사항

  - 오늘의 추천 질문 API 추가
      - GET /api/questions/recommendation
  - 최신 질문 1건 조회 로직 적용
      - findFirstByDeletedAtIsNullAndUseYnTrueOrderByIdDesc 사용

  수정 파일

  - src/main/java/com/ktb/question/controller/QuestionController.java
  - src/main/java/com/ktb/question/service/QuestionService.java
  - src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
  - src/main/java/com/ktb/question/repository/QuestionRepository.java

  ## 관련 Commit, Issue
 - #87 