### PR TITLE
Feat/#112 jwt nickname

### DIFF
--- a/src/main/java/com/ktb/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/ktb/auth/jwt/JwtProvider.java
@@ -26,11 +26,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-/**
- * JWT 토큰 생성 및 검증
- * - Access Token: userId + roles
- * - Refresh Token: userId + familyUuid
- */
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -38,6 +33,7 @@ public class JwtProvider {
 
     private static final String CLAIM_USER_ID = "userId";
     private static final String CLAIM_ROLES = "roles";
+    private static final String CLAIM_NICKNAME = "nickname";
     private static final String CLAIM_TYPE = "type";
     private static final String CLAIM_FAMILY_UUID = "familyUuid";
     private static final String TOKEN_TYPE_ACCESS = "ACCESS";
@@ -54,7 +50,7 @@ public class JwtProvider {
         );
     }
 
-    public String createAccessToken(Long userId, List<String> roles) {
+    public String createAccessToken(Long userId, List<String> roles, String nickname) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
 
@@ -63,6 +59,7 @@ public class JwtProvider {
                 .subject(String.valueOf(userId))
                 .claim(CLAIM_USER_ID, userId)
                 .claim(CLAIM_ROLES, roles)
+                .claim(CLAIM_NICKNAME, nickname)
                 .claim(CLAIM_TYPE, TOKEN_TYPE_ACCESS)
                 .issuer(jwtProperties.getIssuer())
                 .issuedAt(now)

--- a/src/test/java/com/ktb/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/TokenServiceTest.java
@@ -2,11 +2,13 @@ package com.ktb.auth.service;
 
 import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.TokenFamily;
+import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.exception.token.InvalidAccessTokenException;
 import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.jwt.JwtProperties;
 import com.ktb.auth.jwt.JwtProvider;
 import com.ktb.auth.repository.RefreshTokenRepository;
+import com.ktb.auth.repository.UserAccountRepository;
 import com.ktb.auth.service.impl.TokenServiceImpl;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -39,6 +41,9 @@ class TokenServiceTest {
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
 
+    @Mock
+    private UserAccountRepository userAccountRepository;
+
     @InjectMocks
     private TokenServiceImpl tokenService;
 
@@ -50,19 +55,24 @@ class TokenServiceTest {
     private static final String EXPIRED_TOKEN = "expired.token";
     private static final String TAMPERED_TOKEN = "tampered.token";
     private static final String TOKEN_HASH = "token-hash-sha256";
+    private static final String USER_NICKNAME = "테스트유저";
 
     @Test
     @DisplayName("Access Token 발급이 성공해야 한다")
     void issueAccessToken_ShouldSucceed() {
         // given
-        when(jwtProvider.createAccessToken(USER_ID, ROLES)).thenReturn(VALID_ACCESS_TOKEN);
+        UserAccount mockAccount = mock(UserAccount.class);
+        when(mockAccount.getNickname()).thenReturn(USER_NICKNAME);
+        when(userAccountRepository.findById(USER_ID)).thenReturn(Optional.of(mockAccount));
+        when(jwtProvider.createAccessToken(USER_ID, ROLES, USER_NICKNAME)).thenReturn(VALID_ACCESS_TOKEN);
 
         // when
         String accessToken = tokenService.issueAccessToken(USER_ID, ROLES);
 
         // then
         assertThat(accessToken).isEqualTo(VALID_ACCESS_TOKEN);
-        verify(jwtProvider).createAccessToken(USER_ID, ROLES);
+        verify(userAccountRepository).findById(USER_ID);
+        verify(jwtProvider).createAccessToken(USER_ID, ROLES, USER_NICKNAME);
     }
 
     @Test


### PR DESCRIPTION
## 요약
Access Token에 nickname claim을 포함해 프론트에서 사용자 닉네임을 복원할 수 있게 했습니다.

## 변경사항
- JwtProvider에 nickname claim 추가
- TokenServiceImpl에서 사용자 닉네임 조회 후 Access Token 발급
- TokenService 단위 테스트 보정

## 관련 이슈
- #112