### PR TITLE
fix:AnswerMetricRepository, deleted_at 제거

### DIFF
--- a/src/main/java/com/ktb/metric/repository/AnswerMetricRepository.java
+++ b/src/main/java/com/ktb/metric/repository/AnswerMetricRepository.java
@@ -14,7 +14,6 @@ public interface AnswerMetricRepository extends JpaRepository<AnswerMetric, Long
             SELECT am FROM AnswerMetric am
             JOIN FETCH am.metric m
             WHERE am.answer.id = :answerId
-            AND am.deletedAt IS NULL
             ORDER BY m.id ASC
             """)
     List<AnswerMetric> findByAnswerIdWithMetric(@Param("answerId") Long answerId);


### PR DESCRIPTION
 ## 요약

  AnswerMetric 조회 쿼리에서 deleted_at 조건을 제거해, 답변에 매핑된 메트릭을 모두 반환하도록 수정했습니다.

  ## 변경사항

  - findByAnswerIdWithMetric 쿼리에서 deleted_at IS NULL 조건 제거

  ## 변경 파일

  - src/main/java/com/ktb/metric/repository/AnswerMetricRepository.java