### PR TITLE
fix:[#160] Access Token 발급 중 NPE 발생

### DIFF
--- a/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
@@ -26,7 +26,7 @@ public class TokenServiceImpl implements TokenService {
 
     @Override
     public String issueAccessToken(Long accountId, List<String> roles, String nickname) {
-        if(nickname.isBlank()) {
+        if(nickname == null || nickname.isBlank()) {
             nickname = DEFAULT_NICKNAME;
         }
 


### PR DESCRIPTION
## 요약
Access Token 발급 중 발생하는 NPE를 방지하도록 처리 로직을 수정했습니다.

## 변경사항
- TokenServiceImpl에서 NPE 발생 가능 지점 보완

## 변경 파일
- `src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java`

## 관련 Commit / Issue
- Commit: `6c1cc1c7`
- closes `#160`