### PR TITLE
feat:[#125] 학습 기록 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/answer/dto/DailyCount.java
+++ b/src/main/java/com/ktb/answer/dto/DailyCount.java
@@ -1,0 +1,9 @@
+package com.ktb.answer.dto;
+
+import java.time.LocalDate;
+
+public record DailyCount(
+        LocalDate date,
+        long count
+) {
+}

--- a/src/main/java/com/ktb/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/ktb/answer/repository/AnswerRepository.java
@@ -4,6 +4,7 @@ import com.ktb.answer.domain.Answer;
 import com.ktb.answer.domain.AnswerType;
 import com.ktb.answer.dto.CategoryCount;
 import com.ktb.answer.dto.TypeCount;
+import com.ktb.answer.dto.DailyCount;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import java.time.LocalDateTime;
@@ -130,4 +131,19 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             ORDER BY a.createdAt DESC
             """)
     List<LocalDateTime> findCreatedAtByAccountIdOrderByCreatedAtDesc(@Param("accountId") Long accountId);
+
+    @Query("""
+            SELECT new com.ktb.answer.dto.DailyCount(CAST(a.createdAt AS LocalDate), COUNT(a))
+            FROM Answer a
+            WHERE a.deletedAt IS NULL
+            AND a.account.id = :accountId
+            AND a.createdAt >= :startDateTime
+            AND a.createdAt < :endDateTime
+            GROUP BY CAST(a.createdAt AS LocalDate)
+            """)
+    List<DailyCount> countByAccountIdGroupByDate(
+            @Param("accountId") Long accountId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
 }

--- a/src/main/java/com/ktb/answer/service/AnswerStatisticsService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerStatisticsService.java
@@ -1,8 +1,10 @@
 package com.ktb.answer.service;
 
 import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.DailyCount;
 import com.ktb.answer.dto.TypeCount;
 import com.ktb.user.dto.response.CategoryDistributionResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -14,4 +16,6 @@ public interface AnswerStatisticsService {
     List<CategoryDistributionResponse> getCategoryDistribution(Long accountId);
 
     int getStreakDays(Long accountId);
+
+    List<DailyCount> getDailyCounts(Long accountId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/ktb/answer/service/impl/AnswerStatisticsServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerStatisticsServiceImpl.java
@@ -2,6 +2,7 @@ package com.ktb.answer.service.impl;
 
 import com.ktb.answer.domain.AnswerType;
 import com.ktb.answer.dto.CategoryCount;
+import com.ktb.answer.dto.DailyCount;
 import com.ktb.answer.dto.TypeCount;
 import com.ktb.answer.repository.AnswerRepository;
 import com.ktb.answer.service.AnswerStatisticsService;
@@ -48,5 +49,10 @@ public class AnswerStatisticsServiceImpl implements AnswerStatisticsService {
                 .toList();
 
         return dates.size();
+    }
+
+    @Override
+    public List<DailyCount> getDailyCounts(Long accountId, LocalDateTime start, LocalDateTime end) {
+        return answerRepository.countByAccountIdGroupByDate(accountId, start, end);
     }
 }

--- a/src/main/java/com/ktb/user/controller/UserLearningController.java
+++ b/src/main/java/com/ktb/user/controller/UserLearningController.java
@@ -3,6 +3,7 @@ package com.ktb.user.controller;
 import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.common.dto.ApiResponse;
 import com.ktb.user.dto.response.LearningStatsResponse;
+import com.ktb.user.dto.response.WeeklyStatsResponse;
 import com.ktb.user.service.LearningRecordService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserLearningController {
 
     private static final String MESSAGE_STATS_RETRIEVED = "stats_retrieval_success";
+    private static final String MESSAGE_WEEKLY_STATS_RETRIEVED = "weekly_stats_retrieval_success";
     private static final String MESSAGE_UNAUTHORIZED = "unauthorized_request";
 
     private final LearningRecordService learningRecordService;
@@ -47,5 +49,26 @@ public class UserLearningController {
         LearningStatsResponse response = learningRecordService.getStats(accountId);
 
         return ResponseEntity.ok(new ApiResponse<>(MESSAGE_STATS_RETRIEVED, response));
+    }
+
+    @Operation(summary = "주간 학습 통계 조회", description = "이번 주(월~일) 일별 학습 통계를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
+    })
+    @GetMapping("/stats/weekly")
+    public ResponseEntity<@NonNull ApiResponse<WeeklyStatsResponse>> getWeeklyStats(
+            @AuthenticationPrincipal SecurityUserAccount principal
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(401)
+                    .body(new ApiResponse<>(MESSAGE_UNAUTHORIZED, null));
+        }
+
+        Long accountId = principal.getAccount().getId();
+        WeeklyStatsResponse response = learningRecordService.getWeeklyStats(accountId);
+
+        return ResponseEntity.ok(new ApiResponse<>(MESSAGE_WEEKLY_STATS_RETRIEVED, response));
     }
 }

--- a/src/main/java/com/ktb/user/dto/response/WeeklyStatsResponse.java
+++ b/src/main/java/com/ktb/user/dto/response/WeeklyStatsResponse.java
@@ -1,0 +1,41 @@
+package com.ktb.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "주간 학습 통계")
+public record WeeklyStatsResponse(
+        @JsonProperty("week_summary")
+        @Schema(description = "주간 요약 문구", example = "이번주 연습 12회", requiredMode = Schema.RequiredMode.REQUIRED)
+        String weekSummary,
+
+        @JsonProperty("daily_stats")
+        @Schema(description = "일별 학습 통계 (월~일)", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<DailyStatEntry> dailyStats,
+
+        @JsonProperty("max_value_for_chart")
+        @Schema(description = "차트 Y축 최댓값 (최소 3)", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+        long maxValueForChart,
+
+        @JsonProperty("total_this_week")
+        @Schema(description = "이번 주 총 학습 횟수", example = "12", requiredMode = Schema.RequiredMode.REQUIRED)
+        long totalThisWeek
+) {
+
+    @Schema(description = "일별 학습 통계 항목")
+    public record DailyStatEntry(
+            @Schema(description = "날짜", example = "2025-01-20", requiredMode = Schema.RequiredMode.REQUIRED)
+            LocalDate date,
+
+            @JsonProperty("day_of_week")
+            @Schema(description = "요일 (한글)", example = "월", requiredMode = Schema.RequiredMode.REQUIRED)
+            String dayOfWeek,
+
+            @JsonProperty("real_count")
+            @Schema(description = "해당 일 학습 횟수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+            long realCount
+    ) {
+    }
+}

--- a/src/main/java/com/ktb/user/service/LearningRecordService.java
+++ b/src/main/java/com/ktb/user/service/LearningRecordService.java
@@ -1,8 +1,10 @@
 package com.ktb.user.service;
 
 import com.ktb.user.dto.response.LearningStatsResponse;
+import com.ktb.user.dto.response.WeeklyStatsResponse;
 
 public interface LearningRecordService {
     LearningStatsResponse getStats(Long accountId);
 
+    WeeklyStatsResponse getWeeklyStats(Long accountId);
 }

--- a/src/main/java/com/ktb/user/service/impl/LearningRecordServiceImpl.java
+++ b/src/main/java/com/ktb/user/service/impl/LearningRecordServiceImpl.java
@@ -1,12 +1,22 @@
 package com.ktb.user.service.impl;
 
 import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.DailyCount;
 import com.ktb.user.dto.response.CategoryDistributionResponse;
 import com.ktb.user.dto.response.LearningStatsResponse;
+import com.ktb.user.dto.response.WeeklyStatsResponse;
+import com.ktb.user.dto.response.WeeklyStatsResponse.DailyStatEntry;
 import com.ktb.answer.service.AnswerStatisticsService;
 import com.ktb.answer.dto.TypeCount;
 import com.ktb.user.service.LearningRecordService;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -39,6 +49,40 @@ public class LearningRecordServiceImpl implements LearningRecordService {
                 streakDays,
                 totalQuestionsAnswered
         );
+    }
+
+    @Override
+    public WeeklyStatsResponse getWeeklyStats(Long accountId) {
+        LocalDate today = LocalDate.now();
+        LocalDate monday = today.with(DayOfWeek.MONDAY);
+        LocalDateTime start = monday.atStartOfDay();
+        LocalDateTime end = monday.plusDays(7).atStartOfDay();
+
+        List<DailyCount> dailyCounts = answerStatisticsService.getDailyCounts(accountId, start, end);
+
+        Map<LocalDate, Long> countMap = dailyCounts.stream()
+                .collect(Collectors.toMap(DailyCount::date, DailyCount::count));
+
+        String[] koreanDays = {"월", "화", "수", "목", "금", "토", "일"};
+
+        List<DailyStatEntry> dailyStats = new ArrayList<>();
+        long total = 0;
+        long max = 0;
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = monday.plusDays(i);
+            long count = countMap.getOrDefault(date, 0L);
+            dailyStats.add(new DailyStatEntry(date, koreanDays[i], count));
+            total += count;
+            if (count > max) {
+                max = count;
+            }
+        }
+
+        long maxValueForChart = Math.max(max, 3);
+        String weekSummary = "이번주 연습 " + total + "회";
+
+        return new WeeklyStatsResponse(weekSummary, dailyStats, maxValueForChart, total);
     }
 
     private long getTypeCount(List<TypeCount> rows, AnswerType type) {


### PR DESCRIPTION
## 요약
 - `GET /api/users/me/stats/weekly` 엔드포인트 추가
 - 이번 주(월~일) 일별 학습 횟수, 주간 총합, 차트 최댓값을 반환
 - 기존 통계 서비스 레이어(AnswerStatisticsService)를 확장하여 일별 집계 쿼리 추가
                                                                                                                                                                                                                                                                                                                    
 ## 변경 사항
 ### 신규 파일
 | 파일 | 설명 |
 |------|------| 
 | `DailyCount.java` | 일별 카운트 JPQL 프로젝션 DTO |
 | `WeeklyStatsResponse.java` | 주간 통계 응답 DTO (DailyStatEntry 내부 record 포함) |
                                                                                                                                                                                                                                                                                                                    
 ### 수정 파일
 | 파일 | 변경 내용 |
 |------|----------|
 | `AnswerRepository` | `countByAccountIdGroupByDate()` 쿼리 추가 |
 | `AnswerStatisticsService` | `getDailyCounts()` 인터페이스 메서드 추가 |
 | `AnswerStatisticsServiceImpl` | `getDailyCounts()` 구현 (pass-through) |
 | `LearningRecordService` | `getWeeklyStats()` 인터페이스 메서드 추가 |
 | `LearningRecordServiceImpl` | 주 경계 계산, gap-fill, 한글 요일 매핑 핵심 로직 |
 | `UserLearningController` | `GET /stats/weekly` 엔드포인트 추가 |