### PR TITLE
feat: [#85] STT요청 API 구현

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -9,6 +9,8 @@ JWT_SECRET=your_jwt_secret_key_at_least_256_bits
 # AWS S3
 AWS_REGION=your_aws_region_name
 AWS_S3_BUCKET_NAME=your_aws_s3_bucket_name
+AWS_S3_CDN_URL_PREFIX=your_aws_s3_cd_url_prefix
+AWS_S3_KEY_PREFIX=your_aws_s3_key_prefix
 AWS_ACCESS_KEY_ID=your_aws_access_key_id_value
 AWS_SECRET_ACCESS_KEY=your_aws_secret_key_id_value
 

--- a/src/main/java/com/ktb/ai/stt/client/SttClient.java
+++ b/src/main/java/com/ktb/ai/stt/client/SttClient.java
@@ -1,7 +1,7 @@
 package com.ktb.ai.stt.client;
 
 import com.ktb.ai.stt.dto.request.SttRequest;
-import com.ktb.ai.stt.dto.response.SttData;
+import com.ktb.ai.stt.dto.response.SttResponse;
 import com.ktb.ai.stt.exception.*;
 import com.ktb.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +52,7 @@ public class SttClient {
                 url, request.userId(), request.sessionId(), request.audioUrl());
 
         try {
-            ApiResponse<SttData> response = aiRestClient.post()
+            ApiResponse<SttResponse> response = aiRestClient.post()
                     .uri(url)
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(request)

--- a/src/main/java/com/ktb/ai/stt/controller/SttController.java
+++ b/src/main/java/com/ktb/ai/stt/controller/SttController.java
@@ -1,0 +1,53 @@
+package com.ktb.ai.stt.controller;
+
+import com.ktb.ai.stt.dto.request.SttRequest;
+import com.ktb.ai.stt.dto.response.SttResponse;
+import com.ktb.ai.stt.service.SttService;
+import com.ktb.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "STT API", description = "Speech-to-Text 변환 API")
+@RestController
+@RequestMapping("/ai/stt")
+@RequiredArgsConstructor
+public class SttController {
+
+    private static final String MESSAGE_STT_CONVERTED = "speech_to_text_success";
+
+    private final SttService sttService;
+
+    @PostMapping
+    @Operation(summary = "STT 변환", description = "오디오 파일을 텍스트로 변환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변환 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "STT 처리 실패",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
+    public ResponseEntity<ApiResponse<SttResponse>> convert(
+            @Valid @RequestBody SttRequest request
+    ) {
+        String text = sttService.convertToText(
+                request.userId(),
+                request.sessionId(),
+                request.audioUrl()
+        );
+
+        return ResponseEntity.ok(
+                new ApiResponse<>(MESSAGE_STT_CONVERTED,
+                        new SttResponse(request.userId(), request.sessionId(), text))
+        );
+    }
+}

--- a/src/main/java/com/ktb/ai/stt/dto/response/SttResponse.java
+++ b/src/main/java/com/ktb/ai/stt/dto/response/SttResponse.java
@@ -1,0 +1,22 @@
+package com.ktb.ai.stt.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "STT 변환 응답")
+public record SttResponse(
+
+        @JsonProperty("user_id")
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @JsonProperty("session_id")
+        @Schema(description = "면접 세션 식별자", example = "123")
+        Long sessionId,
+
+        @JsonProperty("text")
+        @Schema(description = "변환된 텍스트",
+                example = "RDBMS는 엄격한 스키마가 존재하고 SQL을 사용해 데이터를 관리하는 반면...")
+        String text
+) {
+}

--- a/src/main/java/com/ktb/file/dto/request/PresignedUrlMethod.java
+++ b/src/main/java/com/ktb/file/dto/request/PresignedUrlMethod.java
@@ -1,0 +1,6 @@
+package com.ktb.file.dto.request;
+
+public enum PresignedUrlMethod {
+    PUT,
+    GET
+}

--- a/src/main/java/com/ktb/file/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/ktb/file/dto/request/PresignedUrlRequest.java
@@ -3,33 +3,56 @@ package com.ktb.file.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ktb.file.domain.FileCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
 
 @Schema(description = "Presigned URL 생성 요청")
 public record PresignedUrlRequest(
 
         @JsonProperty("file_name")
         @Schema(description = "파일명", example = "interview_answer.mp3", requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotBlank(message = "파일명은 필수입니다")
         String fileName,
 
         @JsonProperty("file_size")
         @Schema(description = "파일 크기 (bytes)", example = "5242880", requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull(message = "파일 크기는 필수입니다")
-        @Min(value = 1, message = "파일 크기는 1바이트 이상이어야 합니다")
         Long fileSize,
 
         @JsonProperty("mime_type")
         @Schema(description = "MIME 타입", example = "audio/mpeg", requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotBlank(message = "MIME 타입은 필수입니다")
         String mimeType,
 
         @JsonProperty("category")
         @Schema(description = "파일 카테고리", example = "AUDIO", requiredMode = Schema.RequiredMode.REQUIRED,
                 allowableValues = {"PROFILE", "ARCHITECTURE", "ATTACHMENT", "TEMP", "AUDIO", "VIDEO"})
-        @NotNull(message = "파일 카테고리는 필수입니다")
-        FileCategory category
+        FileCategory category,
+
+        @JsonProperty("method")
+        @Schema(description = "HTTP 메서드", example = "PUT",
+                allowableValues = {"PUT", "GET"})
+        PresignedUrlMethod method,
+
+        @JsonProperty("file_id")
+        @Schema(description = "기존 파일 ID (GET/HEAD용)", example = "123")
+        Long fileId
 ) {
+
+    @AssertTrue(message = "PUT 요청은 file_name, file_size, mime_type, category가 필요합니다")
+    public boolean isValidPutRequest() {
+        PresignedUrlMethod resolvedMethod = method == null ? PresignedUrlMethod.PUT : method;
+        if (resolvedMethod != PresignedUrlMethod.PUT) {
+            return true;
+        }
+        return fileName != null && !fileName.isBlank()
+                && fileSize != null && fileSize >= 1
+                && mimeType != null && !mimeType.isBlank()
+                && category != null;
+    }
+
+    @AssertTrue(message = "GET 요청은 file_id가 필요합니다")
+    public boolean isValidReadRequest() {
+        PresignedUrlMethod resolvedMethod = method == null ? PresignedUrlMethod.PUT : method;
+        if (resolvedMethod == PresignedUrlMethod.PUT) {
+            return true;
+        }
+        return fileId != null;
+    }
 }

--- a/src/main/java/com/ktb/file/dto/response/FileUploadConfirmResponse.java
+++ b/src/main/java/com/ktb/file/dto/response/FileUploadConfirmResponse.java
@@ -9,7 +9,7 @@ public record FileUploadConfirmResponse(
         @Schema(description = "파일 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
         Long fileId,
 
-        @Schema(description = "파일 URL (CDN)", example = "https://cdn.example.com/uploads/audio/uuid.mp3",
+        @Schema(description = "파일 URL (Presigned GET)", example = "https://s3.amazonaws.com/bucket/uploads/audio/uuid.mp3?X-Amz-Algorithm=...",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         String fileUrl,
 

--- a/src/main/java/com/ktb/file/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/ktb/file/dto/response/PresignedUrlResponse.java
@@ -20,8 +20,8 @@ public record PresignedUrlResponse(
         @Schema(description = "URL 만료 시간 (초)", example = "300", requiredMode = Schema.RequiredMode.REQUIRED)
         int expiresIn,
 
-        @JsonProperty("upload_method")
-        @Schema(description = "업로드 HTTP 메서드", example = "PUT", requiredMode = Schema.RequiredMode.REQUIRED)
-        String uploadMethod
+        @JsonProperty("method")
+        @Schema(description = "HTTP 메서드", example = "PUT", requiredMode = Schema.RequiredMode.REQUIRED)
+        String method
 ) {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,8 @@ aws:
   region: ${AWS_REGION:ap-northeast-2}
   s3:
     bucket-name: ${AWS_S3_BUCKET_NAME:qfeed-files}
+    cdn-url-prefix: ${AWS_S3_CDN_URL_PREFIX:https://qfeed-dev-s3-audio.s3.ap-northeast-2.amazonaws.com}
+    key-prefix: ${AWS_S3_KEY_PREFIX:uploads}
   credentials:
     access-key: ${AWS_ACCESS_KEY_ID}
     secret-key: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
## 요약

  STT 요청 API를 새로 추가하고, S3 Presigned URL 발급 로직을 PUT/GET로 확장했습니다. 또한 S3 URL prefix를 환경변수로 분리하고, Swagger 문서와 보안 설정을 보완했습니다.
  목표는 AI 서버가 파일을 조회 가능한 presigned GET URL을 받을 수 있도록 하고, STT API를 공식 엔드포인트로 제공하는 것입니다.

  ## 변경사항

  ### 기능 추가/변경 (목적 중심)

  - STT 요청 API 추가
      - POST /ai/stt
      - 요청/응답 포맷 통일 (speech_to_text_success, user_id, session_id, text)
      - audio_url 확장자 .mp3|.m4a|.mp4 검증
  - Presigned URL 발급 메서드 확장
      - 기존 PUT 발급 + GET 발급 지원
      - method=PUT|GET 파라미터 추가
      - GET 요청 시 file_id 기반 presigned GET URL 반환
      - 업로드 완료 확인 응답의 fileUrl을 조회용 presigned GET URL로 변경
  - S3 URL 구성값 환경변수화
      - CDN URL prefix / key prefix를 application.yaml과 .env_template로 분리
      - 하드코딩 제거
  - 문서 및 보안 설정
      - STT / File API 문서 추가 및 갱신
      - Swagger 접근 경로(/swagger-ui/**, /api-docs/**) 보안 허용

  ## 변경 파일 (상세)

  ### Added

  - src/main/java/com/ktb/ai/stt/controller/SttController.java
  - src/main/java/com/ktb/ai/stt/dto/response/SttResponse.java
  - src/main/java/com/ktb/file/dto/request/PresignedUrlMethod.java

  ### Modified

  - src/main/java/com/ktb/ai/stt/client/SttClient.java
  - src/main/java/com/ktb/file/dto/request/PresignedUrlRequest.java
  - src/main/java/com/ktb/file/dto/response/PresignedUrlResponse.java
  - src/main/java/com/ktb/file/dto/response/FileUploadConfirmResponse.java
  - src/main/java/com/ktb/file/service/impl/S3PresignedUrlServiceImpl.java
  - src/main/java/com/ktb/auth/security/config/SecurityConfig.java
  - src/main/resources/application.yaml
  - .env_template

  ## 관련 Commit, Issue

  - #85 

  ### 목적/의도

  - AI 서버가 GET으로 파일 조회 가능하도록 presigned GET URL 발급 필요
  - STT API 공식화로 외부 호출/문서 일관성 확보
  - S3 URL 구성을 환경변수로 분리해 배포 환경별 설정 가능하게 함
