### PR TITLE
feat:[#171]Micrometer 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
     // ✅ Actuator (Health Check)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     // ✅ OAuth Client
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,8 @@ spring:
       - "/"
       - "/error"
       - "/actuator/health"
+      - "/actuator/prometheus"
+      - "/actuator/info"
       - "/api/auth/oauth/tokens"
     anonymous-only-endpoints:
       - "/api/auth/oauth/authorization-url"
@@ -87,10 +89,25 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,metrics,prometheus
+        include: health, metrics, info, prometheus
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: never
+  metrics:
+    tags:
+      application: QFeed
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      slo:
+        http.server.requests: 100ms, 200ms, 500ms, 1s, 2s, 3s
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+        step: 10s
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 요약

  Prometheus 수집을 위한 Micrometer 레지스트리를 추가하고, Actuator 메트릭/프로메테우스 엔드포인트 노출 및 기본 메트릭 설정을 구성했습니다.

  ## 변경사항

  - Prometheus 레지스트리 의존성 추가
  - Actuator 노출 범위에 info, prometheus 추가
  - Health probe 활성화
  - HTTP 요청 메트릭 히스토그램/슬로(SLO) 설정
  - 기본 태그(application) 추가 및 Prometheus export 활성화

  ## 수정/추가/삭제 파일

  - 수정
      - build.gradle
      - src/main/resources/application.yaml

  ## 구현 의도 / 목적

  - Prometheus 기반 모니터링 연동 준비
  - HTTP 요청 지표의 분포/지연 기준을 수집해 성능 분석 용이
  - 서비스 식별을 위한 공통 태그(application) 부여

  ## 관련 Commit, Issue

  - feat:[#171] Micrometer 적용