### PR TITLE
feat:[#158]AI 피드백 Metric/AnswerMetric 저장 및 답변 상세조회 연동

### DIFF
--- a/src/main/java/com/ktb/answer/domain/Answer.java
+++ b/src/main/java/com/ktb/answer/domain/Answer.java
@@ -118,34 +118,6 @@ public class Answer extends BaseSoftDeleteEntity {
         this.status = AnswerStatus.COMPLETED;
     }
 
-    public void upsertAnswerMetrics(List<AnswerMetric> newMetrics) {
-        Map<Long, AnswerMetric> existingByMetricId = this.answerMetrics.stream()
-                .collect(Collectors.toMap(
-                        metric -> metric.getMetric().getId(),
-                        Function.identity(),
-                        (left, right) -> left
-                ));
-
-        Set<Long> incomingMetricIds = new HashSet<>();
-        for (AnswerMetric newMetric : newMetrics) {
-            Long metricId = newMetric.getMetric().getId();
-            incomingMetricIds.add(metricId);
-            AnswerMetric existing = existingByMetricId.get(metricId);
-            if (existing == null) {
-                this.answerMetrics.add(newMetric);
-            } else {
-                existing.restore();
-                existing.updateScore(newMetric.getScore());
-            }
-        }
-
-        for (AnswerMetric existing : this.answerMetrics) {
-            if (!incomingMetricIds.contains(existing.getMetric().getId())) {
-                existing.softDelete();
-            }
-        }
-    }
-
     public List<AnswerMetric> getAnswerMetrics() {
         return Collections.unmodifiableList(answerMetrics);
     }

--- a/src/main/java/com/ktb/answer/domain/Answer.java
+++ b/src/main/java/com/ktb/answer/domain/Answer.java
@@ -5,7 +5,9 @@ import com.ktb.answer.exception.AnswerRequiredTypeException;
 import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.common.domain.BaseSoftDeleteEntity;
+import com.ktb.metric.domain.AnswerMetric;
 import com.ktb.question.domain.Question;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,7 +19,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -68,6 +79,9 @@ public class Answer extends BaseSoftDeleteEntity {
     @Column(name = "answer_ai_feedback", columnDefinition = "TEXT")
     private String aiFeedback;
 
+    @OneToMany(mappedBy = "answer", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private final List<AnswerMetric> answerMetrics = new ArrayList<>();
+
     @Builder
     private Answer(Question question, UserAccount account, String content,
                    AnswerType type) {
@@ -102,6 +116,38 @@ public class Answer extends BaseSoftDeleteEntity {
     public void setAiFeedback(String feedback) {
         this.aiFeedback = feedback;
         this.status = AnswerStatus.COMPLETED;
+    }
+
+    public void upsertAnswerMetrics(List<AnswerMetric> newMetrics) {
+        Map<Long, AnswerMetric> existingByMetricId = this.answerMetrics.stream()
+                .collect(Collectors.toMap(
+                        metric -> metric.getMetric().getId(),
+                        Function.identity(),
+                        (left, right) -> left
+                ));
+
+        Set<Long> incomingMetricIds = new HashSet<>();
+        for (AnswerMetric newMetric : newMetrics) {
+            Long metricId = newMetric.getMetric().getId();
+            incomingMetricIds.add(metricId);
+            AnswerMetric existing = existingByMetricId.get(metricId);
+            if (existing == null) {
+                this.answerMetrics.add(newMetric);
+            } else {
+                existing.restore();
+                existing.updateScore(newMetric.getScore());
+            }
+        }
+
+        for (AnswerMetric existing : this.answerMetrics) {
+            if (!incomingMetricIds.contains(existing.getMetric().getId())) {
+                existing.softDelete();
+            }
+        }
+    }
+
+    public List<AnswerMetric> getAnswerMetrics() {
+        return Collections.unmodifiableList(answerMetrics);
     }
 
     private void validateType(AnswerType type) {

--- a/src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java
@@ -33,10 +33,10 @@ public record FeedbackResponse(
             @Schema(description = "평가 지표 설명", example = "답변의 논리적 흐름과 구조")
             String metricDescription,
 
-            @Schema(description = "획득 점수", example = "85", minimum = "0", maximum = "100")
+            @Schema(description = "획득 점수", example = "4", minimum = "1", maximum = "5")
             int score,
 
-            @Schema(description = "최대 점수", example = "100")
+            @Schema(description = "최대 점수", example = "5")
             int maxScore
     ) {
     }

--- a/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
@@ -17,9 +17,11 @@ import com.ktb.auth.domain.UserAccount;
 import com.ktb.common.dto.ApiResponse;
 import com.ktb.metric.domain.AnswerMetric;
 import com.ktb.metric.domain.Metric;
+import com.ktb.metric.repository.AnswerMetricRepository;
 import com.ktb.metric.repository.MetricRepository;
 import com.ktb.question.domain.Question;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +40,7 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
     private final AnswerRepository answerRepository;
     private final AiFeedbackService aiFeedbackService;
     private final MetricRepository metricRepository;
+    private final AnswerMetricRepository answerMetricRepository;
 
     @Override
     @Transactional
@@ -180,33 +183,25 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
 
     private void saveAnswerMetrics(Answer answer, List<AiFeedbackMetric> aiMetrics) {
         if (aiMetrics == null || aiMetrics.isEmpty()) {
-            answer.upsertAnswerMetrics(List.of());
             return;
         }
 
+        Map<String, Metric> metricMap =
+            metricRepository.findAllByNameIn(aiMetrics.stream().map(AiFeedbackMetric::name).toList())
+                .stream()
+                .collect(Collectors.toMap(Metric::getName, m -> m));
+
         List<AnswerMetric> answerMetrics = new ArrayList<>(aiMetrics.size());
+
         for (AiFeedbackMetric aiMetric : aiMetrics) {
-            Metric metric = findOrCreateMetric(aiMetric.name());
+            Metric metric = metricMap.computeIfAbsent(aiMetric.name(), name ->
+                metricRepository.save(Metric.create(name, ""))
+            );
             int score = aiMetric.score() == null ? 1 : aiMetric.score();
             answerMetrics.add(AnswerMetric.create(answer, metric, score));
         }
 
-        answer.upsertAnswerMetrics(answerMetrics);
-    }
-
-    private Metric findOrCreateMetric(String metricName) {
-        return metricRepository.findByName(metricName)
-                .orElseGet(() -> createMetric(metricName));
-    }
-
-    private Metric createMetric(String metricName) {
-        try {
-            return metricRepository.save(Metric.create(metricName, null));
-        } catch (DataIntegrityViolationException e) {
-            // Unique constraint can fail under race; re-read the row that won.
-            return metricRepository.findByName(metricName)
-                    .orElseThrow(() -> e);
-        }
+        answerMetricRepository.saveAll(answerMetrics);
     }
 
     private String combineFeedback(AiFeedbackFeedback feedback) {

--- a/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
@@ -6,9 +6,7 @@ import com.ktb.ai.feedback.dto.response.AiFeedbackFeedback;
 import com.ktb.ai.feedback.dto.response.AiFeedbackMetric;
 import com.ktb.ai.feedback.dto.response.BadCaseType;
 import com.ktb.ai.feedback.service.AiFeedbackService;
-import com.ktb.common.dto.ApiResponse;
 import com.ktb.answer.domain.Answer;
-import com.ktb.answer.domain.AnswerStatus;
 import com.ktb.answer.dto.FeedbackStatus;
 import com.ktb.answer.dto.response.FeedbackResponse;
 import com.ktb.answer.exception.AnswerAccessDeniedException;
@@ -16,10 +14,16 @@ import com.ktb.answer.exception.AnswerNotFoundException;
 import com.ktb.answer.repository.AnswerRepository;
 import com.ktb.answer.service.AiFeedbackOrchestrator;
 import com.ktb.auth.domain.UserAccount;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.domain.Metric;
+import com.ktb.metric.repository.MetricRepository;
 import com.ktb.question.domain.Question;
+import java.util.ArrayList;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +37,7 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
 
     private final AnswerRepository answerRepository;
     private final AiFeedbackService aiFeedbackService;
+    private final MetricRepository metricRepository;
 
     @Override
     @Transactional
@@ -136,7 +141,6 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
 
         String failureMessage = badCaseType.getMessage() + "\n\n" + badCaseType.getGuidance();
 
-//        answer.transitionTo(AnswerStatus.COMPLETED);
         answer.setAiFeedback(badCaseType.getGuidance());
         answerRepository.save(answer);
 
@@ -147,6 +151,8 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
 
     private FeedbackResponse handleSuccessResponse(Answer answer, ApiResponse<AiFeedbackResponse> apiResponse) {
         AiFeedbackResponse data = apiResponse.data();
+
+        saveAnswerMetrics(answer, data.metrics());
 
         List<FeedbackResponse.RadarChartMetric> radarChart = convertToRadarChart(data.metrics());
         String combinedFeedback = combineFeedback(data.feedback());
@@ -170,6 +176,37 @@ public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
                         5                     // maxScore
                 ))
                 .collect(Collectors.toList());
+    }
+
+    private void saveAnswerMetrics(Answer answer, List<AiFeedbackMetric> aiMetrics) {
+        if (aiMetrics == null || aiMetrics.isEmpty()) {
+            answer.upsertAnswerMetrics(List.of());
+            return;
+        }
+
+        List<AnswerMetric> answerMetrics = new ArrayList<>(aiMetrics.size());
+        for (AiFeedbackMetric aiMetric : aiMetrics) {
+            Metric metric = findOrCreateMetric(aiMetric.name());
+            int score = aiMetric.score() == null ? 1 : aiMetric.score();
+            answerMetrics.add(AnswerMetric.create(answer, metric, score));
+        }
+
+        answer.upsertAnswerMetrics(answerMetrics);
+    }
+
+    private Metric findOrCreateMetric(String metricName) {
+        return metricRepository.findByName(metricName)
+                .orElseGet(() -> createMetric(metricName));
+    }
+
+    private Metric createMetric(String metricName) {
+        try {
+            return metricRepository.save(Metric.create(metricName, null));
+        } catch (DataIntegrityViolationException e) {
+            // Unique constraint can fail under race; re-read the row that won.
+            return metricRepository.findByName(metricName)
+                    .orElseThrow(() -> e);
+        }
     }
 
     private String combineFeedback(AiFeedbackFeedback feedback) {

--- a/src/main/java/com/ktb/metric/domain/AnswerMetric.java
+++ b/src/main/java/com/ktb/metric/domain/AnswerMetric.java
@@ -2,6 +2,7 @@ package com.ktb.metric.domain;
 
 import com.ktb.answer.domain.Answer;
 import com.ktb.common.domain.BaseSoftDeleteEntity;
+import com.ktb.common.domain.BaseTimeEntity;
 import com.ktb.metric.exception.MetricInvalidRangeException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,7 +33,7 @@ import lombok.ToString;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(exclude = {"answer", "metric"})
-public class AnswerMetric extends BaseSoftDeleteEntity {
+public class AnswerMetric extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ktb/metric/domain/AnswerMetric.java
+++ b/src/main/java/com/ktb/metric/domain/AnswerMetric.java
@@ -1,8 +1,7 @@
 package com.ktb.metric.domain;
 
 import com.ktb.answer.domain.Answer;
-import com.ktb.common.domain.BaseTimeEntity;
-import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.domain.BaseSoftDeleteEntity;
 import com.ktb.metric.exception.MetricInvalidRangeException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,7 +32,7 @@ import lombok.ToString;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString(exclude = {"answer", "metric"})
-public class AnswerMetric extends BaseTimeEntity {
+public class AnswerMetric extends BaseSoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,8 +50,8 @@ public class AnswerMetric extends BaseTimeEntity {
     @Column(name = "answer_metric_score", nullable = false)
     private int score;
 
-    private final static int MIN_SCORE = 0;
-    private final static int MAX_SCORE = 100;
+    private final static int MIN_SCORE = 1;
+    private final static int MAX_SCORE = 5;
 
     @Builder
     private AnswerMetric(Answer answer, Metric metric, int score) {

--- a/src/main/java/com/ktb/metric/domain/Metric.java
+++ b/src/main/java/com/ktb/metric/domain/Metric.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,9 @@ import lombok.ToString;
 @Entity
 @Table(
         name = "METRIC",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_metric_name", columnNames = "metric_nm")
+        },
         indexes = {
                 @Index(name = "idx_use_yn", columnList = "metric_use_yn"),
                 @Index(name = "idx_created", columnList = "metric_created_at")

--- a/src/main/java/com/ktb/metric/repository/AnswerMetricRepository.java
+++ b/src/main/java/com/ktb/metric/repository/AnswerMetricRepository.java
@@ -14,6 +14,7 @@ public interface AnswerMetricRepository extends JpaRepository<AnswerMetric, Long
             SELECT am FROM AnswerMetric am
             JOIN FETCH am.metric m
             WHERE am.answer.id = :answerId
+            AND am.deletedAt IS NULL
             ORDER BY m.id ASC
             """)
     List<AnswerMetric> findByAnswerIdWithMetric(@Param("answerId") Long answerId);

--- a/src/main/java/com/ktb/metric/repository/MetricRepository.java
+++ b/src/main/java/com/ktb/metric/repository/MetricRepository.java
@@ -1,11 +1,14 @@
 package com.ktb.metric.repository;
 
 import com.ktb.metric.domain.Metric;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MetricRepository extends JpaRepository<Metric, Long> {
+    Optional<Metric> findByName(String name);
+
     Slice<Metric> findByUseYn(boolean useYn, Pageable pageable);
 
     Slice<Metric> findByIdLessThan(Long cursor, Pageable pageable);

--- a/src/main/java/com/ktb/metric/repository/MetricRepository.java
+++ b/src/main/java/com/ktb/metric/repository/MetricRepository.java
@@ -1,13 +1,14 @@
 package com.ktb.metric.repository;
 
 import com.ktb.metric.domain.Metric;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MetricRepository extends JpaRepository<Metric, Long> {
-    Optional<Metric> findByName(String name);
+    List<Metric> findAllByNameIn(List<String> names);
 
     Slice<Metric> findByUseYn(boolean useYn, Pageable pageable);
 


### PR DESCRIPTION
## 요약

  AI 피드백 동기 처리 결과를 Metric/AnswerMetric으로 영속화하고, 답변 상세조회에서 저장된 메트릭을 radarChart로 내려주도록 연결했습니다.
  Answer aggregate 내부에서 메트릭을 upsert(있으면 update, 없으면 insert)하고 soft delete 처리해, 재계산 없이 일관된 조회가 가능하도록 구성했습니다.

  ## 변경사항

  ### 기능 추가/변경 (목적 중심)

  - AI 피드백 응답 메트릭 저장
      - getFeedbackSync 성공 시 AnswerMetric 저장/갱신
      - metric명 기준 Metric find-or-create
  - 답변 상세조회 연동
      - AnswerApplicationServiceImpl.loadAiFeedback()에서 AnswerMetric 조회 후 radarChart 구성
  - 도메인 내부 upsert 규칙 적용
      - Answer.upsertAnswerMetrics(...)에서 metric 기준으로 추가/갱신 처리
      - 최신 AI 응답에 없는 기존 메트릭은 soft delete 처리
  - 데이터 정합성 강화
      - Metric.metric_nm 유니크 제약 추가
      - 동시 생성 충돌 시 재조회 fallback 처리
      - AnswerMetric(answer_id, metric_id) 유니크 제약으로 답변-메트릭 중복 매핑 방지
  - 점수 스케일 통일
      - AnswerMetric 점수 범위 1~5
      - 응답 스키마도 1~5 기준으로 정렬

  ## JPA 설계/처리 방식

  - Answer-AnswerMetric 연관관계 기반 저장
      - @OneToMany(mappedBy = "answer", cascade = {PERSIST, MERGE})
  - upsertAnswerMetrics를 Answer 엔티티에 배치
      - AnswerMetric 생명주기를 Answer aggregate에서 일관 관리
  - 쓰기지연(Transactional Write-Behind) 기반 처리
      - 서비스에서 엔티티 상태를 변경하고 flush/commit 시점에 insert/update 반영
  - soft delete 정책 반영
      - REMOVE/orphanRemoval은 사용하지 않음
      - 누락된 메트릭은 hard delete 대신 soft delete 처리

  ## 운영 반영 시 필요한 DB 변경사항 (필수)

  운영이 ddl-auto: none 기준이므로 아래 스키마 반영이 선행되어야 합니다.

  - 컬럼 추가
      - ANSWER_METRIC.deleted_at (nullable timestamp/datetime)
  - 유니크 제약 추가
      - METRIC(metric_nm) 유니크 제약 (uk_metric_name)

  참고:

  - ANSWER_METRIC(answer_id, metric_id) 유니크는 엔티티 정의 기준 존재해야 하며, 운영 DB에도 동일하게 보장되어야 합니다.
  - 기존 데이터에 중복 metric_nm이 있으면 유니크 제약 추가 전 정리 작업이 필요합니다.

  ## 배치 관련 (성능 계획)
  - #139 
  - 현재 Metric/AnswerMetric 생성 시 단건 insert 쿼리 중심으로 동작합니다.
  - 트래픽/메트릭 개수 증가 대비해 다음 단계에서 batch 최적화 예정:
      - Metric 사전 조회를 IN 단건화
      - saveAll + Hibernate batch(hibernate.jdbc.batch_size, order_inserts) 적용

  ## 변경 파일 (상세)

  ### Modified

  - src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
  - src/main/java/com/ktb/answer/domain/Answer.java
  - src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
  - src/main/java/com/ktb/metric/domain/Metric.java
  - src/main/java/com/ktb/metric/domain/AnswerMetric.java
  - src/main/java/com/ktb/metric/repository/MetricRepository.java
  - src/main/java/com/ktb/metric/repository/AnswerMetricRepository.java
  - src/main/java/com/ktb/answer/dto/response/FeedbackResponse.java

  ## 관련 Commit, Issue

  - #158 

  ### 목적/의도

  - AI 피드백 저장/조회 경로를 DB 기반으로 일원화해 응답 일관성 확보
  - metric 정의(Metric)와 답변별 점수(AnswerMetric)를 분리해 재사용성과 확장성 강화
  - 연관관계 + 쓰기지연 기반으로 도메인 규칙을 엔티티 중심으로 유지
  - soft delete 정책과 정합성(중복/경합)을 동시에 만족하는 저장 모델 확보
