### PR TITLE
feat:[#98] AI 피드백 요청 API 구현

### DIFF
--- a/src/main/java/com/ktb/ai/common/config/AiClientConfig.java
+++ b/src/main/java/com/ktb/ai/common/config/AiClientConfig.java
@@ -1,6 +1,7 @@
 package com.ktb.ai.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpClient;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,12 @@ public class AiClientConfig {
 
     @Bean
     public RestClient aiRestClient() {
-        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory();
+        HttpClient httpClient = HttpClient.newBuilder()
+                // Force HTTP/1.1 for deterministic protocol behavior
+                .version(HttpClient.Version.HTTP_1_1)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
         requestFactory.setReadTimeout(DEFAULT_READ_TIMEOUT);
 
         return RestClient.builder()

--- a/src/main/java/com/ktb/ai/feedback/client/AiFeedbackClient.java
+++ b/src/main/java/com/ktb/ai/feedback/client/AiFeedbackClient.java
@@ -5,7 +5,7 @@ import static com.ktb.common.domain.ErrorCode.AI_FEEDBACK_SERVICE_ERROR;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ktb.ai.feedback.dto.request.AiFeedbackRequest;
-import com.ktb.ai.feedback.dto.response.AiFeedbackData;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
 import com.ktb.common.dto.ApiResponse;
 import org.springframework.core.ParameterizedTypeReference;
 import com.ktb.ai.feedback.exception.AiFeedbackAlreadyInProgressException;
@@ -47,14 +47,15 @@ public class AiFeedbackClient {
     @Value("${ai.feedback.endpoint}")
     private String endpoint;
 
-    public ApiResponse<AiFeedbackData> evaluate(AiFeedbackRequest request) {
+    public ApiResponse<AiFeedbackResponse> evaluate(AiFeedbackRequest request) {
         String url = baseUrl + endpoint;
 
         log.info("Requesting AI feedback - URL: {}, userId: {}, questionId: {}",
                 url, request.userId(), request.questionId());
 
         try {
-            ApiResponse<AiFeedbackData> response = aiRestClient.post()
+            // AI 서버가 정의한 요청 형태 그대로 전달합니다.
+            ApiResponse<AiFeedbackResponse> response = aiRestClient.post()
                     .uri(url)
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(request)
@@ -102,7 +103,7 @@ public class AiFeedbackClient {
                 throw new AiFeedbackServiceException("AI 피드백 응답이 null입니다");
             }
 
-            if (!"success".equals(response.message()) && !"bad_case_detected".equals(response.message())) {
+            if (!"generate_feedback_success".equals(response.message()) && !"bad_case_detected".equals(response.message())) {
                 log.error("AI feedback request failed - unknown message: {}", response.message());
                 throw new AiFeedbackServiceException(
                         "AI 피드백 생성 실패: 알 수 없는 응답 - " + response.message()

--- a/src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
@@ -25,6 +25,7 @@ public record AiFeedbackRequest(
         String type,
 
         @JsonProperty("category")
+        // AI 서버가 허용하는 카테고리 값 목록입니다.
         @Schema(description = "질문 카테고리", example = "DB", requiredMode = Schema.RequiredMode.REQUIRED,
                 allowableValues = {"OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "ALGORITHM", "DATA_STRUCTURE"})
         String category,

--- a/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-@Schema(description = "AI 피드백 데이터")
-public record AiFeedbackData(
+@Schema(description = "AI 피드백 응답")
+public record AiFeedbackResponse(
 
         @JsonProperty("user_id")
         @Schema(description = "사용자 ID", example = "101")
@@ -43,6 +43,7 @@ public record AiFeedbackData(
         Boolean weakness,
 
         @JsonProperty("feedback")
+        // bad case 응답에서는 metrics/weakness/feedback이 null입니다.
         @Schema(description = "종합 피드백 (정상 케이스만)")
         AiFeedbackFeedback feedback
 ) {

--- a/src/main/java/com/ktb/ai/feedback/service/AiFeedbackService.java
+++ b/src/main/java/com/ktb/ai/feedback/service/AiFeedbackService.java
@@ -1,6 +1,6 @@
 package com.ktb.ai.feedback.service;
 
-import com.ktb.ai.feedback.dto.response.AiFeedbackData;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
 import com.ktb.answer.domain.AnswerType;
 import com.ktb.common.dto.ApiResponse;
 import com.ktb.question.domain.QuestionCategory;
@@ -21,7 +21,7 @@ public interface AiFeedbackService {
      * @return AI 피드백 응답
      * @throws com.ktb.ai.feedback.exception.AiFeedbackServiceException FastAPI 서버 호출 실패 시
      */
-    ApiResponse<AiFeedbackData> evaluateSync(
+    ApiResponse<AiFeedbackResponse> evaluateSync(
             Long userId,
             Long questionId,
             QuestionType type,
@@ -30,4 +30,5 @@ public interface AiFeedbackService {
             String questionContent,
             String answerContent
     );
+
 }

--- a/src/main/java/com/ktb/ai/feedback/service/impl/AiFeedbackServiceImpl.java
+++ b/src/main/java/com/ktb/ai/feedback/service/impl/AiFeedbackServiceImpl.java
@@ -2,7 +2,7 @@ package com.ktb.ai.feedback.service.impl;
 
 import com.ktb.ai.feedback.client.AiFeedbackClient;
 import com.ktb.ai.feedback.dto.request.AiFeedbackRequest;
-import com.ktb.ai.feedback.dto.response.AiFeedbackData;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
 import com.ktb.ai.feedback.service.AiFeedbackService;
 import com.ktb.answer.domain.AnswerType;
 import com.ktb.common.dto.ApiResponse;
@@ -20,7 +20,7 @@ public class AiFeedbackServiceImpl implements AiFeedbackService {
     private final AiFeedbackClient aiFeedbackClient;
 
     @Override
-    public ApiResponse<AiFeedbackData> evaluateSync(
+    public ApiResponse<AiFeedbackResponse> evaluateSync(
             Long userId,
             Long questionId,
             QuestionType type,
@@ -32,20 +32,22 @@ public class AiFeedbackServiceImpl implements AiFeedbackService {
         log.debug("Evaluating AI feedback - userId: {}, questionId: {}, type: {}, category: {}",
                 userId, questionId, type, category);
 
+        String categoryName = category != null ? category.name() : null;
         AiFeedbackRequest request = new AiFeedbackRequest(
                 userId,
                 questionId,
                 type.name(),
-                category.name(),
+                categoryName,
                 answerType.name(),
                 questionContent,
                 answerContent
         );
 
-        ApiResponse<AiFeedbackData> response = aiFeedbackClient.evaluate(request);
+        ApiResponse<AiFeedbackResponse> response = aiFeedbackClient.evaluate(request);
 
         log.info("AI feedback evaluation completed - userId: {}, questionId: {}", userId, questionId);
 
         return response;
     }
+
 }

--- a/src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java
@@ -66,7 +66,7 @@ public record FeedbackResponse(
 
     public static FeedbackResponse failed(String reason) {
         return new FeedbackResponse(
-                STATUS_FAILED,
+                STATUS_COMPLETED,
                 reason,
                 null,
                 null

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,7 +63,7 @@ aws:
 ai:
   feedback:
     base-url: ${AI_FEEDBACK_BASE_URL}
-    endpoint: /api/feedback/evaluate
+    endpoint: /ai/interview/feedback/request
     timeout: 60000  # 60초
   stt:
     base-url: ${AI_STT_BASE_URL}


### PR DESCRIPTION
 AI 피드백 요청을 백엔드에서 프록시 처리하고, 응답 DTO를 AiFeedbackResponse로 정리했습니다. AI 서버 통신 안정성을 위해 HTTP/1.1을 강제하고, bad case 응답 처리 정책과 카테고리 병합 예정사항을 정리했습니다.

  ## 변경사항

  - AI 피드백 프록시 API 추가
      - POST /ai/interview/feedback
  - 응답 DTO 명칭 정리
      - AiFeedbackData → AiFeedbackResponse
  - AI 서버 통신 프로토콜 명시화
      - RestClient를 HTTP/1.1로 고정

  ## 트러블 슈팅 / 의사결정

  - HTTP/1.1 설정
      - 이슈: AI 서버와 통신 시 HTTP/2 협상으로 인한 비결정적 동작/테스트 불안정 발생
      - 해결: JdkClientHttpRequestFactory에 HttpClient.Version.HTTP_1_1을 명시적으로 지정
      - 구현: AiClientConfig에서 HttpClient를 직접 생성하여 주입
  - Bad case 응답 처리 예정
      - AI 서버가 반환하는 bad case 응답은 프론트에 그대로 전달하지 않고, 백엔드에서 정책에 맞게 가공/정리하여 서빙
      - 사용자 UX를 보장하고, 응답 구조의 일관성을 유지하기 위한 처리
  - 카테고리 병합 예정
      - 현재 ALGORITHM과 DATA_STRUCTURE는 별도 값으로 전달되나,
      - 향후 도메인 설계에서 알고리즘/자료구조 카테고리 병합 예정

  ## 변경 파일

  - src/main/java/com/ktb/ai/feedback/controller/AiFeedbackController.java
  - src/main/java/com/ktb/ai/feedback/client/AiFeedbackClient.java
  - src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
  - src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
  - src/main/java/com/ktb/ai/feedback/service/AiFeedbackService.java
  - src/main/java/com/ktb/ai/feedback/service/impl/AiFeedbackServiceImpl.java
  - src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
  - src/main/java/com/ktb/ai/common/config/AiClientConfig.java

  ## 관련 Commit, Issue
 - #98 