### PR TITLE
feat:[#125] 학습 기록 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/answer/dto/CategoryCount.java
+++ b/src/main/java/com/ktb/answer/dto/CategoryCount.java
@@ -1,0 +1,9 @@
+package com.ktb.answer.dto;
+
+import com.ktb.question.domain.QuestionCategory;
+
+public record CategoryCount(
+        QuestionCategory category,
+        long count
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/TypeCount.java
+++ b/src/main/java/com/ktb/answer/dto/TypeCount.java
@@ -1,0 +1,9 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.domain.AnswerType;
+
+public record TypeCount(
+        AnswerType type,
+        long count
+) {
+}

--- a/src/main/java/com/ktb/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/ktb/answer/repository/AnswerRepository.java
@@ -2,9 +2,12 @@ package com.ktb.answer.repository;
 
 import com.ktb.answer.domain.Answer;
 import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.CategoryCount;
+import com.ktb.answer.dto.TypeCount;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -96,4 +99,35 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     //         @Param("sessionId") String sessionId,
     //         @Param("questionId") Long questionId
     // );
+
+    @Query("""
+            SELECT new com.ktb.answer.dto.TypeCount(a.type, COUNT(a))
+            FROM Answer a
+            WHERE a.deletedAt IS NULL
+            AND a.account.id = :accountId
+            AND a.type IN :types
+            GROUP BY a.type
+            """)
+    List<TypeCount> countByAccountIdAndTypeIn(
+            @Param("accountId") Long accountId,
+            @Param("types") List<AnswerType> types
+    );
+
+    @Query("""
+            SELECT new com.ktb.answer.dto.CategoryCount(q.category, COUNT(a))
+            FROM Answer a
+            JOIN a.question q
+            WHERE a.deletedAt IS NULL
+            AND a.account.id = :accountId
+            GROUP BY q.category
+            """)
+    List<CategoryCount> countByAccountIdGroupByCategory(@Param("accountId") Long accountId);
+
+    @Query("""
+            SELECT a.createdAt FROM Answer a
+            WHERE a.deletedAt IS NULL
+            AND a.account.id = :accountId
+            ORDER BY a.createdAt DESC
+            """)
+    List<LocalDateTime> findCreatedAtByAccountIdOrderByCreatedAtDesc(@Param("accountId") Long accountId);
 }

--- a/src/main/java/com/ktb/answer/service/AnswerStatisticsService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerStatisticsService.java
@@ -1,0 +1,17 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.TypeCount;
+import com.ktb.user.dto.response.CategoryDistributionResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface AnswerStatisticsService {
+
+    List<TypeCount> getTypeCounts(Long accountId, List<AnswerType> types);
+
+    List<CategoryDistributionResponse> getCategoryDistribution(Long accountId);
+
+    int getStreakDays(Long accountId);
+}

--- a/src/main/java/com/ktb/answer/service/impl/AnswerStatisticsServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerStatisticsServiceImpl.java
@@ -1,0 +1,52 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.CategoryCount;
+import com.ktb.answer.dto.TypeCount;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AnswerStatisticsService;
+import com.ktb.user.dto.response.CategoryDistributionResponse;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerStatisticsServiceImpl implements AnswerStatisticsService {
+
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public List<TypeCount> getTypeCounts(Long accountId, List<AnswerType> types) {
+        return answerRepository.countByAccountIdAndTypeIn(accountId, types);
+    }
+
+    @Override
+    public List<CategoryDistributionResponse> getCategoryDistribution(Long accountId) {
+        List<CategoryCount> rows = answerRepository.countByAccountIdGroupByCategory(accountId);
+
+        return rows.stream()
+                .map(row -> new CategoryDistributionResponse(
+                        row.category().getCategory(),
+                        row.count()
+                ))
+                .toList();
+    }
+
+    @Override
+    public int getStreakDays(Long accountId) {
+        List<LocalDateTime> createdAtList = answerRepository.findCreatedAtByAccountIdOrderByCreatedAtDesc(accountId);
+        if (createdAtList.isEmpty()) {
+            return 0;
+        }
+
+        List<LocalDate> dates = createdAtList.stream()
+                .map(LocalDateTime::toLocalDate)
+                .distinct()
+                .toList();
+
+        return dates.size();
+    }
+}

--- a/src/main/java/com/ktb/user/controller/UserLearningController.java
+++ b/src/main/java/com/ktb/user/controller/UserLearningController.java
@@ -1,0 +1,51 @@
+package com.ktb.user.controller;
+
+import com.ktb.auth.security.adapter.SecurityUserAccount;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.user.dto.response.LearningStatsResponse;
+import com.ktb.user.service.LearningRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자 학습 API", description = "내 학습 통계 조회 API")
+@RestController
+@RequestMapping("/api/users/me")
+@RequiredArgsConstructor
+public class UserLearningController {
+
+    private static final String MESSAGE_STATS_RETRIEVED = "stats_retrieval_success";
+    private static final String MESSAGE_UNAUTHORIZED = "unauthorized_request";
+
+    private final LearningRecordService learningRecordService;
+
+    @Operation(summary = "학습 통계 요약 조회", description = "내 학습 통계 요약 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
+    @GetMapping("/stats")
+    public ResponseEntity<@NonNull ApiResponse<LearningStatsResponse>> getStats(
+            @AuthenticationPrincipal SecurityUserAccount principal
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(401)
+                    .body(new ApiResponse<>(MESSAGE_UNAUTHORIZED, null));
+        }
+
+        Long accountId = principal.getAccount().getId();
+        LearningStatsResponse response = learningRecordService.getStats(accountId);
+
+        return ResponseEntity.ok(new ApiResponse<>(MESSAGE_STATS_RETRIEVED, response));
+    }
+}

--- a/src/main/java/com/ktb/user/dto/response/CategoryDistributionResponse.java
+++ b/src/main/java/com/ktb/user/dto/response/CategoryDistributionResponse.java
@@ -1,0 +1,16 @@
+package com.ktb.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리별 학습 분포")
+public record CategoryDistributionResponse(
+        @JsonProperty("category")
+        @Schema(description = "카테고리명", example = "OS", requiredMode = Schema.RequiredMode.REQUIRED)
+        String category,
+
+        @JsonProperty("count")
+        @Schema(description = "카테고리별 학습 횟수", example = "15", requiredMode = Schema.RequiredMode.REQUIRED)
+        long count
+) {
+}

--- a/src/main/java/com/ktb/user/dto/response/LearningStatsResponse.java
+++ b/src/main/java/com/ktb/user/dto/response/LearningStatsResponse.java
@@ -1,0 +1,29 @@
+package com.ktb.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "학습 통계 요약")
+public record LearningStatsResponse(
+        @JsonProperty("practice_mode_count")
+        @Schema(description = "연습 모드 학습 횟수", example = "45", requiredMode = Schema.RequiredMode.REQUIRED)
+        long practiceModeCount,
+
+        @JsonProperty("real_interview_count")
+        @Schema(description = "실전 모드 학습 횟수", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
+        long realInterviewCount,
+
+        @JsonProperty("category_distribution")
+        @Schema(description = "카테고리별 학습 분포", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<CategoryDistributionResponse> categoryDistribution,
+
+        @JsonProperty("distinct_days")
+        @Schema(description = "총 학습 일수", example = "7", requiredMode = Schema.RequiredMode.REQUIRED)
+        int streakDays,
+
+        @JsonProperty("total_questions_answered")
+        @Schema(description = "총 답변 수", example = "53", requiredMode = Schema.RequiredMode.REQUIRED)
+        long totalQuestionsAnswered
+) {
+}

--- a/src/main/java/com/ktb/user/service/LearningRecordService.java
+++ b/src/main/java/com/ktb/user/service/LearningRecordService.java
@@ -1,0 +1,8 @@
+package com.ktb.user.service;
+
+import com.ktb.user.dto.response.LearningStatsResponse;
+
+public interface LearningRecordService {
+    LearningStatsResponse getStats(Long accountId);
+
+}

--- a/src/main/java/com/ktb/user/service/impl/LearningRecordServiceImpl.java
+++ b/src/main/java/com/ktb/user/service/impl/LearningRecordServiceImpl.java
@@ -1,0 +1,51 @@
+package com.ktb.user.service.impl;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.user.dto.response.CategoryDistributionResponse;
+import com.ktb.user.dto.response.LearningStatsResponse;
+import com.ktb.answer.service.AnswerStatisticsService;
+import com.ktb.answer.dto.TypeCount;
+import com.ktb.user.service.LearningRecordService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LearningRecordServiceImpl implements LearningRecordService {
+
+    private final AnswerStatisticsService answerStatisticsService;
+
+    @Override
+    public LearningStatsResponse getStats(Long accountId) {
+        List<TypeCount> typeCounts = answerStatisticsService.getTypeCounts(
+                accountId,
+                List.of(AnswerType.PRACTICE_INTERVIEW, AnswerType.REAL_INTERVIEW)
+        );
+
+
+        long practiceModeCount = getTypeCount(typeCounts, AnswerType.PRACTICE_INTERVIEW);
+        long realInterviewCount = getTypeCount(typeCounts, AnswerType.REAL_INTERVIEW);
+
+        long totalQuestionsAnswered = practiceModeCount + realInterviewCount;
+
+        List<CategoryDistributionResponse> categoryDistribution = answerStatisticsService.getCategoryDistribution(accountId);
+        int streakDays = answerStatisticsService.getStreakDays(accountId);
+
+        return new LearningStatsResponse(
+                practiceModeCount,
+                realInterviewCount,
+                categoryDistribution,
+                streakDays,
+                totalQuestionsAnswered
+        );
+    }
+
+    private long getTypeCount(List<TypeCount> rows, AnswerType type) {
+        return rows.stream()
+                .filter(row -> row.type() == type)
+                .mapToLong(TypeCount::count)
+                .findFirst()
+                .orElse(0L);
+    }
+}


### PR DESCRIPTION
 ## 요약
  - 학습 기록 통계 조회 API 구현 (`GET /api/users/me/learning/stats`) 
  - 통계 메서드를 `AnswerStatisticsService`로 생성 (ISP/SRP)
  - 연습 모드/실전 모드 답변 수, 카테고리 분포, 학습 일수 통계 제공

 ## 변경 사항
  - `UserLearningController` — 학습 통계 조회 엔드포인트
  - `LearningRecordService` / `LearningRecordServiceImpl` — 통계 집계 서비스
  - `AnswerStatisticsService` / `AnswerStatisticsServiceImpl` — 답변 통계 전용 서비스 (분리)
  - `AnswerRepository` — 통계 쿼리 메서드 추가
  - `CategoryCount`, `TypeCount`, `LearningStatsResponse`, `CategoryDistributionResponse` — DTO
 ## 관련 이슈
  - Closes #125