### PR TITLE
feat:[137] 질문 카테고리, 목록 API 반영

### DIFF
--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -4,12 +4,14 @@ import com.ktb.common.dto.ApiResponse;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import com.ktb.question.dto.QuestionCreateRequest;
+import com.ktb.question.dto.QuestionCategoryListResponse;
 import com.ktb.question.dto.QuestionDetailResponse;
 import com.ktb.question.dto.QuestionKeywordCheckRequest;
 import com.ktb.question.dto.QuestionKeywordCheckResponse;
 import com.ktb.question.dto.QuestionKeywordListResponse;
 import com.ktb.question.dto.QuestionListResponse;
 import com.ktb.question.dto.QuestionSearchResponse;
+import com.ktb.question.dto.QuestionTypeListResponse;
 import com.ktb.question.dto.QuestionUpdateRequest;
 import com.ktb.question.service.QuestionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -62,6 +64,32 @@ public class QuestionController {
     ) {
         QuestionListResponse result = questionService.getQuestions(category, type, cursor, size);
         return ResponseEntity.ok(new ApiResponse<>("questions_retrieval_success", result));
+    }
+
+    /**
+     * 질문 카테고리 목록 조회
+     */
+    @GetMapping("/categories")
+    @Operation(summary = "질문 카테고리 목록 조회", description = "질문 카테고리 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    public ResponseEntity<ApiResponse<QuestionCategoryListResponse>> getQuestionCategories() {
+        QuestionCategoryListResponse result = questionService.getQuestionCategories();
+        return ResponseEntity.ok(new ApiResponse<>("question_categories_retrieval_success", result));
+    }
+
+    /**
+     * 질문 타입 목록 조회
+     */
+    @GetMapping("/types")
+    @Operation(summary = "질문 타입 목록 조회", description = "질문 타입 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    public ResponseEntity<ApiResponse<QuestionTypeListResponse>> getQuestionTypes() {
+        QuestionTypeListResponse result = questionService.getQuestionTypes();
+        return ResponseEntity.ok(new ApiResponse<>("question_types_retrieval_success", result));
     }
 
     /**

--- a/src/main/java/com/ktb/question/domain/QuestionType.java
+++ b/src/main/java/com/ktb/question/domain/QuestionType.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 public enum QuestionType {
     CS("CS"),
-    SYSTEM_DESIGN("SYSTEM_DESIGN"),
-    PORTFOLIO("PORTFOLIO");
+    SYSTEM_DESIGN("시스템 디자인"),
+    PORTFOLIO("개인화");
 
     private final String type;
 

--- a/src/main/java/com/ktb/question/dto/QuestionCategoryListResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionCategoryListResponse.java
@@ -1,0 +1,11 @@
+package com.ktb.question.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(description = "질문 카테고리 목록 응답")
+public record QuestionCategoryListResponse(
+        @Schema(description = "질문 카테고리 맵 (key: enum name, value: label)")
+        Map<String, String> categories
+) {
+}

--- a/src/main/java/com/ktb/question/dto/QuestionTypeListResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionTypeListResponse.java
@@ -1,0 +1,11 @@
+package com.ktb.question.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(description = "질문 타입 목록 응답")
+public record QuestionTypeListResponse(
+        @Schema(description = "질문 타입 맵 (key: enum name, value: label)")
+        Map<String, String> types
+) {
+}

--- a/src/main/java/com/ktb/question/service/QuestionService.java
+++ b/src/main/java/com/ktb/question/service/QuestionService.java
@@ -23,4 +23,8 @@ public interface QuestionService {
     QuestionKeywordListResponse getQuestionKeywords(Long questionId);
 
     QuestionKeywordCheckResponse checkQuestionKeywords(Long questionId, java.util.List<String> keywords);
+
+    QuestionCategoryListResponse getQuestionCategories();
+
+    QuestionTypeListResponse getQuestionTypes();
 }

--- a/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
@@ -10,6 +10,7 @@ import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import com.ktb.question.dto.KeywordMatchResponse;
 import com.ktb.question.dto.PaginationResponse;
+import com.ktb.question.dto.QuestionCategoryListResponse;
 import com.ktb.question.dto.QuestionCreateRequest;
 import com.ktb.question.dto.QuestionDetailResponse;
 import com.ktb.question.dto.QuestionKeywordCheckResponse;
@@ -17,6 +18,7 @@ import com.ktb.question.dto.QuestionKeywordListResponse;
 import com.ktb.question.dto.QuestionListResponse;
 import com.ktb.question.dto.QuestionSearchResponse;
 import com.ktb.question.dto.QuestionSummaryResponse;
+import com.ktb.question.dto.QuestionTypeListResponse;
 import com.ktb.question.dto.QuestionUpdateRequest;
 import com.ktb.question.exception.QuestionNotFoundException;
 import com.ktb.question.exception.SearchKeywordTooShortException;
@@ -24,6 +26,8 @@ import com.ktb.question.repository.QuestionRepository;
 import com.ktb.question.service.QuestionService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -165,6 +169,30 @@ public class QuestionServiceImpl implements QuestionService {
                 ))
                 .toList();
         return new QuestionKeywordCheckResponse(results);
+    }
+
+    @Override
+    public QuestionCategoryListResponse getQuestionCategories() {
+        Map<String, String> categories = Arrays.stream(QuestionCategory.values())
+                .collect(Collectors.toMap(
+                        QuestionCategory::name,
+                        QuestionCategory::getCategory,
+                        (existing, ignored) -> existing,
+                        LinkedHashMap::new
+                ));
+        return new QuestionCategoryListResponse(categories);
+    }
+
+    @Override
+    public QuestionTypeListResponse getQuestionTypes() {
+        Map<String, String> types = Arrays.stream(QuestionType.values())
+                .collect(Collectors.toMap(
+                        QuestionType::name,
+                        QuestionType::getType,
+                        (existing, ignored) -> existing,
+                        LinkedHashMap::new
+                ));
+        return new QuestionTypeListResponse(types);
     }
 
     private void validateKeyword(String keyword) {


### PR DESCRIPTION
## 요약

  질문 카테고리/타입 목록을 프론트에서 바로 Map으로 사용할 수 있도록 조회 API를 추가했습니다.
  Enum 전체를 key-value 형태로 내려주어 클라이언트에서 별도 매핑 로직 없이 사용 가능하도록 했고, 문서/Swagger도 함께 갱신했습니다.

  ## 변경사항

  ### 기능 추가/변경 (목적 중심)

  - 질문 카테고리 목록 조회 API 추가
      - GET /api/questions/categories
      - 응답: categories Map (key: enum name, value: label)
  - 질문 타입 목록 조회 API 추가
      - GET /api/questions/types
      - 응답: types Map (key: enum name, value: label)

  ## 변경 파일 (상세)

  ### Added

  - src/main/java/com/ktb/question/dto/QuestionCategoryListResponse.java
  - src/main/java/com/ktb/question/dto/QuestionTypeListResponse.java

  ### Modified

  - src/main/java/com/ktb/question/controller/QuestionController.java
  - src/main/java/com/ktb/question/service/QuestionService.java
  - src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java

  ## 관련 Commit, Issue

  - #137 

  ### 목적/의도

  - 프론트 편의성: key-value 형태로 내려줘서 클라이언트에서 즉시 Map으로 사용 가능
  - 일관성: Enum 정의를 서버 기준으로 단일 소스화