### PR TITLE
test:[#173] Answer 도메인 단위 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
     // ✅ 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'

--- a/src/test/java/com/ktb/answer/repository/AnswerRepositoryTest.java
+++ b/src/test/java/com/ktb/answer/repository/AnswerRepositoryTest.java
@@ -1,0 +1,799 @@
+package com.ktb.answer.repository;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.CategoryCount;
+import com.ktb.answer.dto.DailyCount;
+import com.ktb.answer.dto.TypeCount;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.common.config.JpaAuditingConfig;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@ActiveProfiles("test")
+@DisplayName("AnswerRepository 통합 테스트")
+class AnswerRepositoryTest {
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    private UserAccount testAccount;
+    private UserAccount otherAccount;
+    private Question csQuestion;
+    private Question networkQuestion;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        testAccount = UserAccount.createEmailAccount("test@example.com", "테스트유저");
+        testEntityManager.persist(testAccount);
+
+        otherAccount = UserAccount.createEmailAccount("other@example.com", "다른유저");
+        testEntityManager.persist(otherAccount);
+
+        // 테스트 질문 생성
+        csQuestion = Question.create(
+                "운영체제의 프로세스와 스레드의 차이를 설명하세요.",
+                QuestionType.CS,
+                QuestionCategory.OS
+        );
+        testEntityManager.persist(csQuestion);
+
+        networkQuestion = Question.create(
+                "TCP와 UDP의 차이점을 설명하세요.",
+                QuestionType.CS,
+                QuestionCategory.NETWORK
+        );
+        testEntityManager.persist(networkQuestion);
+
+        testEntityManager.clear();
+    }
+
+    @Nested
+    @DisplayName("findByAccountIdWithFiltersNoCursor() 테스트 - 커서 없는 조회")
+    class FindByAccountIdWithFiltersNoCursorTest {
+
+        @Test
+        @DisplayName("첫 페이지 정상 조회")
+        void findFirstPage_ShouldReturnAnswers() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("빈 결과 조회")
+        void findWithNoResults_ShouldReturnEmptySlice() {
+            // Given
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("다른 사용자 답변은 조회되지 않음")
+        void findByAccountId_ShouldNotIncludeOtherUserAnswers() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(otherAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getAccount().getId())
+                    .isEqualTo(testAccount.getId());
+        }
+
+        @Test
+        @DisplayName("type 필터 적용")
+        void findWithTypeFilter_ShouldFilterByType() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.REAL_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    AnswerType.PRACTICE_INTERVIEW,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getType())
+                    .isEqualTo(AnswerType.PRACTICE_INTERVIEW);
+        }
+
+        @Test
+        @DisplayName("category 필터 적용")
+        void findWithCategoryFilter_ShouldFilterByCategory() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    QuestionCategory.OS,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getQuestion().getCategory())
+                    .isEqualTo(QuestionCategory.OS);
+        }
+
+        @Test
+        @DisplayName("questionType 필터 적용")
+        void findWithQuestionTypeFilter_ShouldFilterByQuestionType() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    QuestionType.CS,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getQuestion().getType())
+                    .isEqualTo(QuestionType.CS);
+        }
+
+        @Test
+        @DisplayName("hasNext가 true일 때 더 많은 데이터 존재")
+        void findWithHasNextTrue_ShouldIndicateMoreData() {
+            // Given
+            for (int i = 0; i < 5; i++) {
+                createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            }
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 3)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(3);
+            assertThat(result.hasNext()).isTrue();
+        }
+
+        @Test
+        @DisplayName("마지막 페이지에서 hasNext가 false")
+        void findLastPage_ShouldHaveNoNext() {
+            // Given
+            for (int i = 0; i < 3; i++) {
+                createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            }
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 5)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(3);
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("삭제된 답변은 조회되지 않음")
+        void findWithDeletedAnswer_ShouldExcludeDeleted() {
+            // Given
+            Answer activeAnswer = createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Answer deletedAnswer = createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            // 답변 삭제
+            deletedAnswer.softDelete();
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getId()).isEqualTo(activeAnswer.getId());
+        }
+
+        @Test
+        @DisplayName("날짜 범위 필터 적용")
+        void findWithDateRange_ShouldFilterByDateRange() {
+            // Given
+            Answer answer = createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().plusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(2);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByAccountIdWithFilters() 테스트 - 커서 기반 조회")
+    class FindByAccountIdWithFiltersTest {
+
+        @Test
+        @DisplayName("커서 이후 데이터 조회")
+        void findAfterCursor_ShouldReturnAnswersAfterCursor() throws InterruptedException {
+            // Given
+            Answer answer1 = createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Thread.sleep(10); // createdAt 차이를 위해 잠시 대기
+            Answer answer2 = createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Thread.sleep(10);
+            Answer answer3 = createAndSaveAnswer(testAccount, csQuestion, AnswerType.REAL_INTERVIEW);
+
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // answer2를 다시 조회하여 createdAt 가져오기
+            Answer cursorAnswer = answerRepository.findById(answer2.getId()).orElseThrow();
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When - answer2 이후의 데이터 조회 (answer1만 해당)
+            Slice<Answer> result = answerRepository.findByAccountIdWithFilters(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    cursorAnswer.getCreatedAt(),
+                    cursorAnswer.getId(),
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getId()).isEqualTo(answer1.getId());
+        }
+
+        @Test
+        @DisplayName("동일한 createdAt을 가진 답변들의 정렬 (id 기준)")
+        void findWithSameCreatedAt_ShouldSortById() {
+            // Given - 동일 시간대에 여러 답변 생성
+            Answer answer1 = createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Answer answer2 = createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Answer answer3 = createAndSaveAnswer(testAccount, csQuestion, AnswerType.REAL_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then - id 내림차순 정렬 확인
+            List<Answer> answers = result.getContent();
+            assertThat(answers).hasSize(3);
+
+            for (int i = 0; i < answers.size() - 1; i++) {
+                Answer current = answers.get(i);
+                Answer next = answers.get(i + 1);
+
+                // createdAt 내림차순, 같으면 id 내림차순
+                if (current.getCreatedAt().equals(next.getCreatedAt())) {
+                    assertThat(current.getId()).isGreaterThan(next.getId());
+                } else {
+                    assertThat(current.getCreatedAt()).isAfterOrEqualTo(next.getCreatedAt());
+                }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdWithQuestion() 테스트")
+    class FindByIdWithQuestionTest {
+
+        @Test
+        @DisplayName("답변과 질문 함께 조회")
+        void findByIdWithQuestion_ShouldReturnAnswerWithQuestion() {
+            // Given
+            Answer answer = createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // When
+            Answer result = answerRepository.findByIdWithQuestion(answer.getId());
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getQuestion()).isNotNull();
+            assertThat(result.getQuestion().getId()).isEqualTo(csQuestion.getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 null 반환")
+        void findByIdWithQuestion_WithNonExistent_ShouldReturnNull() {
+            // Given & When
+            Answer result = answerRepository.findByIdWithQuestion(999L);
+
+            // Then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("삭제된 답변 조회 시 null 반환")
+        void findByIdWithQuestion_WithDeleted_ShouldReturnNull() {
+            // Given
+            Answer answer = createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            answer.softDelete();
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // When
+            Answer result = answerRepository.findByIdWithQuestion(answer.getId());
+
+            // Then
+            assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("countByAccountIdAndTypeIn() 테스트")
+    class CountByAccountIdAndTypeInTest {
+
+        @Test
+        @DisplayName("타입별 답변 수 집계")
+        void countByType_ShouldReturnTypeCounts() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.REAL_INTERVIEW);
+
+            // When
+            List<TypeCount> result = answerRepository.countByAccountIdAndTypeIn(
+                    testAccount.getId(),
+                    List.of(AnswerType.PRACTICE_INTERVIEW, AnswerType.REAL_INTERVIEW)
+            );
+
+            // Then
+            assertThat(result).hasSize(2);
+
+            TypeCount practiceCount = result.stream()
+                    .filter(tc -> tc.type() == AnswerType.PRACTICE_INTERVIEW)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(practiceCount.count()).isEqualTo(2);
+
+            TypeCount realCount = result.stream()
+                    .filter(tc -> tc.type() == AnswerType.REAL_INTERVIEW)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(realCount.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("삭제된 답변은 카운트에서 제외")
+        void countByType_ShouldExcludeDeleted() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Answer deletedAnswer = createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            deletedAnswer.softDelete();
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // When
+            List<TypeCount> result = answerRepository.countByAccountIdAndTypeIn(
+                    testAccount.getId(),
+                    List.of(AnswerType.PRACTICE_INTERVIEW)
+            );
+
+            // Then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("답변이 없을 때 빈 리스트 반환")
+        void countByType_WithNoAnswers_ShouldReturnEmptyList() {
+            // Given & When
+            List<TypeCount> result = answerRepository.countByAccountIdAndTypeIn(
+                    testAccount.getId(),
+                    List.of(AnswerType.PRACTICE_INTERVIEW)
+            );
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("countByAccountIdGroupByCategory() 테스트")
+    class CountByAccountIdGroupByCategoryTest {
+
+        @Test
+        @DisplayName("카테고리별 답변 수 집계")
+        void countByCategory_ShouldReturnCategoryCounts() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.REAL_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            // When
+            List<CategoryCount> result = answerRepository.countByAccountIdGroupByCategory(
+                    testAccount.getId()
+            );
+
+            // Then
+            assertThat(result).hasSize(2);
+
+            CategoryCount osCount = result.stream()
+                    .filter(cc -> cc.category() == QuestionCategory.OS)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(osCount.count()).isEqualTo(2);
+
+            CategoryCount networkCount = result.stream()
+                    .filter(cc -> cc.category() == QuestionCategory.NETWORK)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(networkCount.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("답변이 없을 때 빈 리스트 반환")
+        void countByCategory_WithNoAnswers_ShouldReturnEmptyList() {
+            // Given & When
+            List<CategoryCount> result = answerRepository.countByAccountIdGroupByCategory(
+                    testAccount.getId()
+            );
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("countByAccountIdGroupByDate() 테스트")
+    class CountByAccountIdGroupByDateTest {
+
+        @Test
+        @DisplayName("일별 답변 수 집계")
+        void countByDate_ShouldReturnDailyCounts() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime startDateTime = LocalDateTime.now().minusDays(1);
+            LocalDateTime endDateTime = LocalDateTime.now().plusDays(1);
+
+            // When
+            List<DailyCount> result = answerRepository.countByAccountIdGroupByDate(
+                    testAccount.getId(),
+                    startDateTime,
+                    endDateTime
+            );
+
+            // Then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().count()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("날짜 범위 외 답변은 제외")
+        void countByDate_ShouldExcludeOutOfRange() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime startDateTime = LocalDateTime.now().plusDays(1);
+            LocalDateTime endDateTime = LocalDateTime.now().plusDays(2);
+
+            // When
+            List<DailyCount> result = answerRepository.countByAccountIdGroupByDate(
+                    testAccount.getId(),
+                    startDateTime,
+                    endDateTime
+            );
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("삭제된 답변은 카운트에서 제외")
+        void countByDate_ShouldExcludeDeleted() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Answer deletedAnswer = createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            deletedAnswer.softDelete();
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            LocalDateTime startDateTime = LocalDateTime.now().minusDays(1);
+            LocalDateTime endDateTime = LocalDateTime.now().plusDays(1);
+
+            // When
+            List<DailyCount> result = answerRepository.countByAccountIdGroupByDate(
+                    testAccount.getId(),
+                    startDateTime,
+                    endDateTime
+            );
+
+            // Then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().count()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("findCreatedAtByAccountIdOrderByCreatedAtDesc() 테스트")
+    class FindCreatedAtByAccountIdTest {
+
+        @Test
+        @DisplayName("생성일시 내림차순으로 조회")
+        void findCreatedAt_ShouldReturnDescOrder() throws InterruptedException {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Thread.sleep(10);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Thread.sleep(10);
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.REAL_INTERVIEW);
+
+            // When
+            List<LocalDateTime> result = answerRepository.findCreatedAtByAccountIdOrderByCreatedAtDesc(
+                    testAccount.getId()
+            );
+
+            // Then
+            assertThat(result).hasSize(3);
+
+            for (int i = 0; i < result.size() - 1; i++) {
+                assertThat(result.get(i)).isAfterOrEqualTo(result.get(i + 1));
+            }
+        }
+
+        @Test
+        @DisplayName("삭제된 답변은 제외")
+        void findCreatedAt_ShouldExcludeDeleted() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            Answer deletedAnswer = createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+            deletedAnswer.softDelete();
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // When
+            List<LocalDateTime> result = answerRepository.findCreatedAtByAccountIdOrderByCreatedAtDesc(
+                    testAccount.getId()
+            );
+
+            // Then
+            assertThat(result).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Null 파라미터 처리 테스트")
+    class NullParameterTest {
+
+        @Test
+        @DisplayName("type이 null일 때 모든 타입 조회")
+        void findWithNullType_ShouldReturnAllTypes() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.REAL_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,  // type = null
+                    null,
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("category가 null일 때 모든 카테고리 조회")
+        void findWithNullCategory_ShouldReturnAllCategories() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+            createAndSaveAnswer(testAccount, networkQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,  // category = null
+                    null,
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("questionType이 null일 때 모든 질문 타입 조회")
+        void findWithNullQuestionType_ShouldReturnAllQuestionTypes() {
+            // Given
+            createAndSaveAnswer(testAccount, csQuestion, AnswerType.PRACTICE_INTERVIEW);
+
+            LocalDateTime dateFrom = LocalDateTime.now().minusDays(1);
+            LocalDateTime dateTo = LocalDateTime.now().plusDays(1);
+
+            // When
+            Slice<Answer> result = answerRepository.findByAccountIdWithFiltersNoCursor(
+                    testAccount.getId(),
+                    null,
+                    null,
+                    null,  // questionType = null
+                    dateFrom,
+                    dateTo,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+        }
+    }
+
+    // Helper methods
+
+    private Answer createAndSaveAnswer(UserAccount account, Question question, AnswerType type) {
+        Answer answer = Answer.create(
+                question,
+                account,
+                "테스트 답변 내용입니다.",
+                type
+        );
+        Answer saved = testEntityManager.persist(answer);
+        testEntityManager.flush();
+        return saved;
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AiFeedbackOrchestratorTest.java
+++ b/src/test/java/com/ktb/answer/service/AiFeedbackOrchestratorTest.java
@@ -1,0 +1,366 @@
+package com.ktb.answer.service;
+
+import com.ktb.ai.feedback.dto.response.AiFeedbackBadCaseFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackMetric;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.ai.feedback.dto.response.BadCaseType;
+import com.ktb.ai.feedback.service.AiFeedbackService;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.response.feedback.FeedbackResponse;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.impl.AiFeedbackOrchestratorImpl;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.metric.domain.Metric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.metric.repository.MetricRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AiFeedbackOrchestrator 단위 테스트")
+class AiFeedbackOrchestratorTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @Mock
+    private AnswerDomainService answerDomainService;
+
+    @Mock
+    private AiFeedbackService aiFeedbackService;
+
+    @Mock
+    private MetricRepository metricRepository;
+
+    @Mock
+    private AnswerMetricRepository answerMetricRepository;
+
+    @InjectMocks
+    private AiFeedbackOrchestratorImpl aiFeedbackOrchestrator;
+
+    private static final Long ACCOUNT_ID = 1L;
+    private static final Long ANSWER_ID = 100L;
+    private static final Long QUESTION_ID = 200L;
+
+    @Nested
+    @DisplayName("getFeedbackSync() 테스트")
+    class GetFeedbackSyncTest {
+
+        @Test
+        @DisplayName("정상 응답 시 COMPLETED 상태와 피드백 반환")
+        void getFeedbackSync_WithSuccessResponse_ShouldReturnCompleted() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = createSuccessAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(metricRepository.findAllByNameIn(anyList())).thenReturn(Collections.emptyList());
+            when(metricRepository.save(any(Metric.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            FeedbackResponse result = aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo("COMPLETED");
+            assertThat(result.feedback()).isNotNull();
+            assertThat(result.radarChart()).isNotNull();
+            verify(answerRepository).save(mockAnswer);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 AnswerNotFoundException 발생")
+        void getFeedbackSync_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("권한 없는 사용자 접근 시 AnswerAccessDeniedException 발생")
+        void getFeedbackSync_WithUnauthorizedUser_ShouldThrowException() {
+            // Given
+            Long otherAccountId = 999L;
+            Answer mockAnswer = createMockAnswer();
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            doThrow(new AnswerAccessDeniedException(ANSWER_ID, otherAccountId))
+                    .when(answerDomainService).validateOwnership(mockAnswer, otherAccountId);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, otherAccountId))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("bad_case 응답 시 실패 피드백 반환")
+        void getFeedbackSync_WithBadCaseResponse_ShouldReturnFailed() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse badCaseResponse = createBadCaseAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("bad_case_detected", badCaseResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+
+            // When
+            FeedbackResponse result = aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo("COMPLETED");
+            assertThat(result.feedback()).contains(BadCaseType.TOO_SHORT.getMessage());
+            assertThat(result.radarChart()).isNull();
+            verify(answerRepository).save(mockAnswer);
+        }
+
+        @Test
+        @DisplayName("메트릭 저장 성공")
+        void getFeedbackSync_ShouldSaveMetrics() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = createSuccessAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(metricRepository.findAllByNameIn(anyList())).thenReturn(Collections.emptyList());
+            when(metricRepository.save(any(Metric.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            verify(answerMetricRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("빈 메트릭 응답 시 메트릭 저장 스킵")
+        void getFeedbackSync_WithEmptyMetrics_ShouldSkipMetricSave() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = new AiFeedbackResponse(
+                    ACCOUNT_ID, QUESTION_ID, "PRACTICE_INTERVIEW", "CS", "DB",
+                    null, null, false,
+                    new AiFeedbackFeedback("강점입니다.", "개선사항입니다.")
+            );
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+
+            // When
+            aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            verify(answerMetricRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("레이더 차트 데이터 정상 변환")
+        void getFeedbackSync_ShouldConvertRadarChartCorrectly() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = createSuccessAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(metricRepository.findAllByNameIn(anyList())).thenReturn(Collections.emptyList());
+            when(metricRepository.save(any(Metric.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            FeedbackResponse result = aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            assertThat(result.radarChart()).hasSize(2);
+            assertThat(result.radarChart().get(0).metricName()).isEqualTo("논리성");
+            assertThat(result.radarChart().get(0).score()).isEqualTo(4);
+            assertThat(result.radarChart().get(0).maxScore()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("getStatus() 테스트")
+    class GetStatusTest {
+
+        @Test
+        @DisplayName("AI_FEEDBACK_PROCESSING 상태 매핑")
+        void getStatus_WithProcessing_ShouldReturnProcessing() {
+            // Given
+            Answer mockAnswer = mock(Answer.class);
+            when(mockAnswer.getStatus()).thenReturn(AnswerStatus.AI_FEEDBACK_PROCESSING);
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackStatus result = aiFeedbackOrchestrator.getStatus(ANSWER_ID);
+
+            // Then
+            assertThat(result).isEqualTo(FeedbackStatus.PROCESSING);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태 매핑")
+        void getStatus_WithCompleted_ShouldReturnCompleted() {
+            // Given
+            Answer mockAnswer = mock(Answer.class);
+            when(mockAnswer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackStatus result = aiFeedbackOrchestrator.getStatus(ANSWER_ID);
+
+            // Then
+            assertThat(result).isEqualTo(FeedbackStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태 매핑")
+        void getStatus_WithFailed_ShouldReturnFailed() {
+            // Given
+            Answer mockAnswer = mock(Answer.class);
+            when(mockAnswer.getStatus()).thenReturn(AnswerStatus.FAILED);
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackStatus result = aiFeedbackOrchestrator.getStatus(ANSWER_ID);
+
+            // Then
+            assertThat(result).isEqualTo(FeedbackStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 예외 발생")
+        void getStatus_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.getStatus(ANSWER_ID))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("enqueue() 테스트")
+    class EnqueueTest {
+
+        @Test
+        @DisplayName("enqueue 호출 시 경고 로그만 출력 (미구현)")
+        void enqueue_ShouldLogWarning() {
+            // When & Then (예외 없이 호출 가능)
+            aiFeedbackOrchestrator.enqueue(ANSWER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("requestRetry() 테스트")
+    class RequestRetryTest {
+
+        @Test
+        @DisplayName("requestRetry 호출 시 UnsupportedOperationException 발생")
+        void requestRetry_ShouldThrowUnsupportedOperationException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.requestRetry(ANSWER_ID))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("not yet implemented");
+        }
+    }
+
+    // Helper methods
+
+    private Answer createMockAnswer() {
+        Answer answer = mock(Answer.class);
+        Question question = mock(Question.class);
+        UserAccount account = mock(UserAccount.class);
+
+        when(answer.getId()).thenReturn(ANSWER_ID);
+        when(answer.getQuestion()).thenReturn(question);
+        when(answer.getAccount()).thenReturn(account);
+        when(answer.getContent()).thenReturn("테스트 답변 내용");
+        when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+
+        when(question.getId()).thenReturn(QUESTION_ID);
+        when(question.getContent()).thenReturn("테스트 질문");
+        when(question.getType()).thenReturn(QuestionType.CS);
+        when(question.getCategory()).thenReturn(QuestionCategory.DB);
+
+        when(account.getId()).thenReturn(ACCOUNT_ID);
+
+        return answer;
+    }
+
+    private AiFeedbackResponse createSuccessAiFeedbackResponse() {
+        List<AiFeedbackMetric> metrics = List.of(
+                new AiFeedbackMetric("논리성", 4, "논리적으로 잘 설명했습니다."),
+                new AiFeedbackMetric("명확성", 5, "매우 명확하게 답변했습니다.")
+        );
+
+        AiFeedbackFeedback feedback = new AiFeedbackFeedback(
+                "강점: 논리적인 설명",
+                "개선사항: 더 구체적인 예시 필요"
+        );
+
+        return new AiFeedbackResponse(
+                ACCOUNT_ID, QUESTION_ID, "PRACTICE_INTERVIEW", "CS", "DB",
+                metrics, null, false, feedback
+        );
+    }
+
+    private AiFeedbackResponse createBadCaseAiFeedbackResponse() {
+        AiFeedbackBadCaseFeedback badCaseFeedback = new AiFeedbackBadCaseFeedback(
+                "TOO_SHORT",
+                BadCaseType.TOO_SHORT.getMessage(),
+                BadCaseType.TOO_SHORT.getGuidance()
+        );
+
+        return new AiFeedbackResponse(
+                ACCOUNT_ID, QUESTION_ID, "PRACTICE_INTERVIEW", "CS", "DB",
+                null, badCaseFeedback, null, null
+        );
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
@@ -1,0 +1,773 @@
+package com.ktb.answer.service;
+
+import com.ktb.abuse.core.AbuseCheckContext;
+import com.ktb.abuse.core.AbuseGuard;
+import com.ktb.abuse.core.AbuseGuardResult;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailExpand;
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerSubmitCommand;
+import com.ktb.answer.dto.AnswerSubmitResult;
+import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.dto.response.list.AnswerListResponse;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerListInvalidInputException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.impl.AnswerApplicationServiceImpl;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.hashtag.domain.Hashtag;
+import com.ktb.hashtag.exception.HashtagNotFoundException;
+import com.ktb.hashtag.repository.AnswerHashtagRepository;
+import com.ktb.hashtag.repository.HashtagRepository;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AnswerApplicationService 단위 테스트")
+class AnswerApplicationServiceTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @Mock
+    private AnswerDomainService answerDomainService;
+
+    @Mock
+    private ImmediateFeedbackService immediateFeedbackService;
+
+    @Mock
+    private AnswerHashtagRepository answerHashtagRepository;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @Mock
+    private AnswerMetricRepository answerMetricRepository;
+
+    @Mock
+    private AbuseGuard abuseGuard;
+
+    @InjectMocks
+    private AnswerApplicationServiceImpl answerApplicationService;
+
+    private static final Long ACCOUNT_ID = 1L;
+    private static final Long QUESTION_ID = 100L;
+    private static final Long ANSWER_ID = 1000L;
+    private static final String CLIENT_IP = "127.0.0.1";
+    private static final String VALID_ANSWER_TEXT = "유효한 답변 텍스트입니다.";
+
+    @Nested
+    @DisplayName("submit() 테스트")
+    class SubmitTest {
+
+        @Test
+        @DisplayName("정상 제출 시 PROCESSING 상태로 결과 반환")
+        void submit_WithValidData_ShouldReturnProcessingResult() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.accept();
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(
+                    List.of(new KeywordCheckResult(1L, "키워드1", true))
+            );
+            Hashtag mockHashtag = mock(Hashtag.class);
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerDomainService.createAnswer(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+            when(hashtagRepository.findById(anyLong())).thenReturn(Optional.of(mockHashtag));
+
+            // When
+            AnswerSubmitResult result = answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.answerId()).isEqualTo(ANSWER_ID);
+            assertThat(result.aiFeedbackStatus()).isEqualTo(FeedbackStatus.PROCESSING);
+            verify(answerDomainService).validateAnswerContent(VALID_ANSWER_TEXT);
+            verify(answerHashtagRepository).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("abuse 체크 실패 시 NOT_AVAILABLE 상태 반환")
+        void submit_WithAbuseNoFeedback_ShouldReturnNotAvailable() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.acceptNoFeedback(
+                    "ContentQualityGuard",
+                    "Low quality content",
+                    30
+            );
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(Collections.emptyList());
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerDomainService.createAnswer(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+
+            // When
+            AnswerSubmitResult result = answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.answerId()).isEqualTo(ANSWER_ID);
+            assertThat(result.aiFeedbackStatus()).isEqualTo(FeedbackStatus.NOT_AVAILABLE);
+            verify(answerDomainService).transitionStatus(mockAnswer, AnswerStatus.NOT_AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("해시태그 미존재 시 HashtagNotFoundException 발생")
+        void submit_WithNonExistentHashtag_ShouldThrowException() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.accept();
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(
+                    List.of(new KeywordCheckResult(999L, "존재하지않는키워드", true))
+            );
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerDomainService.createAnswer(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+            when(hashtagRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP))
+                    .isInstanceOf(HashtagNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("빈 키워드 목록일 때 해시태그 저장 호출")
+        void submit_WithEmptyKeywords_ShouldSaveEmptyHashtags() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.accept();
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(Collections.emptyList());
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerDomainService.createAnswer(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+
+            // When
+            AnswerSubmitResult result = answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.aiFeedbackStatus()).isEqualTo(FeedbackStatus.PROCESSING);
+            verify(answerHashtagRepository).saveAll(Collections.emptyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("getList() 테스트")
+    class GetListTest {
+
+        @Test
+        @DisplayName("정상적인 목록 조회")
+        void getList_WithValidParams_ShouldReturnList() {
+            // Given
+            LocalDate dateFrom = LocalDate.now().minusDays(7);
+            LocalDate dateTo = LocalDate.now();
+            int limit = 10;
+
+            Answer mockAnswer = createMockAnswerWithQuestion(ANSWER_ID, ACCOUNT_ID);
+            Slice<Answer> mockSlice = new SliceImpl<>(List.of(mockAnswer), PageRequest.of(0, limit), false);
+
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(mockSlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, dateFrom, dateTo, null, limit
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.records()).hasSize(1);
+            assertThat(result.pagination().hasNext()).isFalse();
+            assertThat(result.pagination().nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("빈 결과 조회")
+        void getList_WithNoResults_ShouldReturnEmptyList() {
+            // Given
+            Slice<Answer> emptySlice = new SliceImpl<>(Collections.emptyList());
+
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(emptySlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, null, null, null, null
+            );
+
+            // Then
+            assertThat(result.records()).isEmpty();
+            assertThat(result.pagination().hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("limit이 0일 때 예외 발생")
+        void getList_WithZeroLimit_ShouldThrowException() {
+            // Given & When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getList(
+                            ACCOUNT_ID, null, null, null, null, null, null, 0))
+                    .isInstanceOf(AnswerListInvalidInputException.class)
+                    .hasMessageContaining("limit must be between 1 and 50");
+        }
+
+        @Test
+        @DisplayName("limit이 51일 때 예외 발생")
+        void getList_WithExceedingLimit_ShouldThrowException() {
+            // Given & When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getList(
+                            ACCOUNT_ID, null, null, null, null, null, null, 51))
+                    .isInstanceOf(AnswerListInvalidInputException.class)
+                    .hasMessageContaining("limit must be between 1 and 50");
+        }
+
+        @Test
+        @DisplayName("limit 경계값 1일 때 정상 처리")
+        void getList_WithMinLimit_ShouldSucceed() {
+            // Given
+            Slice<Answer> emptySlice = new SliceImpl<>(Collections.emptyList());
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(emptySlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, null, null, null, 1
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.pagination().limit()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("limit 경계값 50일 때 정상 처리")
+        void getList_WithMaxLimit_ShouldSucceed() {
+            // Given
+            Slice<Answer> emptySlice = new SliceImpl<>(Collections.emptyList());
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(emptySlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, null, null, null, 50
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.pagination().limit()).isEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("dateFrom > dateTo일 때 예외 발생")
+        void getList_WithInvalidDateRange_ShouldThrowException() {
+            // Given
+            LocalDate dateFrom = LocalDate.now();
+            LocalDate dateTo = LocalDate.now().minusDays(7);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getList(
+                            ACCOUNT_ID, null, null, null, dateFrom, dateTo, null, 10))
+                    .isInstanceOf(AnswerListInvalidInputException.class)
+                    .hasMessageContaining("dateFrom must be before or equal to dateTo");
+        }
+
+        @Test
+        @DisplayName("잘못된 Base64 커서일 때 예외 발생")
+        void getList_WithInvalidCursor_ShouldThrowException() {
+            // Given
+            String invalidCursor = "invalid-base64-!!!";
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getList(
+                            ACCOUNT_ID, null, null, null, null, null, invalidCursor, 10))
+                    .isInstanceOf(AnswerListInvalidInputException.class)
+                    .hasMessageContaining("invalid cursor");
+        }
+
+        @Test
+        @DisplayName("커서 페이로드에 필수 필드 누락 시 예외 발생")
+        void getList_WithIncompleteCursorPayload_ShouldThrowException() {
+            // Given - last_answer_id가 null인 커서 (snake_case 사용)
+            String incompleteCursor = Base64.getEncoder()
+                    .encodeToString("{\"last_created_at\":\"2026-01-01T00:00:00\"}".getBytes());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getList(
+                            ACCOUNT_ID, null, null, null, null, null, incompleteCursor, 10))
+                    .isInstanceOf(AnswerListInvalidInputException.class)
+                    .hasMessageContaining("cursor payload is incomplete");
+        }
+
+        @Test
+        @DisplayName("유효한 커서로 조회 시 커서 기반 쿼리 실행")
+        void getList_WithValidCursor_ShouldUseCursorBasedQuery() {
+            // Given - snake_case 사용
+            String validCursor = Base64.getEncoder()
+                    .encodeToString("{\"last_created_at\":\"2026-01-01T00:00:00\",\"last_answer_id\":100}".getBytes());
+
+            Slice<Answer> emptySlice = new SliceImpl<>(Collections.emptyList());
+            when(answerRepository.findByAccountIdWithFilters(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any(), anyLong(), any()))
+                    .thenReturn(emptySlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, null, null, validCursor, 10
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            verify(answerRepository).findByAccountIdWithFilters(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any(), eq(100L), any()
+            );
+            verify(answerRepository, never()).findByAccountIdWithFiltersNoCursor(
+                    any(), any(), any(), any(), any(), any(), any()
+            );
+        }
+
+        @Test
+        @DisplayName("hasNext가 true이고 content가 있을 때 nextCursor 생성")
+        void getList_WithHasNextTrue_ShouldGenerateNextCursor() {
+            // Given
+            Answer mockAnswer = createMockAnswerWithQuestion(ANSWER_ID, ACCOUNT_ID);
+            Slice<Answer> mockSlice = new SliceImpl<>(List.of(mockAnswer), PageRequest.of(0, 10), true);
+
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(mockSlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, null, null, null, 10
+            );
+
+            // Then
+            assertThat(result.pagination().hasNext()).isTrue();
+            assertThat(result.pagination().nextCursor()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("지원되지 않는 questionType일 때 예외 발생")
+        void getList_WithUnsupportedQuestionType_ShouldThrowException() {
+            // Given
+            QuestionType unsupportedType = QuestionType.SYSTEM_DESIGN;
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getList(
+                            ACCOUNT_ID, null, null, unsupportedType, null, null, null, 10))
+                    .isInstanceOf(AnswerListInvalidInputException.class)
+                    .hasMessageContaining("questionType is only supported for");
+        }
+
+        @Test
+        @DisplayName("null limit일 때 기본값 10 사용")
+        void getList_WithNullLimit_ShouldUseDefaultLimit() {
+            // Given
+            Slice<Answer> emptySlice = new SliceImpl<>(Collections.emptyList());
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(emptySlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, null, null, null, null
+            );
+
+            // Then
+            assertThat(result.pagination().limit()).isEqualTo(10);
+        }
+    }
+
+    @Nested
+    @DisplayName("getDetail() 테스트")
+    class GetDetailTest {
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 예외 발생")
+        void getDetail_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findByIdWithQuestion(ANSWER_ID)).thenReturn(null);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getDetail(
+                            ACCOUNT_ID, ANSWER_ID, AnswerDetailQuery.empty()))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 답변 접근 시 예외 발생")
+        void getDetail_WithOtherUserAnswer_ShouldThrowException() {
+            // Given
+            Long otherAccountId = 999L;
+            Answer mockAnswer = createMockAnswerWithQuestion(ANSWER_ID, ACCOUNT_ID);
+
+            when(answerRepository.findByIdWithQuestion(ANSWER_ID)).thenReturn(mockAnswer);
+            doThrow(new AnswerAccessDeniedException(ANSWER_ID, otherAccountId))
+                    .when(answerDomainService).validateOwnership(mockAnswer, otherAccountId);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getDetail(
+                            otherAccountId, ANSWER_ID, AnswerDetailQuery.empty()))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("expand 없이 기본 정보만 조회")
+        void getDetail_WithNoExpand_ShouldReturnBasicInfo() {
+            // Given
+            Answer mockAnswer = createMockAnswerWithQuestion(ANSWER_ID, ACCOUNT_ID);
+            when(answerRepository.findByIdWithQuestion(ANSWER_ID)).thenReturn(mockAnswer);
+
+            // When
+            AnswerDetailResult result = answerApplicationService.getDetail(
+                    ACCOUNT_ID, ANSWER_ID, AnswerDetailQuery.empty()
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.answerId()).isEqualTo(ANSWER_ID);
+            assertThat(result.question()).isNull();
+            assertThat(result.immediateFeedback()).isNull();
+            assertThat(result.aiFeedback()).isNull();
+        }
+
+        @Test
+        @DisplayName("모든 expand 플래그 활성화 시 전체 정보 조회")
+        void getDetail_WithAllExpands_ShouldReturnFullInfo() {
+            // Given
+            Answer mockAnswer = createMockAnswerWithQuestion(ANSWER_ID, ACCOUNT_ID);
+            AnswerDetailQuery query = new AnswerDetailQuery(
+                    EnumSet.allOf(AnswerDetailExpand.class)
+            );
+
+            when(answerRepository.findByIdWithQuestion(ANSWER_ID)).thenReturn(mockAnswer);
+            when(answerHashtagRepository.findByAnswerIdWithHashtag(ANSWER_ID))
+                    .thenReturn(Collections.emptyList());
+            when(answerMetricRepository.findByAnswerIdWithMetric(ANSWER_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            AnswerDetailResult result = answerApplicationService.getDetail(
+                    ACCOUNT_ID, ANSWER_ID, query
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.question()).isNotNull();
+            assertThat(result.immediateFeedback()).isNotNull();
+            assertThat(result.aiFeedback()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("QUESTION expand만 활성화")
+        void getDetail_WithQuestionExpand_ShouldIncludeQuestion() {
+            // Given
+            Answer mockAnswer = createMockAnswerWithQuestion(ANSWER_ID, ACCOUNT_ID);
+            AnswerDetailQuery query = new AnswerDetailQuery(
+                    EnumSet.of(AnswerDetailExpand.QUESTION)
+            );
+
+            when(answerRepository.findByIdWithQuestion(ANSWER_ID)).thenReturn(mockAnswer);
+
+            // When
+            AnswerDetailResult result = answerApplicationService.getDetail(
+                    ACCOUNT_ID, ANSWER_ID, query
+            );
+
+            // Then
+            assertThat(result.question()).isNotNull();
+            assertThat(result.immediateFeedback()).isNull();
+            assertThat(result.aiFeedback()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getFeedback() 테스트")
+    class GetFeedbackTest {
+
+        @Test
+        @DisplayName("존재하지 않는 답변의 피드백 조회 시 예외 발생")
+        void getFeedback_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("PROCESSING 상태일 때 estimatedTimeSeconds 포함")
+        void getFeedback_WithProcessingStatus_ShouldIncludeEstimatedTime() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.PROCESSING);
+            assertThat(result.estimatedTimeSeconds()).isEqualTo(30);
+            assertThat(result.metrics()).isNull();
+            assertThat(result.comment()).isNull();
+        }
+
+        @Test
+        @DisplayName("NOT_AVAILABLE 상태일 때 metrics, comment가 null")
+        void getFeedback_WithNotAvailableStatus_ShouldReturnEmptyFeedback() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.NOT_AVAILABLE);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.NOT_AVAILABLE);
+            assertThat(result.estimatedTimeSeconds()).isNull();
+            assertThat(result.metrics()).isNull();
+        }
+
+        @Test
+        @DisplayName("FAILED 상태일 때 적절한 응답 반환")
+        void getFeedback_WithFailedStatus_ShouldReturnFailedResponse() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.FAILED);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.FAILED);
+            assertThat(result.estimatedTimeSeconds()).isNull();
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태일 때 metrics와 comment 포함")
+        void getFeedback_WithCompletedStatus_ShouldIncludeMetrics() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.COMPLETED);
+            String aiFeedback = "잘 답변하셨습니다.";
+            when(mockAnswer.getAiFeedback()).thenReturn(aiFeedback);
+            when(mockAnswer.getUpdatedAt()).thenReturn(LocalDateTime.now());
+
+            AnswerMetric metric = mock(AnswerMetric.class);
+            when(metric.getMetricName()).thenReturn("논리성");
+            when(metric.getScore()).thenReturn(85);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(answerMetricRepository.findByAnswerIdWithMetric(ANSWER_ID))
+                    .thenReturn(List.of(metric));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.COMPLETED);
+            assertThat(result.metrics()).containsEntry("논리성", 85);
+            assertThat(result.comment()).isEqualTo(aiFeedback);
+            assertThat(result.completedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("빈 metrics 리스트일 때 빈 Map 반환")
+        void getFeedback_WithEmptyMetrics_ShouldReturnEmptyMap() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.COMPLETED);
+            when(mockAnswer.getAiFeedback()).thenReturn("피드백 내용");
+            when(mockAnswer.getUpdatedAt()).thenReturn(LocalDateTime.now());
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(answerMetricRepository.findByAnswerIdWithMetric(ANSWER_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.COMPLETED);
+            assertThat(result.metrics()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 피드백 조회 시 예외 발생")
+        void getFeedback_WithOtherUserAnswer_ShouldThrowException() {
+            // Given
+            Long otherAccountId = 999L;
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.COMPLETED);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            doThrow(new AnswerAccessDeniedException(ANSWER_ID, otherAccountId))
+                    .when(answerDomainService).validateOwnership(mockAnswer, otherAccountId);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getFeedback(otherAccountId, ANSWER_ID))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("submitWithSession() 테스트")
+    class SubmitWithSessionTest {
+
+        @Test
+        @DisplayName("세션 기반 제출은 아직 미구현으로 UnsupportedOperationException 발생")
+        void submitWithSession_ShouldThrowUnsupportedOperationException() {
+            // Given
+            String sessionId = "session-123";
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.REAL_INTERVIEW
+            );
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.submitWithSession(ACCOUNT_ID, sessionId, command))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("not yet implemented");
+        }
+    }
+
+    // Helper methods
+
+    private Answer createMockAnswer(Long answerId, Long accountId, AnswerStatus status) {
+        Answer answer = mock(Answer.class);
+        UserAccount account = mock(UserAccount.class);
+
+        when(answer.getId()).thenReturn(answerId);
+        when(answer.getAccount()).thenReturn(account);
+        when(account.getId()).thenReturn(accountId);
+        when(answer.getStatus()).thenReturn(status);
+        when(answer.getContent()).thenReturn(VALID_ANSWER_TEXT);
+        when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+        when(answer.isOwnedBy(accountId)).thenReturn(true);
+
+        return answer;
+    }
+
+    private Answer createMockAnswerWithQuestion(Long answerId, Long accountId) {
+        Answer answer = mock(Answer.class);
+        UserAccount account = mock(UserAccount.class);
+        Question question = mock(Question.class);
+
+        when(answer.getId()).thenReturn(answerId);
+        when(answer.getAccount()).thenReturn(account);
+        when(account.getId()).thenReturn(accountId);
+        when(answer.getStatus()).thenReturn(AnswerStatus.SUBMITTED);
+        when(answer.getContent()).thenReturn(VALID_ANSWER_TEXT);
+        when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+        when(answer.getQuestion()).thenReturn(question);
+        when(answer.isOwnedBy(accountId)).thenReturn(true);
+        when(answer.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(question.getId()).thenReturn(QUESTION_ID);
+        when(question.getContent()).thenReturn("테스트 질문입니다.");
+        when(question.getCategory()).thenReturn(QuestionCategory.DB);
+        when(question.getType()).thenReturn(QuestionType.CS);
+
+        return answer;
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AnswerDomainServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerDomainServiceTest.java
@@ -1,0 +1,258 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerInvalidContentException;
+import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
+import com.ktb.answer.service.impl.AnswerDomainServiceImpl;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.auth.exception.account.AccountNotFoundException;
+import com.ktb.auth.repository.UserAccountRepository;
+import com.ktb.fixture.AnswerFixture;
+import com.ktb.question.domain.Question;
+import com.ktb.question.exception.QuestionNotFoundException;
+import com.ktb.question.repository.QuestionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnswerDomainService 단위 테스트")
+class AnswerDomainServiceTest {
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
+
+    @InjectMocks
+    private AnswerDomainServiceImpl answerDomainService;
+
+    private static final Long ACCOUNT_ID = 1L;
+    private static final Long QUESTION_ID = 100L;
+    private static final String VALID_CONTENT = "유효한 답변 내용입니다.";
+    private static final int MAX_CONTENT_LENGTH = 1500;
+
+    @Nested
+    @DisplayName("createAnswer() 테스트")
+    class CreateAnswerTest {
+
+        @Test
+        @DisplayName("정상적인 파라미터로 Answer 생성 성공")
+        void createAnswer_WithValidParams_ShouldSucceed() {
+            // Given
+            UserAccount mockAccount = mock(UserAccount.class);
+            Question mockQuestion = mock(Question.class);
+
+            when(userAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(mockAccount));
+            when(questionRepository.findById(QUESTION_ID)).thenReturn(Optional.of(mockQuestion));
+
+            // When
+            Answer result = answerDomainService.createAnswer(
+                    ACCOUNT_ID, QUESTION_ID, VALID_CONTENT, AnswerType.PRACTICE_INTERVIEW
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEqualTo(VALID_CONTENT);
+            assertThat(result.getType()).isEqualTo(AnswerType.PRACTICE_INTERVIEW);
+            assertThat(result.getStatus()).isEqualTo(AnswerStatus.SUBMITTED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 계정 ID로 생성 시 AccountNotFoundException 발생")
+        void createAnswer_WithNonExistentAccount_ShouldThrowException() {
+            // Given
+            when(userAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.createAnswer(
+                            ACCOUNT_ID, QUESTION_ID, VALID_CONTENT, AnswerType.PRACTICE_INTERVIEW))
+                    .isInstanceOf(AccountNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 질문 ID로 생성 시 QuestionNotFoundException 발생")
+        void createAnswer_WithNonExistentQuestion_ShouldThrowException() {
+            // Given
+            UserAccount mockAccount = mock(UserAccount.class);
+
+            when(userAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(mockAccount));
+            when(questionRepository.findById(QUESTION_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.createAnswer(
+                            ACCOUNT_ID, QUESTION_ID, VALID_CONTENT, AnswerType.PRACTICE_INTERVIEW))
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("REAL_INTERVIEW 타입으로 Answer 생성 성공")
+        void createAnswer_WithRealInterviewType_ShouldSucceed() {
+            // Given
+            UserAccount mockAccount = mock(UserAccount.class);
+            Question mockQuestion = mock(Question.class);
+
+            when(userAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(mockAccount));
+            when(questionRepository.findById(QUESTION_ID)).thenReturn(Optional.of(mockQuestion));
+
+            // When
+            Answer result = answerDomainService.createAnswer(
+                    ACCOUNT_ID, QUESTION_ID, VALID_CONTENT, AnswerType.REAL_INTERVIEW
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(AnswerType.REAL_INTERVIEW);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateOwnership() 테스트")
+    class ValidateOwnershipTest {
+
+        @Test
+        @DisplayName("소유자 검증 통과")
+        void validateOwnership_WithOwner_ShouldPass() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithAccountId(ACCOUNT_ID);
+
+            // When & Then (예외 없이 통과)
+            answerDomainService.validateOwnership(answer, ACCOUNT_ID);
+        }
+
+        @Test
+        @DisplayName("비소유자 검증 시 AnswerAccessDeniedException 발생")
+        void validateOwnership_WithNonOwner_ShouldThrowException() {
+            // Given
+            Long ownerAccountId = 1L;
+            Long otherAccountId = 999L;
+            Answer answer = AnswerFixture.createAnswerWithAccountId(ownerAccountId);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.validateOwnership(answer, otherAccountId))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("null 계정 ID로 검증 시 AnswerAccessDeniedException 발생")
+        void validateOwnership_WithNullAccountId_ShouldThrowException() {
+            // Given
+            Answer answer = AnswerFixture.createAnswerWithAccountId(ACCOUNT_ID);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.validateOwnership(answer, null))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("transitionStatus() 테스트")
+    class TransitionStatusTest {
+
+        @Test
+        @DisplayName("SUBMITTED -> IMMEDIATE_FEEDBACK_READY 유효한 전이")
+        void transitionStatus_FromSubmittedToImmediateFeedbackReady_ShouldSucceed() {
+            // Given
+            Answer answer = AnswerFixture.createAnswer();
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.SUBMITTED);
+
+            // When
+            answerDomainService.transitionStatus(answer, AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+
+            // Then
+            assertThat(answer.getStatus()).isEqualTo(AnswerStatus.IMMEDIATE_FEEDBACK_READY);
+        }
+
+        @Test
+        @DisplayName("SUBMITTED -> COMPLETED 무효한 전이 시 예외 발생")
+        void transitionStatus_FromSubmittedToCompleted_ShouldThrowException() {
+            // Given
+            Answer answer = AnswerFixture.createAnswer();
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.transitionStatus(answer, AnswerStatus.COMPLETED))
+                    .isInstanceOf(InvalidAnswerStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateAnswerContent() 테스트")
+    class ValidateAnswerContentTest {
+
+        @Test
+        @DisplayName("유효한 내용 검증 통과")
+        void validateAnswerContent_WithValidContent_ShouldPass() {
+            // When & Then (예외 없이 통과)
+            answerDomainService.validateAnswerContent(VALID_CONTENT);
+        }
+
+        @Test
+        @DisplayName("null 내용 검증 시 AnswerInvalidContentException 발생")
+        void validateAnswerContent_WithNullContent_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.validateAnswerContent(null))
+                    .isInstanceOf(AnswerInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 검증 시 AnswerInvalidContentException 발생")
+        void validateAnswerContent_WithEmptyContent_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.validateAnswerContent(""))
+                    .isInstanceOf(AnswerInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("공백만 있는 내용 검증 시 AnswerInvalidContentException 발생")
+        void validateAnswerContent_WithBlankContent_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.validateAnswerContent("   "))
+                    .isInstanceOf(AnswerInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("최대 길이 초과 시 AnswerInvalidContentException 발생")
+        void validateAnswerContent_WithExceedingLength_ShouldThrowException() {
+            // Given
+            String exceedingContent = "A".repeat(MAX_CONTENT_LENGTH + 1);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerDomainService.validateAnswerContent(exceedingContent))
+                    .isInstanceOf(AnswerInvalidContentException.class);
+        }
+
+        @Test
+        @DisplayName("최대 길이 경계값 검증 통과")
+        void validateAnswerContent_WithMaxLength_ShouldPass() {
+            // Given
+            String maxContent = "A".repeat(MAX_CONTENT_LENGTH);
+
+            // When & Then (예외 없이 통과)
+            answerDomainService.validateAnswerContent(maxContent);
+        }
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AnswerStatisticsServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerStatisticsServiceTest.java
@@ -1,0 +1,257 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.CategoryCount;
+import com.ktb.answer.dto.DailyCount;
+import com.ktb.answer.dto.TypeCount;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.impl.AnswerStatisticsServiceImpl;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.user.dto.response.CategoryDistributionResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnswerStatisticsService 단위 테스트")
+class AnswerStatisticsServiceTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @InjectMocks
+    private AnswerStatisticsServiceImpl answerStatisticsService;
+
+    private static final Long ACCOUNT_ID = 1L;
+
+    @Nested
+    @DisplayName("getTypeCounts() 테스트")
+    class GetTypeCountsTest {
+
+        @Test
+        @DisplayName("답변 타입별 카운트 조회 성공")
+        void getTypeCounts_WithAnswers_ShouldReturnCounts() {
+            // Given
+            List<AnswerType> types = List.of(AnswerType.PRACTICE_INTERVIEW, AnswerType.REAL_INTERVIEW);
+            List<TypeCount> expectedCounts = List.of(
+                    new TypeCount(AnswerType.PRACTICE_INTERVIEW, 10),
+                    new TypeCount(AnswerType.REAL_INTERVIEW, 5)
+            );
+
+            when(answerRepository.countByAccountIdAndTypeIn(ACCOUNT_ID, types))
+                    .thenReturn(expectedCounts);
+
+            // When
+            List<TypeCount> result = answerStatisticsService.getTypeCounts(ACCOUNT_ID, types);
+
+            // Then
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(TypeCount::type)
+                    .containsExactly(AnswerType.PRACTICE_INTERVIEW, AnswerType.REAL_INTERVIEW);
+            assertThat(result).extracting(TypeCount::count)
+                    .containsExactly(10L, 5L);
+        }
+
+        @Test
+        @DisplayName("답변이 없는 경우 빈 목록 반환")
+        void getTypeCounts_WithNoAnswers_ShouldReturnEmptyList() {
+            // Given
+            List<AnswerType> types = List.of(AnswerType.PRACTICE_INTERVIEW);
+
+            when(answerRepository.countByAccountIdAndTypeIn(ACCOUNT_ID, types))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            List<TypeCount> result = answerStatisticsService.getTypeCounts(ACCOUNT_ID, types);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("특정 타입 필터로 카운트 조회")
+        void getTypeCounts_WithTypeFilter_ShouldReturnFilteredCounts() {
+            // Given
+            List<AnswerType> types = List.of(AnswerType.PRACTICE_INTERVIEW);
+            List<TypeCount> expectedCounts = List.of(
+                    new TypeCount(AnswerType.PRACTICE_INTERVIEW, 15)
+            );
+
+            when(answerRepository.countByAccountIdAndTypeIn(ACCOUNT_ID, types))
+                    .thenReturn(expectedCounts);
+
+            // When
+            List<TypeCount> result = answerStatisticsService.getTypeCounts(ACCOUNT_ID, types);
+
+            // Then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).type()).isEqualTo(AnswerType.PRACTICE_INTERVIEW);
+            assertThat(result.get(0).count()).isEqualTo(15L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCategoryDistribution() 테스트")
+    class GetCategoryDistributionTest {
+
+        @Test
+        @DisplayName("카테고리별 분포 조회 성공")
+        void getCategoryDistribution_WithAnswers_ShouldReturnDistribution() {
+            // Given
+            List<CategoryCount> categoryCounts = List.of(
+                    new CategoryCount(QuestionCategory.DB, 10),
+                    new CategoryCount(QuestionCategory.NETWORK, 5),
+                    new CategoryCount(QuestionCategory.OS, 3)
+            );
+
+            when(answerRepository.countByAccountIdGroupByCategory(ACCOUNT_ID))
+                    .thenReturn(categoryCounts);
+
+            // When
+            List<CategoryDistributionResponse> result = answerStatisticsService.getCategoryDistribution(ACCOUNT_ID);
+
+            // Then
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting(CategoryDistributionResponse::category)
+                    .containsExactly(
+                            QuestionCategory.DB.getCategory(),
+                            QuestionCategory.NETWORK.getCategory(),
+                            QuestionCategory.OS.getCategory()
+                    );
+        }
+
+        @Test
+        @DisplayName("답변이 없는 경우 빈 분포 반환")
+        void getCategoryDistribution_WithNoAnswers_ShouldReturnEmptyDistribution() {
+            // Given
+            when(answerRepository.countByAccountIdGroupByCategory(ACCOUNT_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            List<CategoryDistributionResponse> result = answerStatisticsService.getCategoryDistribution(ACCOUNT_ID);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getStreakDays() 테스트")
+    class GetStreakDaysTest {
+
+        @Test
+        @DisplayName("답변이 없는 경우 0 반환")
+        void getStreakDays_WithNoAnswers_ShouldReturnZero() {
+            // Given
+            when(answerRepository.findCreatedAtByAccountIdOrderByCreatedAtDesc(ACCOUNT_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            int result = answerStatisticsService.getStreakDays(ACCOUNT_ID);
+
+            // Then
+            assertThat(result).isZero();
+        }
+
+        @Test
+        @DisplayName("연속 답변일 수 계산")
+        void getStreakDays_WithConsecutiveDays_ShouldReturnStreakCount() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            List<LocalDateTime> createdAtList = List.of(
+                    now,
+                    now.minusDays(1),
+                    now.minusDays(2)
+            );
+
+            when(answerRepository.findCreatedAtByAccountIdOrderByCreatedAtDesc(ACCOUNT_ID))
+                    .thenReturn(createdAtList);
+
+            // When
+            int result = answerStatisticsService.getStreakDays(ACCOUNT_ID);
+
+            // Then
+            assertThat(result).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("같은 날 중복 답변은 1일로 계산")
+        void getStreakDays_WithSameDayDuplicates_ShouldCountAsOneDay() {
+            // Given
+            LocalDateTime now = LocalDateTime.now();
+            List<LocalDateTime> createdAtList = List.of(
+                    now,
+                    now.minusHours(2),
+                    now.minusHours(4),
+                    now.minusDays(1)
+            );
+
+            when(answerRepository.findCreatedAtByAccountIdOrderByCreatedAtDesc(ACCOUNT_ID))
+                    .thenReturn(createdAtList);
+
+            // When
+            int result = answerStatisticsService.getStreakDays(ACCOUNT_ID);
+
+            // Then
+            assertThat(result).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyCounts() 테스트")
+    class GetDailyCountsTest {
+
+        @Test
+        @DisplayName("기간 내 일별 카운트 조회 성공")
+        void getDailyCounts_WithinRange_ShouldReturnDailyCounts() {
+            // Given
+            LocalDateTime start = LocalDateTime.now().minusDays(7);
+            LocalDateTime end = LocalDateTime.now();
+            List<DailyCount> expectedCounts = List.of(
+                    new DailyCount(LocalDate.now().minusDays(2), 3),
+                    new DailyCount(LocalDate.now().minusDays(1), 5),
+                    new DailyCount(LocalDate.now(), 2)
+            );
+
+            when(answerRepository.countByAccountIdGroupByDate(ACCOUNT_ID, start, end))
+                    .thenReturn(expectedCounts);
+
+            // When
+            List<DailyCount> result = answerStatisticsService.getDailyCounts(ACCOUNT_ID, start, end);
+
+            // Then
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting(DailyCount::count)
+                    .containsExactly(3L, 5L, 2L);
+        }
+
+        @Test
+        @DisplayName("기간 내 답변이 없는 경우 빈 목록 반환")
+        void getDailyCounts_WithNoAnswersInRange_ShouldReturnEmptyList() {
+            // Given
+            LocalDateTime start = LocalDateTime.now().minusDays(7);
+            LocalDateTime end = LocalDateTime.now();
+
+            when(answerRepository.countByAccountIdGroupByDate(ACCOUNT_ID, start, end))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            List<DailyCount> result = answerStatisticsService.getDailyCounts(ACCOUNT_ID, start, end);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/ktb/answer/service/ImmediateFeedbackServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/ImmediateFeedbackServiceTest.java
@@ -1,0 +1,219 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.service.impl.ImmediateFeedbackServiceImpl;
+import com.ktb.fixture.QuestionHashtagFixture;
+import com.ktb.hashtag.domain.QuestionHashtag;
+import com.ktb.hashtag.repository.QuestionHashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ImmediateFeedbackService 단위 테스트")
+class ImmediateFeedbackServiceTest {
+
+    @Mock
+    private QuestionHashtagRepository questionHashtagRepository;
+
+    @InjectMocks
+    private ImmediateFeedbackServiceImpl immediateFeedbackService;
+
+    private static final Long QUESTION_ID = 100L;
+
+    @Nested
+    @DisplayName("evaluate() 테스트")
+    class EvaluateTest {
+
+        @Test
+        @DisplayName("답변에 키워드가 포함된 경우 included=true 반환")
+        void evaluate_WithKeywordIncluded_ShouldReturnTrue() {
+            // Given
+            String answerText = "데이터베이스 인덱스를 사용하면 조회 성능이 향상됩니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("인덱스", "성능");
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(QUESTION_ID))
+                    .thenReturn(questionHashtags);
+
+            // When
+            ImmediateFeedbackResult result = immediateFeedbackService.evaluate(QUESTION_ID, answerText);
+
+            // Then
+            assertThat(result.keywords()).hasSize(2);
+            assertThat(result.keywords())
+                    .allMatch(KeywordCheckResult::included);
+        }
+
+        @Test
+        @DisplayName("답변에 키워드가 포함되지 않은 경우 included=false 반환")
+        void evaluate_WithKeywordNotIncluded_ShouldReturnFalse() {
+            // Given
+            String answerText = "테스트 답변입니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("인덱스", "성능");
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(QUESTION_ID))
+                    .thenReturn(questionHashtags);
+
+            // When
+            ImmediateFeedbackResult result = immediateFeedbackService.evaluate(QUESTION_ID, answerText);
+
+            // Then
+            assertThat(result.keywords()).hasSize(2);
+            assertThat(result.keywords())
+                    .noneMatch(KeywordCheckResult::included);
+        }
+
+        @Test
+        @DisplayName("질문에 키워드가 없는 경우 빈 목록 반환")
+        void evaluate_WithNoKeywords_ShouldReturnEmptyList() {
+            // Given
+            String answerText = "테스트 답변입니다.";
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(QUESTION_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            ImmediateFeedbackResult result = immediateFeedbackService.evaluate(QUESTION_ID, answerText);
+
+            // Then
+            assertThat(result.keywords()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("checkKeywords() 테스트")
+    class CheckKeywordsTest {
+
+        @Test
+        @DisplayName("대소문자 무시하고 키워드 매칭")
+        void checkKeywords_WithDifferentCase_ShouldMatch() {
+            // Given
+            String answerText = "INDEX를 사용하면 성능이 향상됩니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("index");
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().included()).isTrue();
+        }
+
+        @Test
+        @DisplayName("정확히 일치하는 키워드 매칭")
+        void checkKeywords_WithExactMatch_ShouldMatch() {
+            // Given
+            String answerText = "정규화를 통해 데이터 중복을 제거합니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("정규화");
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().included()).isTrue();
+            assertThat(results.getFirst().keyword()).isEqualTo("정규화");
+        }
+
+        @Test
+        @DisplayName("부분 문자열로 키워드 매칭")
+        void checkKeywords_WithPartialMatch_ShouldMatch() {
+            // Given
+            String answerText = "비정규화를 사용합니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("정규화");
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().included()).isTrue();
+        }
+
+        @Test
+        @DisplayName("다중 키워드 중 일부만 포함된 경우")
+        void checkKeywords_WithMultipleKeywords_ShouldMatchSome() {
+            // Given
+            String answerText = "인덱스를 사용합니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags(
+                    "인덱스", "정규화", "트랜잭션"
+            );
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(3);
+
+            long includedCount = results.stream()
+                    .filter(KeywordCheckResult::included)
+                    .count();
+            assertThat(includedCount).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("빈 키워드 목록 처리")
+        void checkKeywords_WithEmptyKeywords_ShouldReturnEmptyList() {
+            // Given
+            String answerText = "테스트 답변입니다.";
+            List<QuestionHashtag> emptyHashtags = Collections.emptyList();
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, emptyHashtags);
+
+            // Then
+            assertThat(results).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("extractKeywords() 테스트")
+    class ExtractKeywordsTest {
+
+        @Test
+        @DisplayName("질문 ID로 키워드 추출 성공")
+        void extractKeywords_WithValidQuestionId_ShouldReturnKeywords() {
+            // Given
+            Long testQuestionId = 200L;
+            List<QuestionHashtag> expectedHashtags = QuestionHashtagFixture.createMockQuestionHashtags("키워드1", "키워드2");
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(testQuestionId))
+                    .thenReturn(expectedHashtags);
+
+            // When
+            List<QuestionHashtag> results = immediateFeedbackService.extractKeywords(testQuestionId);
+
+            // Then
+            assertThat(results).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("키워드가 없는 질문에서 빈 목록 반환")
+        void extractKeywords_WithNoKeywords_ShouldReturnEmptyList() {
+            // Given
+            Long testQuestionId = 300L;
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(testQuestionId))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            List<QuestionHashtag> results = immediateFeedbackService.extractKeywords(testQuestionId);
+
+            // Then
+            assertThat(results).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/ktb/fixture/QuestionHashtagFixture.java
+++ b/src/test/java/com/ktb/fixture/QuestionHashtagFixture.java
@@ -1,0 +1,61 @@
+package com.ktb.fixture;
+
+import com.ktb.hashtag.domain.Hashtag;
+import com.ktb.hashtag.domain.QuestionHashtag;
+import com.ktb.question.domain.Question;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QuestionHashtagFixture {
+
+    public static QuestionHashtag createQuestionHashtag() {
+        return QuestionHashtag.create(
+                mock(Question.class),
+                HashtagFixture.createHashtag()
+        );
+    }
+
+    public static QuestionHashtag createQuestionHashtag(Question question, Hashtag hashtag) {
+        return QuestionHashtag.create(question, hashtag);
+    }
+
+    public static QuestionHashtag createMockQuestionHashtag(Long hashtagId, String keyword) {
+        QuestionHashtag questionHashtag = mock(QuestionHashtag.class);
+        Hashtag hashtag = mock(Hashtag.class);
+
+        when(hashtag.getId()).thenReturn(hashtagId);
+        when(hashtag.getName()).thenReturn(keyword.toLowerCase());
+        when(questionHashtag.getHashtag()).thenReturn(hashtag);
+
+        return questionHashtag;
+    }
+
+    public static List<QuestionHashtag> createMockQuestionHashtags(String... keywords) {
+        return Arrays.stream(keywords)
+                .map(keyword -> {
+                    long id = (long) keyword.hashCode();
+                    return createMockQuestionHashtag(id, keyword);
+                })
+                .toList();
+    }
+
+    public static List<QuestionHashtag> createQuestionHashtagsWithKeywords(Long questionId, String... keywords) {
+        Question question = mock(Question.class);
+        when(question.getId()).thenReturn(questionId);
+
+        return Arrays.stream(keywords)
+                .map(keyword -> {
+                    Hashtag hashtag = HashtagFixture.createHashtag(keyword);
+                    return QuestionHashtag.create(question, hashtag);
+                })
+                .toList();
+    }
+
+    public static List<QuestionHashtag> createEmptyQuestionHashtags() {
+        return List.of();
+    }
+}

--- a/src/test/java/com/ktb/fixture/UserAccountFixture.java
+++ b/src/test/java/com/ktb/fixture/UserAccountFixture.java
@@ -1,0 +1,62 @@
+package com.ktb.fixture;
+
+import com.ktb.auth.domain.UserAccount;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserAccountFixture {
+
+    private static final String DEFAULT_EMAIL = "test@example.com";
+    private static final String DEFAULT_NICKNAME = "테스트유저";
+    private static int counter = 0;
+
+    public static UserAccount createUserAccount() {
+        return UserAccount.createEmailAccount(
+                DEFAULT_EMAIL + (++counter),
+                DEFAULT_NICKNAME
+        );
+    }
+
+    public static UserAccount createUserAccount(String email, String nickname) {
+        return UserAccount.createEmailAccount(email, nickname);
+    }
+
+    public static UserAccount createUserAccountWithNickname(String nickname) {
+        return UserAccount.createEmailAccount(
+                DEFAULT_EMAIL + (++counter),
+                nickname
+        );
+    }
+
+    public static UserAccount createMockUserAccount(Long accountId) {
+        UserAccount account = mock(UserAccount.class);
+        when(account.getId()).thenReturn(accountId);
+        when(account.getEmail()).thenReturn(DEFAULT_EMAIL);
+        when(account.getNickname()).thenReturn(DEFAULT_NICKNAME);
+        when(account.isActive()).thenReturn(true);
+        return account;
+    }
+
+    public static UserAccount createMockUserAccount(Long accountId, String nickname) {
+        UserAccount account = mock(UserAccount.class);
+        when(account.getId()).thenReturn(accountId);
+        when(account.getEmail()).thenReturn(DEFAULT_EMAIL);
+        when(account.getNickname()).thenReturn(nickname);
+        when(account.isActive()).thenReturn(true);
+        return account;
+    }
+
+    public static UserAccount createMockInactiveUserAccount(Long accountId) {
+        UserAccount account = mock(UserAccount.class);
+        when(account.getId()).thenReturn(accountId);
+        when(account.getEmail()).thenReturn(DEFAULT_EMAIL);
+        when(account.getNickname()).thenReturn(DEFAULT_NICKNAME);
+        when(account.isActive()).thenReturn(false);
+        return account;
+    }
+
+    public static void resetCounter() {
+        counter = 0;
+    }
+}


### PR DESCRIPTION
## 요약
Answer 도메인의 서비스 레이어에 대한 단위 테스트 코드를 추가하여 테스트 커버리지를 향상시켰습니다.

## 변경사항

### 1. 서비스 테스트 추가
- **AnswerDomainServiceTest** (15개): 답변 생성, 소유권 검증, 상태 전이, 내용 검증
- **ImmediateFeedbackServiceTest** (10개): 즉시 피드백 평가, 키워드 매칭
- **AnswerStatisticsServiceTest** (10개): 타입별/카테고리별 통계, 연속 답변일
- **AiFeedbackOrchestratorTest** (13개): AI 피드백 동기 요청, 상태 조회
- **AnswerApplicationServiceTest** (30개): 답변 제출, 목록, 상세, 피드백 조회

### 2. Repository 테스트 추가
- **AnswerRepositoryTest**: 커스텀 쿼리 메서드 테스트

### 3. Fixture 추가
- **UserAccountFixture**: 사용자 계정 테스트 데이터 생성
- **QuestionHashtagFixture**: 질문-해시태그 연관 테스트 데이터 생성

## 관련 Issue / Commit
- closes #173 
- commit : `0f8bf6e7`

## 테스트 결과
 ```bash                                                                                                                      
 ./gradlew test --tests "com.ktb.answer.service.*"   
 
 # BUILD SUCCESSFUL - 78개 테스트 통과                                   
 ```