### PR TITLE
feat:[#102]AWS SSM Parameter Store 적용

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,8 +1,8 @@
 # OAuth
 KAKAO_CLIENT_ID=your_kakao_client_id
 KAKAO_CLIENT_SECRET=your_kakao_client_secret
-KAKAO_REDIRECT_URI=https://q-feed.com/api/auth/oauth/kakao/callback
-OAUTH2_FRONTEND_REDIRECT_URI=https://q-feed.com/oauth2/redirect
+KAKAO_REDIRECT_URI=your_kakao_redirect_uri
+OAUTH2_FRONTEND_REDIRECT_URI=your_oauth2_frontend_redirect_uri
 
 # JWT Token
 JWT_SECRET=your_jwt_secret_key_at_least_256_bits
@@ -10,20 +10,24 @@ JWT_SECRET=your_jwt_secret_key_at_least_256_bits
 # AWS S3
 AWS_REGION=your_aws_region_name
 AWS_S3_BUCKET_NAME=your_aws_s3_bucket_name
-AWS_S3_CDN_URL_PREFIX=your_aws_s3_cd_url_prefix
-AWS_S3_KEY_PREFIX=your_aws_s3_key_prefix
-AWS_ACCESS_KEY_ID=your_aws_access_key_id_value
-AWS_SECRET_ACCESS_KEY=your_aws_secret_key_id_value
 AWS_S3_CDN_URL_PREFIX=your_aws_cdn_url_prefix
 AWS_S3_KEY_PREFIX=your_aws_key_prefix
+AWS_ACCESS_KEY_ID=your_aws_access_key_id_value
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key_value
+
+# AWS Parameter Store
+AWS_PARAMETER_STORE_ENABLED=your_parameter_store_enabled
+AWS_PARAMETER_STORE_PATH=your_parameter_store_path
 
 # AI Service URLs
-AI_FEEDBACK_BASE_URL=http://localhost:8000
-AI_STT_BASE_URL=http://localhost:8001
+AI_FEEDBACK_BASE_URL=your_ai_feedback_base_url
+AI_STT_BASE_URL=your_ai_stt_base_url
 
+# CORS
+CORS_ALLOWED_ORIGIN=your_cors_allowed_origin
 
 # DB
-SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/qfeed
-SPRING_DATASOURCE_DRIVER=org.postgresql.Driver
-SPRING_DATASOURCE_USERNAME=postgres
-SPRING_DATASOURCE_PASSWORD=postgres
+SPRING_DATASOURCE_URL=your_spring_datasource_url
+SPRING_DATASOURCE_DRIVER=your_spring_datasource_driver
+SPRING_DATASOURCE_USERNAME=your_spring_datasource_username
+SPRING_DATASOURCE_PASSWORD=your_spring_datasource_password

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.20.0')
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sts'
+    implementation 'software.amazon.awssdk:ssm'
 
     // ✅ 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/ktb/common/config/ParameterStoreEnvironmentPostProcessor.java
+++ b/src/main/java/com/ktb/common/config/ParameterStoreEnvironmentPostProcessor.java
@@ -1,0 +1,172 @@
+package com.ktb.common.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
+import software.amazon.awssdk.services.ssm.model.Parameter;
+
+/*
+ * AWS SSM Parameter Store에서 값을 읽어와 Spring Environment에 주입하는 부트스트랩 로더.
+ * - 실행 시점: ApplicationContext 생성 전(아주 초기 단계)
+ * - 목적: application.yaml의 ${ENV_VAR}가 SSM 값을 참조할 수 있게 함
+ */
+public class ParameterStoreEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+    private static final Logger log = LoggerFactory.getLogger(ParameterStoreEnvironmentPostProcessor.class);
+    private static final String SOURCE_NAME = "aws-parameter-store";
+    private static final String[] PARAMETER_STORE_PATH_KEYS = {
+        "AWS_PARAMETER_STORE_PATH",
+        "PARAMETER_STORE_PATH",
+        "aws.parameter-store.path"
+    };
+    private static final String[] PARAMETER_STORE_ENABLED_KEYS = {
+        "AWS_PARAMETER_STORE_ENABLED",
+        "PARAMETER_STORE_ENABLED",
+        "aws.parameter-store.enabled"
+    };
+    private static final String[] AWS_REGION_KEYS = {"AWS_REGION", "aws.region"};
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        /*
+         * Parameter Store를 사용할지 판단하기 위한 경로 설정.
+         * 이 값은 "아직" application.yaml 바인딩 전이므로,
+         * 시스템 환경변수/시스템 프로퍼티에 미리 존재해야 안정적으로 동작한다.
+         */
+        String path = resolve(environment, PARAMETER_STORE_PATH_KEYS);
+        if (!StringUtils.hasText(path)) {
+            // 경로가 없으면 Parameter Store를 사용하지 않는 것으로 보고 종료.
+            return;
+        }
+
+        boolean enabled = resolveBoolean(environment, true, PARAMETER_STORE_ENABLED_KEYS);
+        if (!enabled) {
+            // 명시적으로 비활성화된 경우 종료.
+            return;
+        }
+
+        // SSM 호출에 필요한 리전. 없으면 경고만 남기고 앱 기동은 계속한다.
+        String region = resolve(environment, AWS_REGION_KEYS);
+        if (!StringUtils.hasText(region)) {
+            log.warn("AWS Parameter Store enabled but region is missing. Set AWS_REGION or aws.region.");
+            return;
+        }
+
+        String normalizedPath = normalizePath(path);
+        Map<String, Object> values = new HashMap<>();
+
+        /*
+         * 기본 자격증명 체인 사용:
+         * - EC2: 인스턴스 프로파일(IAM Role)
+         * - 로컬: 환경변수 / AWS_PROFILE / ~/.aws/credentials
+         */
+        try (SsmClient ssm = SsmClient.builder()
+            .region(Region.of(region))
+            .credentialsProvider(DefaultCredentialsProvider.create())
+            .build()) {
+            String nextToken = null;
+            do {
+                // 지정한 경로 하위의 파라미터를 재귀적으로 조회 (SecureString 복호화 포함)
+                GetParametersByPathRequest request = GetParametersByPathRequest.builder()
+                    .path(normalizedPath)
+                    .recursive(true)
+                    .withDecryption(true)
+                    .nextToken(nextToken)
+                    .build();
+                var response = ssm.getParametersByPath(request);
+                for (Parameter parameter : response.parameters()) {
+                    // 예: "/qfeed/prod/jwt/secret" -> "jwt.secret"
+                    String key = toPropertyKey(normalizedPath, parameter.name());
+                    if (StringUtils.hasText(key)) {
+                        values.putIfAbsent(key, parameter.value());
+                    }
+                }
+                nextToken = response.nextToken();
+            } while (StringUtils.hasText(nextToken));
+        } catch (Exception ex) {
+            // 실패해도 서비스는 계속 기동 (Parameter Store는 옵션 소스로 취급)
+            log.warn("Failed to load AWS Parameter Store values from {}", normalizedPath, ex);
+            return;
+        }
+
+        if (!values.isEmpty()) {
+            // 시스템 환경변수보다 뒤에 붙여서 ENV > SSM > yaml 우선순위 유지
+            addPropertySource(environment.getPropertySources(), new MapPropertySource(SOURCE_NAME, values));
+            log.info("Loaded {} values from AWS Parameter Store path {}", values.size(), normalizedPath);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    private static String resolve(ConfigurableEnvironment environment, String... keys) {
+        // 여러 키를 순서대로 조회해서 가장 먼저 발견되는 값을 사용
+        for (String key : keys) {
+            String value = environment.getProperty(key);
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static boolean resolveBoolean(ConfigurableEnvironment environment, boolean defaultValue, String... keys) {
+        // 값이 없으면 defaultValue를 사용
+        String value = resolve(environment, keys);
+        if (!StringUtils.hasText(value)) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(value.trim());
+    }
+
+    private static String normalizePath(String path) {
+        // "/qfeed/prod/" 같은 입력을 "/qfeed/prod"로 정규화
+        String normalized = path.trim();
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        if (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static String toPropertyKey(String basePath, String fullName) {
+        // basePath 제거 후 "/" -> "." 치환
+        String key = fullName;
+        if (key.startsWith(basePath)) {
+            key = key.substring(basePath.length());
+        }
+        if (key.startsWith("/")) {
+            key = key.substring(1);
+        }
+        if (!StringUtils.hasText(key)) {
+            return "";
+        }
+        return key.replace("/", ".");
+    }
+
+    private static void addPropertySource(MutablePropertySources sources, MapPropertySource source) {
+        // 시스템 환경변수 뒤에 추가해 ENV 우선순위를 유지
+        if (sources.contains(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME)) {
+            sources.addAfter(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, source);
+        } else {
+            sources.addLast(source);
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.EnvironmentPostProcessor
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.EnvironmentPostProcessor
@@ -1,0 +1,1 @@
+com.ktb.common.config.ParameterStoreEnvironmentPostProcessor

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,10 +2,10 @@ spring:
   application:
     name: QFeed
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/qfeed}
-    driver-class-name: ${SPRING_DATASOURCE_DRIVER:org.postgresql.Driver}
-    username: ${SPRING_DATASOURCE_USERNAME:postgres}
-    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
+    url: ${SPRING_DATASOURCE_URL}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
 
   security:
     oauth2:
@@ -14,7 +14,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URI:https://q-feed.com/api/auth/oauth/kakao/callback}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: Kakao
@@ -37,14 +37,14 @@ spring:
     open-in-view: false
 
 oauth:
-  frontend-redirect-uri: ${OAUTH2_FRONTEND_REDIRECT_URI:https://q-feed.com/oauth2/redirect}
+  frontend-redirect-uri: ${OAUTH2_FRONTEND_REDIRECT_URI}
 
 cookie:
   secure: true
 
 cors:
   allowed-origins:
-    - ${CORS_ALLOWED_ORIGIN:https://q-feed.com}
+    - ${CORS_ALLOWED_ORIGIN}
 
 jwt:
   secret: ${JWT_SECRET}
@@ -53,10 +53,13 @@ jwt:
 
 aws:
   region: ${AWS_REGION:ap-northeast-2}
+  parameter-store:
+    enabled: ${AWS_PARAMETER_STORE_ENABLED}
+    path: ${AWS_PARAMETER_STORE_PATH:}
   s3:
-    bucket-name: ${AWS_S3_BUCKET_NAME:qfeed-files}
-    cdn-url-prefix: ${AWS_S3_CDN_URL_PREFIX:https://qfeed-dev-s3-audio.s3.ap-northeast-2.amazonaws.com}
-    key-prefix: ${AWS_S3_KEY_PREFIX:uploads}
+    bucket-name: ${AWS_S3_BUCKET_NAME}
+    cdn-url-prefix: ${AWS_S3_CDN_URL_PREFIX}
+    key-prefix: ${AWS_S3_KEY_PREFIX}
   credentials:
     access-key: ${AWS_ACCESS_KEY_ID}
     secret-key: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
 ## 요약

  SSM Parameter Store에서 환경변수를 읽어 부트스트랩 단계에 Spring Environment로 주입하도록 구성했습니다.
  EC2에서는 IAM Role 인증으로 SSM을 호출하며, 운영 환경에서는 경로 기반으로 값을 중앙 관리합니다.

  ———

  ## 변경사항 (애플리케이션 측)

  ### 기능/구조

  - Parameter Store 로더 추가
      - com.ktb.common.config.ParameterStoreEnvironmentPostProcessor
      - 부트 로드 전에 실행되는 클래스로, SSM 값을 Environment에 주입
  - SSM SDK 의존성 추가
      - software.amazon.awssdk:ssm 추가
  - Parameter Store 설정 키 추가
      - aws.parameter-store.enabled, aws.parameter-store.path
  - .env_template 정리
      - application.yaml 기반 필요 환경변수 가이드화

  ### 변경 파일

  - 추가
      - src/main/java/com/ktb/common/config/ParameterStoreEnvironmentPostProcessor.java
      - src/main/resources/META-INF/spring/org.springframework.boot.EnvironmentPostProcessor
  - 수정
      - build.gradle
      - src/main/resources/application.yaml
      - .env_template

  ———

  ## 클라우드 팀 설정 필요 사항

  ### 1) EC2 환경변수(필수)

  AWS_REGION=ap-northeast-2
  AWS_PARAMETER_STORE_PATH=/qfeed/prod
  AWS_PARAMETER_STORE_ENABLED=true

  ### 2) IAM Role 권한(필수)

  - ssm:GetParametersByPath
  - (SecureString 사용 시) kms:Decrypt

  ———

  ## 키 매핑 논의 필요 (중요)

  현재 로더는 **/경로/aaa/bbb → aaa.bbb**로 키를 변환합니다.
  application.yaml이 기대하는 키(예: JWT_SECRET)와
  SSM에 저장된 경로(예: /qfeed/prod/be/jwt-secret)가 일치하도록 규칙 합의가 필요합니다.