### PR TITLE
feat:[#101] 추천 질문 조회

### DIFF
--- a/src/main/java/com/ktb/question/repository/QuestionRepository.java
+++ b/src/main/java/com/ktb/question/repository/QuestionRepository.java
@@ -47,5 +47,18 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             Pageable pageable
     );
 
-    java.util.Optional<Question> findFirstByDeletedAtIsNullAndUseYnTrueOrderByIdDesc();
+    @Query(value = """
+             SELECT question_id
+             FROM question
+             WHERE question_id >= (
+                 SELECT floor(random() * (max(question_id) - min(question_id) + 1)) + min(question_id)
+                 FROM question
+                 WHERE use_yn = true AND deleted_at IS NULL 
+             )
+             AND use_yn = true
+             AND deleted_at IS NULL
+             ORDER BY question_id
+             LIMIT 1
+            """, nativeQuery = true)
+    java.util.Optional<Long> findRandomActiveId();
 }

--- a/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
@@ -83,9 +83,12 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionDetailResponse getDailyRecommendation() {
-        Question question = questionRepository
-                .findFirstByDeletedAtIsNullAndUseYnTrueOrderByIdDesc()
+        Long questionId = questionRepository.findRandomActiveId()
                 .orElseThrow(() -> new QuestionNotFoundException(0L));
+
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionNotFoundException(questionId));
+
         return toDetailResponse(question);
     }
 


### PR DESCRIPTION
 ## 요약    

추천 질문 조회를 ID 범위 점프 방식의 PostgreSQL 네이티브 쿼리로 변경하여 랜덤 1건 조회 성능을 개선합니다.

## 변경 사항

 - 기존 findFirstByDeletedAtIsNullAndUseYnTrueOrderByIdDesc() → findRandomActiveId() 네이티브 쿼리로 변경
   - ID 범위 내 랜덤 값을 생성하고 PK Index Scan으로 1건 조회 (O(N) → O(log N))
   - SELECT question_id만 조회하여 Index Only Scan 활용 (SELECT * anti-index pattern 회피)
 - getDailyRecommendation() 서비스 로직을 최신 질문 조회 → findById() 엔티티 조회 2단계로 변경

## 관련 Issue
 - #101