### PR TITLE
feat:[#154] 답변 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/answer/controller/AnswerController.java
+++ b/src/main/java/com/ktb/answer/controller/AnswerController.java
@@ -1,5 +1,7 @@
 package com.ktb.answer.controller;
 
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
 import com.ktb.answer.dto.AnswerSubmitCommand;
 import com.ktb.answer.dto.AnswerSubmitResult;
 import com.ktb.answer.dto.request.AnswerDetailRequest;
@@ -93,22 +95,20 @@ public class AnswerController {
     })
     @GetMapping("/answers/{answerId}")
     public ResponseEntity<ApiResponse<AnswerDetailResponse>> getAnswerDetail(
-            @Parameter(hidden = true) Long accountId,  // TODO: Spring Security에서 주입
+            @AuthenticationPrincipal SecurityUserAccount principal,
             @Parameter(description = "답변 ID", example = "1")
             @PathVariable Long answerId,
             @Valid @ModelAttribute AnswerDetailRequest request
     ) {
-        // TODO: 구현 필요
-        // 1. accountId 추출
-        // 2. Service 호출 (소유권 검증 포함)
-        // 3. expand 파라미터 처리
-        // 4. Result를 Response DTO로 변환
-        // 5. ApiResponse로 래핑하여 반환
-
+        Long accountId = principal.getAccount().getId();
         log.info("GET /api/answers/{} - accountId: {}", answerId, accountId);
 
+        AnswerDetailQuery query = request.toQuery();
+        AnswerDetailResult detailResult = answerApplicationService.getDetail(accountId, answerId, query);
+        AnswerDetailResponse response = AnswerDetailResponse.of(detailResult);
+
         return ResponseEntity.ok(
-                new ApiResponse<>(MESSAGE_ANSWER_DETAIL_RETRIEVED, null)
+                new ApiResponse<>(MESSAGE_ANSWER_DETAIL_RETRIEVED, response)
         );
     }
 

--- a/src/main/java/com/ktb/answer/dto/AnswerContentResult.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerContentResult.java
@@ -1,11 +1,9 @@
 package com.ktb.answer.dto;
 
-import java.time.Instant;
-
 public record AnswerContentResult(
         String answerText,
         String audioUrl,
         String videoUrl,
-        Instant answeredAt
+        String answeredAt
 ) {
 }

--- a/src/main/java/com/ktb/answer/dto/AnswerDetailResult.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerDetailResult.java
@@ -1,9 +1,11 @@
 package com.ktb.answer.dto;
 
+import com.ktb.answer.domain.AnswerStatus;
 import com.ktb.answer.domain.AnswerType;
 
 public record AnswerDetailResult(
         Long answerId,
+        AnswerStatus status,
         AnswerType type,
         QuestionSummary question,
         AnswerContentResult answer,

--- a/src/main/java/com/ktb/answer/dto/FeedbackStatus.java
+++ b/src/main/java/com/ktb/answer/dto/FeedbackStatus.java
@@ -1,9 +1,24 @@
 package com.ktb.answer.dto;
 
+import com.ktb.answer.domain.AnswerStatus;
+
 public enum FeedbackStatus {
     PROCESSING,
     COMPLETED,
     FAILED,
     FAILED_RETRYABLE,
-    NOT_AVAILABLE
+    NOT_AVAILABLE;
+
+    /**
+     * AnswerStatus를 FeedbackStatus로 변환
+     */
+    public static FeedbackStatus from(AnswerStatus answerStatus) {
+        return switch (answerStatus) {
+            case AI_FEEDBACK_PROCESSING -> PROCESSING;
+            case COMPLETED -> COMPLETED;
+            case FAILED -> FAILED;
+            case FAILED_RETRYABLE -> FAILED_RETRYABLE;
+            default -> NOT_AVAILABLE;
+        };
+    }
 }

--- a/src/main/java/com/ktb/answer/dto/QuestionSummary.java
+++ b/src/main/java/com/ktb/answer/dto/QuestionSummary.java
@@ -2,7 +2,8 @@ package com.ktb.answer.dto;
 
 public record QuestionSummary(
         Long questionId,
-        String title,
-        String content
+        String content,
+        String category,
+        String type
 ) {
 }

--- a/src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java
@@ -1,7 +1,10 @@
 package com.ktb.answer.dto.request;
 
+import com.ktb.answer.dto.AnswerDetailQuery;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * 답변 상세 조회 요청 DTO
@@ -16,7 +19,17 @@ public record AnswerDetailRequest(
         String expand
 ) {
 
-    private static final String EXPAND_QUESTION = "question";
-    private static final String EXPAND_FEEDBACK = "feedback";
-    private static final String EXPAND_IMMEDIATE_FEEDBACK = "immediate_feedback";
+    /**
+     * expand 문자열을 AnswerDetailQuery로 변환
+     */
+    public AnswerDetailQuery toQuery() {
+        if (expand == null || expand.isBlank()) {
+            return AnswerDetailQuery.empty();
+        }
+        List<String> values = Arrays.stream(expand.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        return AnswerDetailQuery.of(values);
+    }
 }

--- a/src/main/java/com/ktb/answer/dto/response/AnswerDetailResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/AnswerDetailResponse.java
@@ -1,5 +1,7 @@
 package com.ktb.answer.dto.response;
 
+import com.ktb.answer.dto.AiFeedbackSummary;
+import com.ktb.answer.dto.AnswerDetailResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
@@ -48,7 +50,10 @@ public record AnswerDetailResponse(
             String category,
 
             @Schema(description = "질문 타입", example = "TECHNICAL")
-            String type
+            String type,
+
+            @Schema(description = "질문 핵심 키워드", example="")
+            List<String> keywords
     ) {
     }
 
@@ -92,5 +97,58 @@ public record AnswerDetailResponse(
             @Schema(description = "점수 (0-100)", example = "85", minimum = "0", maximum = "100")
             int score
     ) {
+    }
+
+    /**
+     * AnswerDetailResult를 AnswerDetailResponse로 변환하는 정적 팩토리 메서드
+     */
+    public static AnswerDetailResponse of(AnswerDetailResult result) {
+        QuestionDetail questionDetail = null;
+        if (result.question() != null) {
+            questionDetail = new QuestionDetail(
+                result.question().questionId(),
+                result.question().content(),
+                result.question().category(),
+                result.question().type(),
+                null  // keywords는 별도 조회 필요
+            );
+        }
+
+        ImmediateFeedbackDetail immediateFeedbackDetail = null;
+        if (result.immediateFeedback() != null) {
+            List<KeywordCheck> keywords = result.immediateFeedback().keywords().stream()
+                .map(keyword -> new KeywordCheck(
+                    keyword.keyword(),
+                    keyword.included()
+                ))
+                .toList();
+            immediateFeedbackDetail = new ImmediateFeedbackDetail(keywords);
+        }
+
+        AiFeedbackDetail aiFeedbackDetail = null;
+        if (result.aiFeedback() != null) {
+            AiFeedbackSummary summary = result.aiFeedback();
+            List<MetricScore> metrics = summary.radarChart() == null
+                ? null
+                : summary.radarChart().entrySet().stream()
+                    .map(entry -> new MetricScore(entry.getKey(), entry.getValue()))
+                    .toList();
+            aiFeedbackDetail = new AiFeedbackDetail(
+                summary.status() == null ? null : summary.status().name(),
+                summary.comment(),
+                metrics
+            );
+        }
+
+        return new AnswerDetailResponse(
+            result.answerId(),
+            result.answer() == null ? null : result.answer().answerText(),
+            result.type() == null ? null : result.type().name(),
+            result.status() == null ? null : result.status().name(),
+            result.answer() == null ? null : result.answer().answeredAt(),
+            questionDetail,
+            immediateFeedbackDetail,
+            aiFeedbackDetail
+        );
     }
 }

--- a/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
@@ -93,7 +93,7 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
         Answer answer = answerRepository.findById(answerId)
                 .orElseThrow(() -> new AnswerNotFoundException(answerId));
 
-        return mapAnswerStatusToFeedbackStatus(answer.getStatus());
+        return FeedbackStatus.from(answer.getStatus());
     }
 
     @Override
@@ -184,15 +184,5 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
         if (!Objects.equals(answerUserId, jwtUserId)) {
             throw new AnswerAccessDeniedException(jwtUserId, answerUserId);
         }
-    }
-
-    private FeedbackStatus mapAnswerStatusToFeedbackStatus(AnswerStatus answerStatus) {
-        return switch (answerStatus) {
-            case AI_FEEDBACK_PROCESSING -> FeedbackStatus.PROCESSING;
-            case COMPLETED -> FeedbackStatus.COMPLETED;
-            case FAILED -> FeedbackStatus.FAILED;
-            case FAILED_RETRYABLE -> FeedbackStatus.FAILED_RETRYABLE;
-            default -> FeedbackStatus.NOT_AVAILABLE;
-        };
     }
 }

--- a/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
@@ -5,13 +5,18 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.ktb.answer.domain.Answer;
 import com.ktb.answer.domain.AnswerStatus;
 import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AiFeedbackSummary;
+import com.ktb.answer.dto.AnswerContentResult;
 import com.ktb.answer.dto.AnswerDetailQuery;
 import com.ktb.answer.dto.AnswerDetailResult;
 import com.ktb.answer.dto.AnswerListCursor;
 import com.ktb.answer.dto.AnswerSubmitCommand;
 import com.ktb.answer.dto.AnswerSubmitResult;
 import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.FeedbackStatus;
 import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.dto.QuestionSummary;
 import com.ktb.answer.dto.response.AnswerListResponse;
 import com.ktb.answer.exception.AnswerAccessDeniedException;
 import com.ktb.answer.exception.AnswerNotFoundException;
@@ -31,6 +36,8 @@ import com.ktb.hashtag.domain.Hashtag;
 import com.ktb.hashtag.exception.HashtagNotFoundException;
 import com.ktb.hashtag.repository.AnswerHashtagRepository;
 import com.ktb.hashtag.repository.HashtagRepository;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.repository.AnswerMetricRepository;
 import com.ktb.question.domain.Question;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
@@ -45,6 +52,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -63,6 +72,7 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
     private final ImmediateFeedbackService immediateFeedbackService;
     private final AnswerHashtagRepository answerHashtagRepository;
     private final HashtagRepository hashtagRepository;
+    private final AnswerMetricRepository answerMetricRepository;
 
     private final JsonMapper jsonMapper = JsonMapper.builder().build();
 
@@ -197,22 +207,88 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
     public AnswerDetailResult getDetail(Long accountId, Long answerId, AnswerDetailQuery query)
             throws AnswerNotFoundException, AnswerAccessDeniedException {
 
-        // TODO: MVP V2 구현 필요
-        // 1. Answer 조회
-        // 2. 소유권 검증
-        // 3. expand 파라미터에 따라 추가 데이터 조회
-        //    - expand=question: Question 정보 포함
-        //    - expand=feedback: ANSWER_METRIC, AI 피드백 포함
-        //    - expand=immediate_feedback: 즉각 피드백 포함
-        // 4. DTO로 변환하여 반환
-
         log.debug("Retrieving answer detail for answerId: {}, accountId: {}", answerId, accountId);
 
+        // 1. Answer 조회 (Question eager load)
         Answer answer = findAnswerById(answerId);
+
+        // 2. 소유권 검증
         validateOwnership(answer, accountId);
 
-        // TODO: expand 처리 및 DTO 변환
-        return null;
+        // 3. 기본 Answer 정보 구성
+        AnswerContentResult answerContent = new AnswerContentResult(
+            answer.getContent(),
+            null,  // audioUrl (MVP V2: 파일 연동 시 구현)
+            null,  // videoUrl (MVP V2: 파일 연동 시 구현)
+            answer.getCreatedAt() == null ? null : answer.getCreatedAt().toString()
+        );
+
+        // 4. expand 파라미터에 따라 추가 데이터 조회
+        QuestionSummary questionSummary = null;
+        if (query.includeQuestion()) {
+            Question question = answer.getQuestion();
+            questionSummary = new QuestionSummary(
+                question.getId(),
+                question.getContent(),
+                question.getCategory().name(),
+                question.getType().name()
+            );
+        }
+
+        ImmediateFeedbackResult immediateFeedback = null;
+        if (query.includeImmediateFeedback()) {
+            immediateFeedback = loadImmediateFeedback(answerId);
+        }
+
+        AiFeedbackSummary aiFeedback = null;
+        if (query.includeFeedback()) {
+            aiFeedback = loadAiFeedback(answer);
+        }
+
+        // 5. DTO 구성 및 반환
+        return new AnswerDetailResult(
+            answer.getId(),
+            answer.getStatus(),
+            answer.getType(),
+            questionSummary,
+            answerContent,
+            immediateFeedback,
+            aiFeedback
+        );
+    }
+
+    private ImmediateFeedbackResult loadImmediateFeedback(Long answerId) {
+        List<AnswerHashtag> answerHashtags = answerHashtagRepository.findByAnswerIdWithHashtag(answerId);
+
+        List<KeywordCheckResult> keywords = answerHashtags.stream()
+            .map(ah -> new KeywordCheckResult(
+                ah.getHashtag().getId(),
+                ah.getHashtag().getName(),
+                ah.isIncluded()
+            ))
+            .toList();
+
+        return new ImmediateFeedbackResult(keywords);
+    }
+
+    private AiFeedbackSummary loadAiFeedback(Answer answer) {
+        // FeedbackStatus enum의 from() 메서드 사용 (중복 코드 제거)
+        FeedbackStatus status = FeedbackStatus.from(answer.getStatus());
+
+        if (status != FeedbackStatus.COMPLETED) {
+            return new AiFeedbackSummary(status, null, null);
+        }
+
+        // COMPLETED 상태일 때만 메트릭 조회
+        List<AnswerMetric> metrics = answerMetricRepository.findByAnswerIdWithMetric(answer.getId());
+
+        Map<String, Integer> radarChart = metrics.stream()
+            .collect(Collectors.toMap(
+                AnswerMetric::getMetricName,
+                AnswerMetric::getScore
+            ));
+
+        return new AiFeedbackSummary(status, radarChart, answer.getAiFeedback());
     }
 
     @Override

--- a/src/main/java/com/ktb/hashtag/repository/AnswerHashtagRepository.java
+++ b/src/main/java/com/ktb/hashtag/repository/AnswerHashtagRepository.java
@@ -1,7 +1,10 @@
 package com.ktb.hashtag.repository;
 
 import com.ktb.hashtag.domain.AnswerHashtag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +14,12 @@ public interface AnswerHashtagRepository extends JpaRepository<AnswerHashtag, Lo
      * 답변 삭제 시 AnswerHashtag 함께 삭제
      */
     void deleteByAnswerId(Long answerId);
+
+    @Query("""
+            SELECT ah FROM AnswerHashtag ah
+            JOIN FETCH ah.hashtag h
+            WHERE ah.answer.id = :answerId
+            ORDER BY h.id ASC
+            """)
+    List<AnswerHashtag> findByAnswerIdWithHashtag(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/ktb/metric/domain/AnswerMetric.java
+++ b/src/main/java/com/ktb/metric/domain/AnswerMetric.java
@@ -80,4 +80,8 @@ public class AnswerMetric extends BaseTimeEntity {
             throw new MetricInvalidRangeException();
         }
     }
+
+    public String getMetricName() {
+        return this.metric.getName();
+    }
 }


### PR DESCRIPTION
## 요약
답변 상세 조회 API를 구현하고 expand 파라미터로 질문/즉각 피드백/AI 피드백을 선택적으로 포함할 수 있게 했습니다.
응답 스키마와 상태 정의도 API 명세서에 맞게 정리했습니다.

## 변경사항
- 답변 상세 조회 API 구현 및 expand 처리
- AnswerDetailRequest/Response 스키마 확장
- 즉각 피드백/AI 피드백 DTO 연결
- AnswerHashtag/AnswerMetric 조회 최적화 준비 (fetch join)
- FeedbackStatus 정의 보완

### 변경 파일
- `src/main/java/com/ktb/answer/controller/AnswerController.java`  
  답변 상세 조회 엔드포인트에서 expand 파라미터 해석 및 응답 매핑 로직 추가
- `src/main/java/com/ktb/answer/dto/AnswerContentResult.java`  
  상세 조회용 답변 콘텐츠 DTO 구조 조정
- `src/main/java/com/ktb/answer/dto/AnswerDetailResult.java`  
  상세 조회 결과 DTO에 status 포함
- `src/main/java/com/ktb/answer/dto/FeedbackStatus.java`  
  AI 피드백 상태 정의 보완
- `src/main/java/com/ktb/answer/dto/QuestionSummary.java`  
  상세 조회용 질문 요약 DTO 정리
- `src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java`  
  expand 파라미터 수용을 위한 요청 DTO 확장
- `src/main/java/com/ktb/answer/dto/response/AnswerDetailResponse.java`  
  질문/즉각 피드백/AI 피드백 포함 응답 스키마 확장
- `src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java`  
  답변 상세 응답 구조에 맞춰 상태 처리 보강
- `src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java`  
  상세 조회 로직 구현 및 expand 조건에 따른 데이터 조합
- `src/main/java/com/ktb/hashtag/repository/AnswerHashtagRepository.java`  
  즉각 피드백용 해시태그 fetch join 쿼리 추가
- `src/main/java/com/ktb/metric/domain/AnswerMetric.java`  
  metric 접근 편의 메서드 추가

## 관련 Commit / Issue
- Commit: `00db093`
- Issue: Closes `#154`