### PR TITLE
feat:[#86]프로필 페이지 내 학습 기록 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/answer/dto/AnswerListCursor.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerListCursor.java
@@ -1,0 +1,10 @@
+package com.ktb.answer.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record AnswerListCursor(
+        @JsonProperty("last_created_at") LocalDateTime lastCreatedAt,
+        @JsonProperty("last_answer_id") Long lastAnswerId
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
@@ -2,11 +2,13 @@ package com.ktb.answer.dto.request;
 
 import com.ktb.answer.domain.AnswerType;
 import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 
 /**
  * 답변 목록 조회 요청 DTO
@@ -14,34 +16,36 @@ import java.time.LocalDate;
 @Schema(description = "답변 목록 조회 요청")
 public record AnswerListRequest(
 
-        @Parameter(description = "답변 타입 필터", example = "PRACTICE_INTERVIEW")
-        @Schema(description = "답변 타입 (PRACTICE_INTERVIEW, REAL_INTERVIEW, PORTFOLIO_INTERVIEW)", example = "PRACTICE_INTERVIEW")
+        @Parameter(description = "답변 타입 필터 (선택)", example = "PRACTICE_INTERVIEW")
+        @Schema(description = "답변 타입 필터 (PRACTICE_INTERVIEW, REAL_INTERVIEW)", example = "PRACTICE_INTERVIEW")
         AnswerType type,
 
-        @Parameter(description = "질문 카테고리 필터", example = "OS")
-        @Schema(description = "질문 카테고리 (OS, NETWORK, DB, COMPUTER_ARCHITECTURE, ALGORITHM, DATA_STRUCTURE)", example = "OS")
+        @Parameter(description = "질문 카테고리 필터 (선택)", example = "OS")
+        @Schema(description = "질문 카테고리 필터 (OS, NETWORK, DB, COMPUTER_ARCHITECTURE, DATA_STRUCTURE_ALGORITHM)", example = "OS")
         QuestionCategory category,
 
-        @Parameter(description = "조회 시작 날짜 (YYYY-MM-DD)", example = "2026-01-01")
-        @Schema(description = "조회 시작 날짜", example = "2026-01-01", format = "date")
+        @Parameter(description = "질문 타입 필터 (선택, MVP: CS만 허용)", example = "CS")
+        @Schema(description = "질문 타입 필터 (CS, SYSTEM_DESIGN, PORTFOLIO). 현재는 CS만 지원", example = "CS")
+        QuestionType questionType,
+
+        @Parameter(description = "조회 시작 날짜 (YYYY-MM-DD, 미입력 시 dateTo 기준 1개월 전)", example = "2026-01-01")
+        @Schema(description = "조회 시작 날짜 (미입력 시 dateTo 기준 1개월 전)", example = "2026-01-01", format = "date")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate dateFrom,
 
-        @Parameter(description = "조회 종료 날짜 (YYYY-MM-DD)", example = "2026-01-31")
-        @Schema(description = "조회 종료 날짜", example = "2026-01-31", format = "date")
+        @Parameter(description = "조회 종료 날짜 (YYYY-MM-DD, 미입력 시 오늘)", example = "2026-01-31")
+        @Schema(description = "조회 종료 날짜 (미입력 시 오늘)", example = "2026-01-31", format = "date")
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate dateTo,
 
-        @Parameter(description = "페이지 크기 (1-50)", example = "10")
+        @Parameter(description = "페이지 크기 (1-50, 기본값 10)", example = "10")
         @Schema(description = "페이지 크기 (기본값: 10, 최대: 50)", example = "10", minimum = "1", maximum = "50")
         @Min(1) @Max(50)
         Integer limit,
 
-        @Parameter(description = "다음 페이지 커서 (Base64 인코딩)", example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
-        @Schema(description = "페이지네이션 커서 (이전 응답의 nextCursor 값)", example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
-        String cursor,
-
-        @Parameter(description = "확장 필드 (쉼표 구분: question,feedback)", example = "question,feedback")
-        @Schema(description = "응답에 포함할 확장 필드 (question: 질문 정보, feedback: 피드백 요약)", example = "question,feedback")
-        String expand
+        @Parameter(description = "다음 페이지 커서 (Base64 인코딩, 이전 응답의 nextCursor)", example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
+        @Schema(description = "페이지네이션 커서 (필터/정렬 조건은 첫 요청과 동일해야 함)", example = "eyJsYXN0X2NyZWF0ZWRfYXQiOiIyMDI2LTAxLTIyVDEwOjAwOjAwIiwibGFzdF9hbnN3ZXJfaWQiOjEwfQ==")
+        String cursor
 ) {
 
     private static final int DEFAULT_LIMIT = 10;

--- a/src/main/java/com/ktb/answer/dto/response/AnswerListResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/AnswerListResponse.java
@@ -25,13 +25,13 @@ public record AnswerListResponse(
             String type,
 
             @Schema(description = "답변 작성 시각", example = "2026-01-22T10:30:00")
-            String answeredAt,
+            String createdAt,
 
-            @Schema(description = "질문 정보 (expand=question 시 포함)")
-            QuestionInfo question,
+        @Schema(description = "질문 정보")
+        QuestionInfo question,
 
-            @Schema(description = "피드백 요약 정보 (expand=feedback 시 포함)")
-            FeedbackInfo feedback
+        @Schema(description = "피드백 요약 정보")
+        FeedbackInfo feedback
     ) {
     }
 
@@ -54,7 +54,7 @@ public record AnswerListResponse(
             boolean feedbackAvailable,
 
             @Schema(description = "AI 피드백 상태", example = "COMPLETED",
-                    allowableValues = {"PROCESSING", "COMPLETED", "FAILED"})
+                    allowableValues = {"PROCESSING", "COMPLETED", "FAILED", "FAILED_RETRYABLE", "NOT_AVAILABLE"})
             String aiFeedbackStatus
     ) {
     }

--- a/src/main/java/com/ktb/answer/exception/AnswerListInvalidInputException.java
+++ b/src/main/java/com/ktb/answer/exception/AnswerListInvalidInputException.java
@@ -1,0 +1,15 @@
+package com.ktb.answer.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AnswerListInvalidInputException extends BusinessException {
+
+    public AnswerListInvalidInputException(String message) {
+        super(ErrorCode.INVALID_INPUT, message);
+    }
+
+    public AnswerListInvalidInputException(String message, Throwable cause) {
+        super(ErrorCode.INVALID_INPUT, message, cause);
+    }
+}

--- a/src/main/java/com/ktb/answer/service/AnswerApplicationService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerApplicationService.java
@@ -6,6 +6,7 @@ import com.ktb.answer.dto.AnswerDetailResult;
 import com.ktb.answer.dto.AnswerSubmitCommand;
 import com.ktb.answer.dto.AnswerSubmitResult;
 import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.response.AnswerListResponse;
 import com.ktb.answer.exception.AnswerAccessDeniedException;
 import com.ktb.answer.exception.AnswerNotFoundException;
 import com.ktb.file.exception.FileAlreadyDeletedException;
@@ -14,9 +15,10 @@ import com.ktb.file.exception.FileNotFoundException;
 import com.ktb.file.exception.FileSizeExceededException;
 import com.ktb.file.exception.FileStorageMigrationException;
 import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
 import com.ktb.question.exception.QuestionDisabledException;
 import com.ktb.question.exception.QuestionNotFoundException;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,24 +32,22 @@ public interface AnswerApplicationService {
      * @param accountId       현재 사용자 ID
      * @param type            답변 타입 필터 (선택)
      * @param category        질문 카테고리 필터 (선택)
+     * @param questionType    질문 타입 필터 (선택)
      * @param dateFrom        시작 날짜 (선택)
      * @param dateTo          종료 날짜 (선택)
-     * @param cursorCreatedAt 커서 생성 시각 (페이지네이션)
-     * @param cursorAnswerId  커서 답변 ID (페이지네이션)
+     * @param cursor          페이지네이션 커서 (Base64)
      * @param limit           조회 개수
-     * @param expand          확장 필드 (question, feedback)
      * @return 답변 목록 (Slice)
      */
-    Slice<?> getList(
+    AnswerListResponse getList(
             Long accountId,
             AnswerType type,
             QuestionCategory category,
-            LocalDateTime dateFrom,
-            LocalDateTime dateTo,
-            LocalDateTime cursorCreatedAt,
-            Long cursorAnswerId,
-            int limit,
-            String expand
+            QuestionType questionType,
+            LocalDate dateFrom,
+            LocalDate dateTo,
+            String cursor,
+            Integer limit
     );
 
     /**


### PR DESCRIPTION
## 요약

  학습 기록 목록 조회 API를 프론트 요구사항(무한 스크롤, 기간/카테고리 필터)에 맞춰 구현했습니다.
  커서 기반 페이지네이션을 적용하고, 기본 조회 기간(최근 1개월)과 limit 기본값/검증을 서비스 레이어에서 일관되게 처리했습니다.
  커서를 Base64로 인코딩/디코딩하는 과정에서 커서가 선택적으로 전달되도록 설계했고, 그로 인해 PostgreSQL 파라미터 타입 추론 오류가 발생할 수 있었으나 쿼리 구조를 개선하여 해결했습니다.

  ## 변경사항

  ### 기능 추가/변경 (목적 중심)

  - 학습 기록 목록 조회 API 구현
      - GET /api/answers
      - 응답 필드: 답변 모드, 문제 카테고리, 질문 내용, 답변 생성일
  - 필터/정렬/기본값 처리
      - 필터: 답변 타입 / 질문 카테고리 / 질문 타입 / 기간
      - 기본 기간: dateTo 미입력 시 오늘, dateFrom 미입력 시 1개월 전
      - 정렬: createdAt DESC, id DESC
  - 커서 기반 페이지네이션
      - createdAt + id 복합 커서 사용 (중복/누락 방지)
      - Base64 인코딩 커서(nextCursor) 제공 → 다음 요청에 cursor로 전달
      - 커서가 없는 경우(첫 페이지)도 동일 API로 조회 가능
  - 입력 검증 강화
      - limit 기본값(10) + 범위(1~50) 검증
      - questionType은 MVP에서 CS만 허용
      - 잘못된 커서/바인딩 실패는 400으로 처리
  - PostgreSQL 쿼리 안정화
      - (:param IS NULL OR ...) 패턴 제거
      - enum 필터는 COALESCE(:param, col) 방식 적용
      - 날짜 필터는 서비스에서 항상 공급하여 직접 비교
  - 문서/Swagger 최신화
      - query param + 기본값/제약 조건 반영
      - expand 제거 반영

  ## 변경 파일 (상세)

  ### Added

  - src/main/java/com/ktb/answer/dto/AnswerListCursor.java
  - src/main/java/com/ktb/common/exception/InvalidInputException.java

  ### Modified

  - src/main/java/com/ktb/answer/controller/AnswerController.java
  - src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
  - src/main/java/com/ktb/answer/dto/response/AnswerListResponse.java
  - src/main/java/com/ktb/answer/repository/AnswerRepository.java
  - src/main/java/com/ktb/answer/service/AnswerApplicationService.java
  - src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
  - src/main/java/com/ktb/common/exception/GlobalExceptionHandler.java
  - docs/api-docs.md

  ### 목적/의도

  - UX 최적화: 무한 스크롤 기반 화면에 맞춘 커서 페이지네이션 제공
  - 정합성 확보: 동일 시간대 데이터 중복/누락 방지를 위해 createdAt + id 복합 커서 채택
  - MVP 스코프 유지: questionType 필터는 CS만 허용
  - 운영 안정성: 기본 기간/limit 값을 서비스에서 일관 처리해 예측 가능한 응답 제공
  - 커서 Base64 인코딩 도입 의도
      - createdAt + id 복합 커서를 URL 파라미터로 안전하게 전달하기 위해 Base64로 인코딩
      - 커서는 “다음 페이지 요청 시에만” 필요하므로 선택적으로 사용하도록 설계
      - 첫 페이지는 cursor 없이 동일 API로 조회 가능
  - DB 안정성
      - 문제: 커서를 선택적으로 전달할 수 있도록 하면서 JPQL에서 (:param IS NULL OR col = :param) 패턴이 빈번히 등장
        → null 바인딩 시 Postgres가 파라미터 타입을 추론하지 못해 `could not determine data type of parameter $N` 오류 발생
      - 해결: enum 필터는 COALESCE(:param, col) 방식으로 전환하여 컬럼 타입을 기준으로 비교
        날짜 필터는 서비스에서 항상 값(기본값 포함)을 공급하여 >=, <= 직접 비교만 사용
      - 효과: 커서 유무와 무관하게 타입 추론 오류 제거, 쿼리 실행 안정성 확보

  ## 관련 Commit, Issue

  - #86 