### PR TITLE
feat:[#118] Logback 로그 설정 적용

### DIFF
--- a/src/main/java/com/ktb/common/filter/TraceIdFilter.java
+++ b/src/main/java/com/ktb/common/filter/TraceIdFilter.java
@@ -1,0 +1,35 @@
+package com.ktb.common.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String traceId = UUID.randomUUID().toString().substring(0, 8);
+
+        MDC.put("traceId", traceId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,41 @@
+<configuration>
+    <property name="LOG_HOME" value="./logs" />
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+    <appender name="STDOUT"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <Pattern>
+                [%d{yyyy-MM-dd HH:mm:ss}] [%level] [%logger{0}] [%X{traceId}] %msg%n
+            </Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <file>${LOG_HOME}/app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>${LOG_HOME}/%d{yyyy/MM, aux}/app-%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 60 days worth of history, but at most 10GB -->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>60</maxHistory>
+            <totalSizeCap>10GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}] [%level] [%logger{0}] [%X{traceId}] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- LOG everything at INFO level -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
 ## 요약                                                                                                                                                                                                                                                                                                            
 요청별 고유 Trace ID를 부여하는 필터와 Logback 로그 설정을 적용하여 로그 추적성을 개선합니다.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
 ## 변경 사항                                                                                                                                                                                                                                                                                                       
 - `TraceIdFilter` 추가: 모든 HTTP 요청에 UUID 기반 8자리 traceId를 MDC에 설정하는 서블릿 필터                                                                                                                                                                                                                      
 - `logback.xml` 추가: 콘솔(STDOUT) 및 파일(FILE) 로그 appender 설정                                                                                                                                                                                                                                                
   - 로그 패턴: `[날짜] [레벨] [로거] [traceId] 메시지`                                                                                                                                                                                                                                                             
   - 파일 롤링 정책: 일별 롤링, 파일당 최대 10MB, 60일 보관, 총 10GB 제한
   
## 관련 Issue
- #118 