### PR TITLE
refactor:[#181] JWT, Cookie DIP/OCP 원칙 적용 리팩토링 진행

### DIFF
--- a/src/main/java/com/ktb/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.ktb.auth.controller;
 
 import com.ktb.auth.config.OAuthProperties;
 import com.ktb.auth.dto.AuthorizationUrlResult;
+import com.ktb.auth.dto.CookieSpec;
 import com.ktb.auth.dto.OAuthExchangeCodeResult;
 import com.ktb.auth.dto.OAuthLoginResult;
 import com.ktb.auth.dto.jwt.TokenRefreshResult;
@@ -18,7 +19,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -121,8 +121,8 @@ public class AuthController {
 
         response.setHeader("Authorization", "Bearer " + result.accessToken());
 
-        Cookie refreshTokenCookie = cookieService.createRefreshTokenCookie(result.refreshToken());
-        response.addCookie(refreshTokenCookie);
+        CookieSpec cookieSpec = cookieService.createRefreshTokenCookie(result.refreshToken());
+        response.addCookie(cookieSpec.toServletCookie());
 
         OAuthLoginResponse responseDto = new OAuthLoginResponse(result.user());
 
@@ -153,8 +153,8 @@ public class AuthController {
 
         response.setHeader("Authorization", "Bearer " + result.accessToken());
 
-        Cookie newRefreshTokenCookie = cookieService.createRefreshTokenCookie(result.refreshToken());
-        response.addCookie(newRefreshTokenCookie);
+        CookieSpec cookieSpec = cookieService.createRefreshTokenCookie(result.refreshToken());
+        response.addCookie(cookieSpec.toServletCookie());
 
         TokenRefreshResponse responseDto = new TokenRefreshResponse(result.expiresIn());
 
@@ -184,8 +184,8 @@ public class AuthController {
             oauthApplicationService.logout(principal.getAccount().getId(), refreshToken);
         }
 
-        Cookie expiredCookie = cookieService.createExpiredRefreshTokenCookie();
-        response.addCookie(expiredCookie);
+        CookieSpec expiredSpec = cookieService.createExpiredRefreshTokenCookie();
+        response.addCookie(expiredSpec.toServletCookie());
 
         return ResponseEntity.ok(
             new ApiResponse<>("logout_success", null)
@@ -210,8 +210,8 @@ public class AuthController {
 
         int revokedCount = oauthApplicationService.logoutAll(principal.getAccount().getId());
 
-        Cookie expiredCookie = cookieService.createExpiredRefreshTokenCookie();
-        response.addCookie(expiredCookie);
+        CookieSpec expiredSpec = cookieService.createExpiredRefreshTokenCookie();
+        response.addCookie(expiredSpec.toServletCookie());
 
         return ResponseEntity.ok(
             new ApiResponse<>("all_sessions_logged_out", new LogoutAllResponse(revokedCount))

--- a/src/main/java/com/ktb/auth/dto/CookieSpec.java
+++ b/src/main/java/com/ktb/auth/dto/CookieSpec.java
@@ -1,0 +1,24 @@
+package com.ktb.auth.dto;
+
+import jakarta.servlet.http.Cookie;
+
+public record CookieSpec(
+        String name,
+        String value,
+        int maxAgeSeconds,
+        String path,
+        boolean httpOnly,
+        boolean secure,
+        String sameSite
+) {
+
+    public Cookie toServletCookie() {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setMaxAge(maxAgeSeconds);
+        cookie.setPath(path);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setSecure(secure);
+        cookie.setAttribute("SameSite", sameSite);
+        return cookie;
+    }
+}

--- a/src/main/java/com/ktb/auth/dto/TokenFamilyInfo.java
+++ b/src/main/java/com/ktb/auth/dto/TokenFamilyInfo.java
@@ -1,0 +1,8 @@
+package com.ktb.auth.dto;
+
+public record TokenFamilyInfo(
+        Long id,
+        String uuid,
+        boolean active
+) {
+}

--- a/src/main/java/com/ktb/auth/dto/jwt/RefreshTokenInfo.java
+++ b/src/main/java/com/ktb/auth/dto/jwt/RefreshTokenInfo.java
@@ -2,9 +2,10 @@ package com.ktb.auth.dto.jwt;
 
 import java.time.LocalDateTime;
 
-public record RefreshTokenEntity(
+public record RefreshTokenInfo(
         Long id,
         Long familyId,
-        Boolean used,
-        LocalDateTime expiresAt) {
+        boolean used,
+        LocalDateTime expiresAt
+) {
 }

--- a/src/main/java/com/ktb/auth/service/CookieService.java
+++ b/src/main/java/com/ktb/auth/service/CookieService.java
@@ -1,24 +1,21 @@
 package com.ktb.auth.service;
 
-import jakarta.servlet.http.Cookie;
+import com.ktb.auth.dto.CookieSpec;
 
-/**
- * Cookie 관리 서비스
- */
 public interface CookieService {
 
     /**
-     * Refresh Token 쿠키 생성
+     * Refresh Token 쿠키 스펙 생성
      *
      * @param refreshToken Refresh Token 값
-     * @return 생성된 쿠키
+     * @return 쿠키 스펙
      */
-    Cookie createRefreshTokenCookie(String refreshToken);
+    CookieSpec createRefreshTokenCookie(String refreshToken);
 
     /**
-     * Refresh Token 쿠키 삭제를 위한 빈 쿠키 생성
+     * Refresh Token 쿠키 삭제를 위한 만료된 쿠키 스펙 생성
      *
-     * @return 만료된 쿠키
+     * @return 만료된 쿠키 스펙
      */
-    Cookie createExpiredRefreshTokenCookie();
+    CookieSpec createExpiredRefreshTokenCookie();
 }

--- a/src/main/java/com/ktb/auth/service/RTRService.java
+++ b/src/main/java/com/ktb/auth/service/RTRService.java
@@ -1,15 +1,15 @@
 package com.ktb.auth.service;
 
 import com.ktb.auth.domain.RevokeReason;
-import com.ktb.auth.domain.TokenFamily;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 
 public interface RTRService {
 
     /**
      * 토큰 재사용 탐지
      */
-    void detectReuse(RefreshTokenEntity tokenEntity);
+    void detectReuse(RefreshTokenInfo tokenInfo);
 
     /**
      * Family 폐기
@@ -24,11 +24,20 @@ public interface RTRService {
     /**
      * Family 생성 (새 세션 시작)
      */
-    TokenFamily createFamily(Long accountId, String deviceInfo, String clientIp);
+    TokenFamilyInfo createFamily(Long accountId, String deviceInfo, String clientIp);
 
     /**
      * Family 활성 상태 확인
      */
     void validateFamilyActive(Long familyId);
+
+    /**
+     * 계정의 모든 Family 폐기 (전체 로그아웃)
+     *
+     * @param accountId 계정 ID
+     * @param reason    폐기 사유
+     * @return 폐기된 Family 수
+     */
+    int revokeAllFamilies(Long accountId, RevokeReason reason);
 }
 

--- a/src/main/java/com/ktb/auth/service/RefreshTokenStore.java
+++ b/src/main/java/com/ktb/auth/service/RefreshTokenStore.java
@@ -1,0 +1,26 @@
+package com.ktb.auth.service;
+
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenStore {
+
+    /**
+     * Refresh Token 저장
+     *
+     * @param familyId  Token Family ID
+     * @param tokenHash 토큰 해시값
+     * @param expiresAt 만료 시각
+     */
+    void save(Long familyId, String tokenHash, LocalDateTime expiresAt);
+
+    /**
+     * 토큰 해시로 Refresh Token 조회
+     *
+     * @param tokenHash 토큰 해시값
+     * @return RefreshTokenInfo (Optional)
+     */
+    Optional<RefreshTokenInfo> findByTokenHash(String tokenHash);
+}

--- a/src/main/java/com/ktb/auth/service/TokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/TokenFamilyStore.java
@@ -1,0 +1,23 @@
+package com.ktb.auth.service;
+
+import com.ktb.auth.dto.TokenFamilyInfo;
+
+import java.util.Optional;
+
+public interface TokenFamilyStore {
+
+    /**
+     * UUID로 Token Family 조회
+     *
+     * @param uuid Family UUID
+     * @return TokenFamilyInfo (Optional)
+     */
+    Optional<TokenFamilyInfo> findByUuid(String uuid);
+
+    /**
+     * Family 마지막 사용 시각 업데이트
+     *
+     * @param uuid Family UUID
+     */
+    void updateLastUsed(String uuid);
+}

--- a/src/main/java/com/ktb/auth/service/TokenService.java
+++ b/src/main/java/com/ktb/auth/service/TokenService.java
@@ -1,9 +1,10 @@
 package com.ktb.auth.service;
 
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenClaims;
 
+import java.time.Duration;
 import java.util.List;
 
 public interface TokenService {
@@ -12,6 +13,11 @@ public interface TokenService {
      * Access Token 발급
      */
     String issueAccessToken(Long accountId, List<String> roles, String nickname);
+
+    /**
+     * Refresh Token 발급
+     */
+    String issueRefreshToken(Long accountId, String familyUuid, String nickname);
 
     /**
      * Access Token 검증
@@ -24,8 +30,34 @@ public interface TokenService {
     RefreshTokenClaims validateRefreshToken(String refreshToken);
 
     /**
-     * Refresh Token Hash로 DB 조회
+     * Refresh Token 저장
+     *
+     * @param familyId     Token Family ID
+     * @param refreshToken Refresh Token 문자열
      */
-    RefreshTokenEntity findByTokenHash(String tokenHash);
+    void storeRefreshToken(Long familyId, String refreshToken);
+
+    /**
+     * 저장된 Refresh Token 조회
+     *
+     * @param refreshToken Refresh Token 문자열
+     * @return RefreshTokenInfo
+     */
+    RefreshTokenInfo getStoredRefreshToken(String refreshToken);
+
+    /**
+     * 토큰 해시 생성
+     */
+    String generateTokenHash(String token);
+
+    /**
+     * Refresh Token 유효 기간 조회
+     */
+    Duration getRefreshTokenDuration();
+
+    /**
+     * Access Token 만료 시간(초) 조회
+     */
+    long getAccessTokenExpiresSeconds();
 }
 

--- a/src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/CookieServiceImpl.java
@@ -1,8 +1,8 @@
 package com.ktb.auth.service.impl;
 
+import com.ktb.auth.dto.CookieSpec;
 import com.ktb.auth.jwt.JwtProperties;
 import com.ktb.auth.service.CookieService;
-import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -11,30 +11,45 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CookieServiceImpl implements CookieService {
 
+    private static final String COOKIE_PATH = "/api/auth";
+    private static final String SAME_SITE_STRICT = "Strict";
+    private static final String SAME_SITE_LAX = "Lax";
+    private static final int MILLISECONDS_PER_SECOND = 1000;
+    private static final int EXPIRED_MAX_AGE = 0;
+
     private final JwtProperties jwtProperties;
 
     @Value("${cookie.secure:true}")
     private boolean cookieSecure;
 
     @Override
-    public Cookie createRefreshTokenCookie(String refreshToken) {
-        Cookie cookie = new Cookie(jwtProperties.getRefreshTokenCookieName(), refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(cookieSecure);
-        cookie.setPath("/api/auth");
-        cookie.setMaxAge((int) (jwtProperties.getRefreshTokenExpiration() / 1000));
-        cookie.setAttribute("SameSite", cookieSecure ? "Strict" : "Lax");
-        return cookie;
+    public CookieSpec createRefreshTokenCookie(String refreshToken) {
+        int maxAgeSeconds = (int) (jwtProperties.getRefreshTokenExpiration() / MILLISECONDS_PER_SECOND);
+        String sameSite = cookieSecure ? SAME_SITE_STRICT : SAME_SITE_LAX;
+
+        return new CookieSpec(
+                jwtProperties.getRefreshTokenCookieName(),
+                refreshToken,
+                maxAgeSeconds,
+                COOKIE_PATH,
+                true,
+                cookieSecure,
+                sameSite
+        );
     }
 
     @Override
-    public Cookie createExpiredRefreshTokenCookie() {
-        Cookie cookie = new Cookie(jwtProperties.getRefreshTokenCookieName(), "");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(cookieSecure);
-        cookie.setPath("/api/auth");
-        cookie.setMaxAge(0);
-        cookie.setAttribute("SameSite", cookieSecure ? "Strict" : "Lax");
-        return cookie;
+    public CookieSpec createExpiredRefreshTokenCookie() {
+        String sameSite = cookieSecure ? SAME_SITE_STRICT : SAME_SITE_LAX;
+
+        return new CookieSpec(
+                jwtProperties.getRefreshTokenCookieName(),
+                "",
+                EXPIRED_MAX_AGE,
+                COOKIE_PATH,
+                true,
+                cookieSecure,
+                sameSite
+        );
     }
 }

--- a/src/main/java/com/ktb/auth/service/impl/JpaRefreshTokenStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/JpaRefreshTokenStore.java
@@ -1,0 +1,51 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.domain.RefreshToken;
+import com.ktb.auth.domain.TokenFamily;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
+import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
+import com.ktb.auth.repository.RefreshTokenRepository;
+import com.ktb.auth.repository.TokenFamilyRepository;
+import com.ktb.auth.service.RefreshTokenStore;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JpaRefreshTokenStore implements RefreshTokenStore {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenFamilyRepository tokenFamilyRepository;
+
+    @Override
+    @Transactional
+    public void save(Long familyId, String tokenHash, LocalDateTime expiresAt) {
+        TokenFamily family = tokenFamilyRepository.findById(familyId)
+                .orElseThrow(() -> new TokenFamilyNotFoundException(familyId));
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .family(family)
+                .tokenHash(tokenHash)
+                .expiresAt(expiresAt)
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    @Override
+    public Optional<RefreshTokenInfo> findByTokenHash(String tokenHash) {
+        return refreshTokenRepository.findByTokenHashWithFamily(tokenHash)
+                .map(token -> new RefreshTokenInfo(
+                        token.getId(),
+                        token.getFamily().getId(),
+                        token.getUsed(),
+                        token.getExpiresAt()
+                ));
+    }
+}

--- a/src/main/java/com/ktb/auth/service/impl/JpaTokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/JpaTokenFamilyStore.java
@@ -1,0 +1,41 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.domain.TokenFamily;
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
+import com.ktb.auth.repository.TokenFamilyRepository;
+import com.ktb.auth.service.TokenFamilyStore;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JpaTokenFamilyStore implements TokenFamilyStore {
+
+    private final TokenFamilyRepository tokenFamilyRepository;
+
+    @Override
+    public Optional<TokenFamilyInfo> findByUuid(String uuid) {
+        return tokenFamilyRepository.findByUuid(uuid)
+                .map(family -> new TokenFamilyInfo(
+                        family.getId(),
+                        family.getUuid(),
+                        family.isValid()
+                ));
+    }
+
+    @Override
+    @Transactional
+    public void updateLastUsed(String uuid) {
+        tokenFamilyRepository.findByUuid(uuid)
+                .ifPresentOrElse(
+                    TokenFamily::updateLastUsed,
+                        () -> { throw new TokenFamilyNotFoundException(uuid); }
+                );
+    }
+}

--- a/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
@@ -4,31 +4,27 @@ import com.ktb.auth.client.KakaoOAuth2Client;
 import com.ktb.auth.config.KakaoOAuthProviderProperties;
 import com.ktb.auth.config.KakaoOAuthRegistrationProperties;
 import com.ktb.auth.domain.OAuthProvider;
-import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.RevokeReason;
-import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.dto.AuthorizationUrlResult;
 import com.ktb.auth.dto.OAuthExchangeCodeResult;
 import com.ktb.auth.dto.OAuthExchangePayload;
-import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
-import com.ktb.auth.dto.response.KakaoUserInfoResponse;
 import com.ktb.auth.dto.OAuthLoginResult;
-import com.ktb.auth.dto.jwt.TokenRefreshResult;
+import com.ktb.auth.dto.TokenFamilyInfo;
 import com.ktb.auth.dto.UserInfo;
+import com.ktb.auth.dto.jwt.RefreshTokenClaims;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
+import com.ktb.auth.dto.jwt.TokenRefreshResult;
+import com.ktb.auth.dto.response.KakaoUserInfoResponse;
 import com.ktb.auth.exception.family.FamilyOwnershipException;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
 import com.ktb.auth.exception.oauth.OAuthProviderException;
 import com.ktb.auth.exception.oauth.UnsupportedProviderException;
-import com.ktb.auth.jwt.JwtProvider;
-import com.ktb.auth.repository.RefreshTokenRepository;
-import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.service.OAuthApplicationService;
 import com.ktb.auth.service.OAuthDomainService;
 import com.ktb.auth.service.RTRService;
+import com.ktb.auth.service.TokenFamilyStore;
 import com.ktb.auth.service.TokenService;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,9 +44,7 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     private final OAuthDomainService oauthDomainService;
     private final TokenService tokenService;
     private final RTRService rtrService;
-    private final JwtProvider jwtProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final TokenFamilyRepository tokenFamilyRepository;
+    private final TokenFamilyStore tokenFamilyStore;
     private final KakaoOAuthProviderProperties kakaoProviderProperties;
     private final KakaoOAuthRegistrationProperties kakaoRegistrationProperties;
 
@@ -125,18 +119,24 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     public OAuthLoginResult exchange(String exchangeCode) {
         OAuthExchangePayload payload = oauthDomainService.consumeExchangeCode(exchangeCode);
 
-        TokenFamily family = rtrService.createFamily(payload.accountId(), payload.deviceInfo(), payload.clientIp());
+        TokenFamilyInfo family = rtrService.createFamily(
+                payload.accountId(),
+                payload.deviceInfo(),
+                payload.clientIp()
+        );
 
-        String accessToken = tokenService.issueAccessToken(payload.accountId(), DEFAULT_ROLES, payload.nickname());
-        String refreshToken = jwtProvider.createRefreshToken(payload.accountId(), family.getUuid(), payload.nickname());
+        String accessToken = tokenService.issueAccessToken(
+                payload.accountId(),
+                DEFAULT_ROLES,
+                payload.nickname()
+        );
+        String refreshToken = tokenService.issueRefreshToken(
+                payload.accountId(),
+                family.uuid(),
+                payload.nickname()
+        );
 
-        String tokenHash = jwtProvider.generateTokenHash(refreshToken);
-        RefreshToken refreshTokenEntity = RefreshToken.builder()
-                .family(family)
-                .tokenHash(tokenHash)
-                .expiresAt(LocalDateTime.now().plus(jwtProvider.refreshTokenDuration()))
-                .build();
-        refreshTokenRepository.save(refreshTokenEntity);
+        tokenService.storeRefreshToken(family.id(), refreshToken);
 
         return new OAuthLoginResult(
                 accessToken,
@@ -150,54 +150,49 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     public TokenRefreshResult refreshTokens(String refreshToken) {
         RefreshTokenClaims claims = tokenService.validateRefreshToken(refreshToken);
 
-        String tokenHash = jwtProvider.generateTokenHash(refreshToken);
-        RefreshTokenEntity tokenEntity = tokenService.findByTokenHash(tokenHash);
+        RefreshTokenInfo tokenInfo = tokenService.getStoredRefreshToken(refreshToken);
 
-        rtrService.detectReuse(tokenEntity);
+        rtrService.detectReuse(tokenInfo);
+        rtrService.validateFamilyActive(tokenInfo.familyId());
+        rtrService.markAsUsed(tokenInfo.id());
 
-        rtrService.validateFamilyActive(tokenEntity.familyId());
-
-        rtrService.markAsUsed(tokenEntity.id());
-
-        String newAccessToken = tokenService.issueAccessToken(claims.userId(), DEFAULT_ROLES, claims.userNickname());
-
-        String newRefreshToken = jwtProvider.createRefreshToken(claims.userId(), claims.familyUuid(), claims.userNickname());
-
-        TokenFamily family = tokenFamilyRepository.findByUuid(claims.familyUuid())
+        TokenFamilyInfo family = tokenFamilyStore.findByUuid(claims.familyUuid())
                 .orElseThrow(() -> new TokenFamilyNotFoundException(claims.familyUuid()));
 
-        String newTokenHash = jwtProvider.generateTokenHash(newRefreshToken);
+        String newAccessToken = tokenService.issueAccessToken(
+                claims.userId(),
+                DEFAULT_ROLES,
+                claims.userNickname()
+        );
+        String newRefreshToken = tokenService.issueRefreshToken(
+                claims.userId(),
+                claims.familyUuid(),
+                claims.userNickname()
+        );
 
-        RefreshToken newTokenEntity = RefreshToken.builder()
-                .family(family)
-                .tokenHash(newTokenHash)
-                .expiresAt(LocalDateTime.now().plus(jwtProvider.refreshTokenDuration()))
-                .build();
-
-        family.updateLastUsed();
-
-        refreshTokenRepository.save(newTokenEntity);
+        tokenFamilyStore.updateLastUsed(claims.familyUuid());
+        tokenService.storeRefreshToken(family.id(), newRefreshToken);
 
         log.info("Token Refresh 성공: userId={}, familyUuid={}", claims.userId(), claims.familyUuid());
 
-        return new TokenRefreshResult(newAccessToken, newRefreshToken, jwtProvider.accessTokenExpiresSeconds());
+        return new TokenRefreshResult(
+                newAccessToken,
+                newRefreshToken,
+                (int) tokenService.getAccessTokenExpiresSeconds()
+        );
     }
 
     @Override
     @Transactional
     public void logout(Long accountId, String refreshToken) {
-        // Refresh Token 검증
         RefreshTokenClaims claims = tokenService.validateRefreshToken(refreshToken);
 
         if (!claims.userId().equals(accountId)) {
             throw new FamilyOwnershipException();
         }
 
-        // Family UUID로 Family 조회 및 무효화
-        TokenFamily family = tokenFamilyRepository.findByUuid(claims.familyUuid())
-                .orElseThrow(() -> new TokenFamilyNotFoundException(claims.familyUuid()));
-
-        family.revoke(RevokeReason.USER_LOGOUT);
+        RefreshTokenInfo tokenInfo = tokenService.getStoredRefreshToken(refreshToken);
+        rtrService.revokeFamily(tokenInfo.familyId(), RevokeReason.USER_LOGOUT);
 
         log.info("로그아웃 성공: accountId={}, familyUuid={}", accountId, claims.familyUuid());
     }
@@ -205,7 +200,7 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     @Override
     @Transactional
     public int logoutAll(Long accountId) {
-        int count = tokenFamilyRepository.revokeAllByAccountId(accountId, RevokeReason.USER_LOGOUT);
+        int count = rtrService.revokeAllFamilies(accountId, RevokeReason.USER_LOGOUT);
 
         log.info("전체 로그아웃 성공: accountId={}, revokedCount={}", accountId, count);
         return count;

--- a/src/main/java/com/ktb/auth/service/impl/RTRServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/RTRServiceImpl.java
@@ -4,7 +4,8 @@ import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.exception.account.AccountNotFoundException;
 import com.ktb.auth.exception.family.FamilyRevokedException;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
@@ -28,10 +29,10 @@ public class RTRServiceImpl implements RTRService {
     private final UserAccountRepository userAccountRepository;
 
     @Override
-    public void detectReuse(RefreshTokenEntity tokenEntity) {
-        if (tokenEntity.used()) {
-            revokeFamily(tokenEntity.familyId(), RevokeReason.REUSE_DETECTED);
-            throw new TokenReuseDetectedException(tokenEntity.familyId());
+    public void detectReuse(RefreshTokenInfo tokenInfo) {
+        if (tokenInfo.used()) {
+            revokeFamily(tokenInfo.familyId(), RevokeReason.REUSE_DETECTED);
+            throw new TokenReuseDetectedException(tokenInfo.familyId());
         }
     }
 
@@ -48,19 +49,25 @@ public class RTRServiceImpl implements RTRService {
     @Transactional
     public void markAsUsed(Long refreshTokenId) {
         RefreshToken token = refreshTokenRepository.findById(refreshTokenId)
-                .orElseThrow(() -> new InvalidRefreshTokenException("RefreshToken을 찾을 수 없습니다."));
+                .orElseThrow(InvalidRefreshTokenException::new);
 
         token.markAsUsed();
     }
 
     @Override
     @Transactional
-    public TokenFamily createFamily(Long accountId, String deviceInfo, String clientIp) {
+    public TokenFamilyInfo createFamily(Long accountId, String deviceInfo, String clientIp) {
         UserAccount account = userAccountRepository.findById(accountId)
                 .orElseThrow(() -> new AccountNotFoundException(accountId));
 
         TokenFamily family = TokenFamily.create(account, deviceInfo, clientIp);
-        return tokenFamilyRepository.save(family);
+        TokenFamily savedFamily = tokenFamilyRepository.save(family);
+
+        return new TokenFamilyInfo(
+                savedFamily.getId(),
+                savedFamily.getUuid(),
+                savedFamily.isValid()
+        );
     }
 
     @Override
@@ -68,13 +75,14 @@ public class RTRServiceImpl implements RTRService {
         TokenFamily family = tokenFamilyRepository.findById(familyId)
                 .orElseThrow(() -> new TokenFamilyNotFoundException(familyId));
 
-        if (family.isRevoked()) {
-            throw new FamilyRevokedException();
-        }
-
-        if (family.isExpired()) {
+        if (family.isRevoked() || family.isExpired()) {
             throw new FamilyRevokedException();
         }
     }
 
+    @Override
+    @Transactional
+    public int revokeAllFamilies(Long accountId, RevokeReason reason) {
+        return tokenFamilyRepository.revokeAllByAccountId(accountId, reason);
+    }
 }

--- a/src/main/java/com/ktb/auth/service/impl/RedisRefreshTokenStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/RedisRefreshTokenStore.java
@@ -1,0 +1,40 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
+import com.ktb.auth.service.RefreshTokenStore;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis 기반 Refresh Token 저장소 구현체 (캐시 레이어)
+ * Redis 프로파일 활성화 시 사용
+ * <p>
+ * TODO: Redis 도입 시 구현 완료 필요
+ * - RedisTemplate 주입
+ * - Cache-Aside 패턴 적용
+ * - JpaRefreshTokenStore를 fallback으로 사용
+ */
+@Slf4j
+@Service
+@Profile("redis")
+@RequiredArgsConstructor
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private final JpaRefreshTokenStore jpaStore;
+
+    @Override
+    public void save(Long familyId, String tokenHash, LocalDateTime expiresAt) {
+        jpaStore.save(familyId, tokenHash, expiresAt);
+        log.debug("Redis 캐시에 Refresh Token 저장 (미구현, JPA fallback): familyId={}", familyId);
+    }
+
+    @Override
+    public Optional<RefreshTokenInfo> findByTokenHash(String tokenHash) {
+        log.debug("Redis 캐시에서 Refresh Token 조회 (미구현, JPA fallback): tokenHash={}", tokenHash);
+        return jpaStore.findByTokenHash(tokenHash);
+    }
+}

--- a/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
@@ -1,0 +1,39 @@
+package com.ktb.auth.service.impl;
+
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.service.TokenFamilyStore;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis 기반 Token Family 저장소 구현체 (캐시 레이어)
+ * Redis 프로파일 활성화 시 사용
+ * <p>
+ * TODO: Redis 도입 시 구현 완료 필요
+ * - RedisTemplate 주입
+ * - Cache-Aside 패턴 적용
+ * - JpaTokenFamilyStore를 fallback으로 사용
+ */
+@Slf4j
+@Service
+@Profile("redis")
+@RequiredArgsConstructor
+public class RedisTokenFamilyStore implements TokenFamilyStore {
+
+    private final JpaTokenFamilyStore jpaStore;
+
+    @Override
+    public Optional<TokenFamilyInfo> findByUuid(String uuid) {
+        log.debug("Redis 캐시에서 Token Family 조회 (미구현, JPA fallback): uuid={}", uuid);
+        return jpaStore.findByUuid(uuid);
+    }
+
+    @Override
+    public void updateLastUsed(String uuid) {
+        jpaStore.updateLastUsed(uuid);
+        log.debug("Redis 캐시에 Token Family 마지막 사용 시각 업데이트 (미구현, JPA fallback): uuid={}", uuid);
+    }
+}

--- a/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
@@ -1,14 +1,16 @@
 package com.ktb.auth.service.impl;
 
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenClaims;
 import com.ktb.auth.exception.token.InvalidAccessTokenException;
 import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.jwt.JwtProvider;
-import com.ktb.auth.repository.RefreshTokenRepository;
+import com.ktb.auth.service.RefreshTokenStore;
 import com.ktb.auth.service.TokenService;
 import io.jsonwebtoken.Claims;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,28 +21,41 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class TokenServiceImpl implements TokenService {
 
-    private final JwtProvider jwtProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
-
     private static final String DEFAULT_NICKNAME = "사용자";
+    private static final String CLAIM_USER_ID = "userId";
+    private static final String CLAIM_NICKNAME = "nickname";
+    private static final String CLAIM_ROLES = "roles";
+    private static final String CLAIM_FAMILY_UUID = "familyUuid";
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenStore refreshTokenStore;
 
     @Override
     public String issueAccessToken(Long accountId, List<String> roles, String nickname) {
-        if(nickname == null || nickname.isBlank()) {
-            nickname = DEFAULT_NICKNAME;
-        }
+        String effectiveNickname = (nickname == null || nickname.isBlank())
+                ? DEFAULT_NICKNAME
+                : nickname;
 
-        return jwtProvider.createAccessToken(accountId, roles, nickname);
+        return jwtProvider.createAccessToken(accountId, roles, effectiveNickname);
+    }
+
+    @Override
+    public String issueRefreshToken(Long accountId, String familyUuid, String nickname) {
+        String effectiveNickname = (nickname == null || nickname.isBlank())
+                ? DEFAULT_NICKNAME
+                : nickname;
+
+        return jwtProvider.createRefreshToken(accountId, familyUuid, effectiveNickname);
     }
 
     @Override
     public TokenClaims validateAccessToken(String accessToken) {
         try {
             Claims claims = jwtProvider.validateAccessToken(accessToken);
-            Long userId = claims.get("userId", Long.class);
-            String userNickname = claims.get("nickname", String.class);
+            Long userId = claims.get(CLAIM_USER_ID, Long.class);
+            String userNickname = claims.get(CLAIM_NICKNAME, String.class);
             @SuppressWarnings("unchecked")
-            List<String> roles = claims.get("roles", List.class);
+            List<String> roles = claims.get(CLAIM_ROLES, List.class);
 
             return new TokenClaims(userId, userNickname, roles);
         } catch (Exception e) {
@@ -52,25 +67,43 @@ public class TokenServiceImpl implements TokenService {
     public RefreshTokenClaims validateRefreshToken(String refreshToken) {
         try {
             Claims claims = jwtProvider.validateRefreshToken(refreshToken);
-            Long userId = claims.get("userId", Long.class);
-            String userNickname = claims.get("nickname", String.class);
-            String familyUuid = claims.get("familyUuid", String.class);
+            Long userId = claims.get(CLAIM_USER_ID, Long.class);
+            String userNickname = claims.get(CLAIM_NICKNAME, String.class);
+            String familyUuid = claims.get(CLAIM_FAMILY_UUID, String.class);
 
             return new RefreshTokenClaims(userId, userNickname, familyUuid);
         } catch (Exception e) {
-            throw new InvalidRefreshTokenException(e.getMessage());
+            throw new InvalidRefreshTokenException();
         }
     }
 
     @Override
-    public RefreshTokenEntity findByTokenHash(String tokenHash) {
-        return refreshTokenRepository.findByTokenHashWithFamily(tokenHash)
-                .map(token -> new RefreshTokenEntity(
-                        token.getId(),
-                        token.getFamily().getId(),
-                        token.getUsed(),
-                        token.getExpiresAt()
-                ))
+    @Transactional
+    public void storeRefreshToken(Long familyId, String refreshToken) {
+        String tokenHash = generateTokenHash(refreshToken);
+        LocalDateTime expiresAt = LocalDateTime.now().plus(getRefreshTokenDuration());
+        refreshTokenStore.save(familyId, tokenHash, expiresAt);
+    }
+
+    @Override
+    public RefreshTokenInfo getStoredRefreshToken(String refreshToken) {
+        String tokenHash = generateTokenHash(refreshToken);
+        return refreshTokenStore.findByTokenHash(tokenHash)
                 .orElseThrow(InvalidRefreshTokenException::new);
+    }
+
+    @Override
+    public String generateTokenHash(String token) {
+        return jwtProvider.generateTokenHash(token);
+    }
+
+    @Override
+    public Duration getRefreshTokenDuration() {
+        return jwtProvider.refreshTokenDuration();
+    }
+
+    @Override
+    public long getAccessTokenExpiresSeconds() {
+        return jwtProvider.accessTokenExpiresSeconds();
     }
 }

--- a/src/main/resources/application-redis.yaml
+++ b/src/main/resources/application-redis.yaml
@@ -1,0 +1,13 @@
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      timeout: 3000
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
+          max-wait: -1ms

--- a/src/test/java/com/ktb/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/ktb/auth/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.ktb.auth.controller;
 import com.ktb.auth.config.CorsProperties;
 import com.ktb.auth.config.OAuthProperties;
 import com.ktb.auth.dto.AuthorizationUrlResult;
+import com.ktb.auth.dto.CookieSpec;
 import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.auth.security.config.SecurityConfig;
 import com.ktb.auth.security.config.SecurityProperties;
@@ -115,10 +116,18 @@ class AuthControllerTest {
         // given
         UserInfo userInfo = new UserInfo("테스트유저", true);
         OAuthLoginResult result = new OAuthLoginResult(ACCESS_TOKEN, REFRESH_TOKEN, userInfo);
-        Cookie mockCookie = new Cookie("refreshToken", REFRESH_TOKEN);
+        CookieSpec cookieSpec = new CookieSpec(
+                "refreshToken",
+                REFRESH_TOKEN,
+                1209600,
+                "/api/auth",
+                true,
+                true,
+                "Strict"
+        );
 
         when(oauthApplicationService.exchange("exchange-code-123")).thenReturn(result);
-        when(cookieService.createRefreshTokenCookie(REFRESH_TOKEN)).thenReturn(mockCookie);
+        when(cookieService.createRefreshTokenCookie(REFRESH_TOKEN)).thenReturn(cookieSpec);
 
         // when & then
         mockMvc.perform(post("/api/auth/oauth/exchange").with(csrf())
@@ -138,10 +147,18 @@ class AuthControllerTest {
     void refreshTokens_ShouldSucceedAndSetNewCookie() throws Exception {
         // given
         TokenRefreshResult result = new TokenRefreshResult("new.access.token", NEW_REFRESH_TOKEN, 600);
-        Cookie newCookie = new Cookie("refreshToken", NEW_REFRESH_TOKEN);
+        CookieSpec cookieSpec = new CookieSpec(
+                "refreshToken",
+                NEW_REFRESH_TOKEN,
+                1209600,
+                "/api/auth",
+                true,
+                true,
+                "Strict"
+        );
 
         when(oauthApplicationService.refreshTokens(REFRESH_TOKEN)).thenReturn(result);
-        when(cookieService.createRefreshTokenCookie(NEW_REFRESH_TOKEN)).thenReturn(newCookie);
+        when(cookieService.createRefreshTokenCookie(NEW_REFRESH_TOKEN)).thenReturn(cookieSpec);
 
         // when & then
         mockMvc.perform(post("/api/auth/tokens").with(csrf())
@@ -169,9 +186,16 @@ class AuthControllerTest {
         // given
         SecurityUserAccount principal = new SecurityUserAccount(1L, "사용자", List.of("ROLE_USER"));
 
-        Cookie expiredCookie = new Cookie("refreshToken", "");
-        expiredCookie.setMaxAge(0);
-        when(cookieService.createExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
+        CookieSpec expiredSpec = new CookieSpec(
+                "refreshToken",
+                "",
+                0,
+                "/api/auth",
+                true,
+                true,
+                "Strict"
+        );
+        when(cookieService.createExpiredRefreshTokenCookie()).thenReturn(expiredSpec);
 
         // when & then
         mockMvc.perform(post("/api/auth/logout").with(csrf()).with(user(principal))
@@ -189,9 +213,16 @@ class AuthControllerTest {
         SecurityUserAccount principal = new SecurityUserAccount(1L, "사용자", List.of("ROLE_USER"));
 
         when(oauthApplicationService.logoutAll(any())).thenReturn(3);
-        Cookie expiredCookie = new Cookie("refreshToken", "");
-        expiredCookie.setMaxAge(0);
-        when(cookieService.createExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
+        CookieSpec expiredSpec = new CookieSpec(
+                "refreshToken",
+                "",
+                0,
+                "/api/auth",
+                true,
+                true,
+                "Strict"
+        );
+        when(cookieService.createExpiredRefreshTokenCookie()).thenReturn(expiredSpec);
 
         // when & then
         mockMvc.perform(post("/api/auth/logout/all").with(csrf()).with(user(principal)))

--- a/src/test/java/com/ktb/auth/service/CookieServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/CookieServiceTest.java
@@ -1,5 +1,6 @@
 package com.ktb.auth.service;
 
+import com.ktb.auth.dto.CookieSpec;
 import com.ktb.auth.jwt.JwtProperties;
 import com.ktb.auth.service.impl.CookieServiceImpl;
 import jakarta.servlet.http.Cookie;
@@ -46,13 +47,33 @@ class CookieServiceTest {
         }
 
         @Test
-        @DisplayName("Refresh Token 쿠키 생성 시 Secure=true, SameSite=Strict 설정")
+        @DisplayName("Refresh Token 쿠키 스펙 생성 시 Secure=true, SameSite=Strict 설정")
         void createRefreshTokenCookie_ShouldSetSecureAndStrictSameSite() {
             // given
             when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
 
             // when
-            Cookie cookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
+            CookieSpec spec = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
+
+            // then
+            assertThat(spec.name()).isEqualTo(COOKIE_NAME);
+            assertThat(spec.value()).isEqualTo(SAMPLE_REFRESH_TOKEN);
+            assertThat(spec.httpOnly()).isTrue();
+            assertThat(spec.secure()).isTrue();
+            assertThat(spec.path()).isEqualTo("/api/auth");
+            assertThat(spec.maxAgeSeconds()).isEqualTo((int) (REFRESH_TOKEN_EXPIRATION / 1000));
+            assertThat(spec.sameSite()).isEqualTo("Strict");
+        }
+
+        @Test
+        @DisplayName("CookieSpec에서 Servlet Cookie로 변환이 성공해야 한다")
+        void toServletCookie_ShouldConvertCorrectly() {
+            // given
+            when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
+            CookieSpec spec = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
+
+            // when
+            Cookie cookie = spec.toServletCookie();
 
             // then
             assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
@@ -65,19 +86,19 @@ class CookieServiceTest {
         }
 
         @Test
-        @DisplayName("만료된 Refresh Token 쿠키 생성 시 Secure=true, SameSite=Strict 설정")
+        @DisplayName("만료된 Refresh Token 쿠키 스펙 생성 시 Secure=true, SameSite=Strict 설정")
         void createExpiredRefreshTokenCookie_ShouldSetSecureAndStrictSameSite() {
             // when
-            Cookie cookie = cookieService.createExpiredRefreshTokenCookie();
+            CookieSpec spec = cookieService.createExpiredRefreshTokenCookie();
 
             // then
-            assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
-            assertThat(cookie.getValue()).isEmpty();
-            assertThat(cookie.isHttpOnly()).isTrue();
-            assertThat(cookie.getSecure()).isTrue();
-            assertThat(cookie.getPath()).isEqualTo("/api/auth");
-            assertThat(cookie.getMaxAge()).isZero();
-            assertThat(cookie.getAttribute("SameSite")).isEqualTo("Strict");
+            assertThat(spec.name()).isEqualTo(COOKIE_NAME);
+            assertThat(spec.value()).isEmpty();
+            assertThat(spec.httpOnly()).isTrue();
+            assertThat(spec.secure()).isTrue();
+            assertThat(spec.path()).isEqualTo("/api/auth");
+            assertThat(spec.maxAgeSeconds()).isZero();
+            assertThat(spec.sameSite()).isEqualTo("Strict");
         }
     }
 
@@ -92,38 +113,38 @@ class CookieServiceTest {
         }
 
         @Test
-        @DisplayName("Refresh Token 쿠키 생성 시 Secure=false, SameSite=Lax 설정")
+        @DisplayName("Refresh Token 쿠키 스펙 생성 시 Secure=false, SameSite=Lax 설정")
         void createRefreshTokenCookie_ShouldSetInsecureAndLaxSameSite() {
             // given
             when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
 
             // when
-            Cookie cookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
+            CookieSpec spec = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
 
             // then
-            assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
-            assertThat(cookie.getValue()).isEqualTo(SAMPLE_REFRESH_TOKEN);
-            assertThat(cookie.isHttpOnly()).isTrue();
-            assertThat(cookie.getSecure()).isFalse();
-            assertThat(cookie.getPath()).isEqualTo("/api/auth");
-            assertThat(cookie.getMaxAge()).isEqualTo((int) (REFRESH_TOKEN_EXPIRATION / 1000));
-            assertThat(cookie.getAttribute("SameSite")).isEqualTo("Lax");
+            assertThat(spec.name()).isEqualTo(COOKIE_NAME);
+            assertThat(spec.value()).isEqualTo(SAMPLE_REFRESH_TOKEN);
+            assertThat(spec.httpOnly()).isTrue();
+            assertThat(spec.secure()).isFalse();
+            assertThat(spec.path()).isEqualTo("/api/auth");
+            assertThat(spec.maxAgeSeconds()).isEqualTo((int) (REFRESH_TOKEN_EXPIRATION / 1000));
+            assertThat(spec.sameSite()).isEqualTo("Lax");
         }
 
         @Test
-        @DisplayName("만료된 Refresh Token 쿠키 생성 시 Secure=false, SameSite=Lax 설정")
+        @DisplayName("만료된 Refresh Token 쿠키 스펙 생성 시 Secure=false, SameSite=Lax 설정")
         void createExpiredRefreshTokenCookie_ShouldSetInsecureAndLaxSameSite() {
             // when
-            Cookie cookie = cookieService.createExpiredRefreshTokenCookie();
+            CookieSpec spec = cookieService.createExpiredRefreshTokenCookie();
 
             // then
-            assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
-            assertThat(cookie.getValue()).isEmpty();
-            assertThat(cookie.isHttpOnly()).isTrue();
-            assertThat(cookie.getSecure()).isFalse();
-            assertThat(cookie.getPath()).isEqualTo("/api/auth");
-            assertThat(cookie.getMaxAge()).isZero();
-            assertThat(cookie.getAttribute("SameSite")).isEqualTo("Lax");
+            assertThat(spec.name()).isEqualTo(COOKIE_NAME);
+            assertThat(spec.value()).isEmpty();
+            assertThat(spec.httpOnly()).isTrue();
+            assertThat(spec.secure()).isFalse();
+            assertThat(spec.path()).isEqualTo("/api/auth");
+            assertThat(spec.maxAgeSeconds()).isZero();
+            assertThat(spec.sameSite()).isEqualTo("Lax");
         }
     }
 
@@ -135,10 +156,10 @@ class CookieServiceTest {
         when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
 
         // when
-        Cookie cookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
+        CookieSpec spec = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
 
         // then
-        assertThat(cookie.getMaxAge()).isEqualTo(1209600);
+        assertThat(spec.maxAgeSeconds()).isEqualTo(1209600);
     }
 
     @Test
@@ -149,13 +170,13 @@ class CookieServiceTest {
         when(jwtProperties.getRefreshTokenExpiration()).thenReturn(REFRESH_TOKEN_EXPIRATION);
 
         // when
-        Cookie expiredCookie = cookieService.createExpiredRefreshTokenCookie();
-        Cookie normalCookie = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
+        CookieSpec expiredSpec = cookieService.createExpiredRefreshTokenCookie();
+        CookieSpec normalSpec = cookieService.createRefreshTokenCookie(SAMPLE_REFRESH_TOKEN);
 
         // then
-        assertThat(expiredCookie.isHttpOnly()).isEqualTo(normalCookie.isHttpOnly());
-        assertThat(expiredCookie.getSecure()).isEqualTo(normalCookie.getSecure());
-        assertThat(expiredCookie.getPath()).isEqualTo(normalCookie.getPath());
-        assertThat(expiredCookie.getAttribute("SameSite")).isEqualTo(normalCookie.getAttribute("SameSite"));
+        assertThat(expiredSpec.httpOnly()).isEqualTo(normalSpec.httpOnly());
+        assertThat(expiredSpec.secure()).isEqualTo(normalSpec.secure());
+        assertThat(expiredSpec.path()).isEqualTo(normalSpec.path());
+        assertThat(expiredSpec.sameSite()).isEqualTo(normalSpec.sameSite());
     }
 }

--- a/src/test/java/com/ktb/auth/service/OAuthApplicationServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/OAuthApplicationServiceTest.java
@@ -4,28 +4,24 @@ import com.ktb.auth.client.KakaoOAuth2Client;
 import com.ktb.auth.config.KakaoOAuthProviderProperties;
 import com.ktb.auth.config.KakaoOAuthRegistrationProperties;
 import com.ktb.auth.domain.OAuthProvider;
-import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
-import com.ktb.auth.exception.oauth.OAuthProviderException;
-import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.RevokeReason;
-import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.dto.AuthorizationUrlResult;
 import com.ktb.auth.dto.KakaoAccount;
 import com.ktb.auth.dto.KakaoProfile;
 import com.ktb.auth.dto.OAuthExchangeCodeResult;
 import com.ktb.auth.dto.OAuthExchangePayload;
-import com.ktb.auth.dto.response.KakaoUserInfoResponse;
 import com.ktb.auth.dto.OAuthLoginResult;
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.dto.jwt.RefreshTokenClaims;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenRefreshResult;
+import com.ktb.auth.dto.response.KakaoUserInfoResponse;
 import com.ktb.auth.exception.family.FamilyRevokedException;
 import com.ktb.auth.exception.oauth.InvalidExchangeCodeException;
 import com.ktb.auth.exception.oauth.InvalidStateException;
+import com.ktb.auth.exception.oauth.OAuthProviderException;
 import com.ktb.auth.exception.token.TokenReuseDetectedException;
-import com.ktb.auth.jwt.JwtProvider;
-import com.ktb.auth.repository.RefreshTokenRepository;
-import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.service.impl.OAuthApplicationServiceImpl;
 import com.ktb.common.domain.ErrorCode;
 import com.ktb.common.exception.BusinessException;
@@ -36,7 +32,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -65,13 +60,7 @@ class OAuthApplicationServiceTest {
     private RTRService rtrService;
 
     @Mock
-    private JwtProvider jwtProvider;
-
-    @Mock
-    private RefreshTokenRepository refreshTokenRepository;
-
-    @Mock
-    private TokenFamilyRepository tokenFamilyRepository;
+    private TokenFamilyStore tokenFamilyStore;
 
     @Mock
     private KakaoOAuthProviderProperties kakaoProviderProperties;
@@ -226,15 +215,12 @@ class OAuthApplicationServiceTest {
     void exchange_WithValidCode_ShouldSucceed() {
         // given
         OAuthExchangePayload payload = new OAuthExchangePayload(USER_ID, USER_NICKNAME, true, DEVICE_INFO, CLIENT_IP);
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(mockFamily.getUuid()).thenReturn(FAMILY_UUID);
+        TokenFamilyInfo familyInfo = new TokenFamilyInfo(FAMILY_ID, FAMILY_UUID, true);
 
         when(oauthDomainService.consumeExchangeCode(EXCHANGE_CODE)).thenReturn(payload);
-        when(rtrService.createFamily(USER_ID, DEVICE_INFO, CLIENT_IP)).thenReturn(mockFamily);
+        when(rtrService.createFamily(USER_ID, DEVICE_INFO, CLIENT_IP)).thenReturn(familyInfo);
         when(tokenService.issueAccessToken(USER_ID, List.of("ROLE_USER"), USER_NICKNAME)).thenReturn(ACCESS_TOKEN);
-        when(jwtProvider.createRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn(REFRESH_TOKEN);
-        when(jwtProvider.generateTokenHash(REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
-        when(jwtProvider.refreshTokenDuration()).thenReturn(Duration.ofDays(14));
+        when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn(REFRESH_TOKEN);
 
         // when
         OAuthLoginResult result = oauthApplicationService.exchange(EXCHANGE_CODE);
@@ -244,7 +230,7 @@ class OAuthApplicationServiceTest {
         assertThat(result.refreshToken()).isEqualTo(REFRESH_TOKEN);
         assertThat(result.user().nickname()).isEqualTo("신규유저");
         assertThat(result.user().isNewUser()).isTrue();
-        verify(refreshTokenRepository).save(any(RefreshToken.class));
+        verify(tokenService).storeRefreshToken(FAMILY_ID, REFRESH_TOKEN);
     }
 
     @Test
@@ -266,21 +252,18 @@ class OAuthApplicationServiceTest {
     void refreshTokens_ShouldSucceed() {
         // given
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
-        RefreshTokenEntity tokenEntity = new RefreshTokenEntity(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
-        TokenFamily mockFamily = mock(TokenFamily.class);
+        RefreshTokenInfo tokenInfo = new RefreshTokenInfo(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
+        TokenFamilyInfo familyInfo = new TokenFamilyInfo(FAMILY_ID, FAMILY_UUID, true);
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(jwtProvider.generateTokenHash(REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
-        when(tokenService.findByTokenHash(TOKEN_HASH)).thenReturn(tokenEntity);
-        doNothing().when(rtrService).detectReuse(tokenEntity);
+        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(tokenInfo);
+        doNothing().when(rtrService).detectReuse(tokenInfo);
         doNothing().when(rtrService).validateFamilyActive(FAMILY_ID);
         doNothing().when(rtrService).markAsUsed(100L);
+        when(tokenFamilyStore.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(familyInfo));
         when(tokenService.issueAccessToken(USER_ID, List.of("ROLE_USER"), USER_NICKNAME)).thenReturn("new.access.token");
-        when(jwtProvider.createRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
-        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
-        when(jwtProvider.generateTokenHash("new.refresh.token")).thenReturn("new-token-hash");
-        when(jwtProvider.refreshTokenDuration()).thenReturn(Duration.ofDays(14));
-        when(jwtProvider.accessTokenExpiresSeconds()).thenReturn(600);
+        when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
+        when(tokenService.getAccessTokenExpiresSeconds()).thenReturn(600L);
 
         // when
         TokenRefreshResult result = oauthApplicationService.refreshTokens(REFRESH_TOKEN);
@@ -291,8 +274,8 @@ class OAuthApplicationServiceTest {
         assertThat(result.expiresIn()).isEqualTo(600);
 
         verify(rtrService).markAsUsed(100L);
-        verify(mockFamily).updateLastUsed();
-        verify(refreshTokenRepository).save(any(RefreshToken.class));
+        verify(tokenFamilyStore).updateLastUsed(FAMILY_UUID);
+        verify(tokenService).storeRefreshToken(FAMILY_ID, "new.refresh.token");
     }
 
     @Test
@@ -300,11 +283,10 @@ class OAuthApplicationServiceTest {
     void refreshTokens_WithReusedToken_ShouldRevokeFamily() {
         // given
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, FAMILY_UUID, USER_NICKNAME);
-        RefreshTokenEntity usedToken = new RefreshTokenEntity(100L, FAMILY_ID, true, LocalDateTime.now().plusDays(7));
+        RefreshTokenInfo usedToken = new RefreshTokenInfo(100L, FAMILY_ID, true, LocalDateTime.now().plusDays(7));
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(jwtProvider.generateTokenHash(REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
-        when(tokenService.findByTokenHash(TOKEN_HASH)).thenReturn(usedToken);
+        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(usedToken);
         doThrow(new TokenReuseDetectedException(FAMILY_ID))
                 .when(rtrService).detectReuse(usedToken);
 
@@ -322,16 +304,16 @@ class OAuthApplicationServiceTest {
     void logout_ShouldSucceed() {
         // given
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
-        TokenFamily mockFamily = mock(TokenFamily.class);
+        RefreshTokenInfo tokenInfo = new RefreshTokenInfo(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(tokenInfo);
 
         // when
         oauthApplicationService.logout(USER_ID, REFRESH_TOKEN);
 
         // then
-        verify(mockFamily).revoke(RevokeReason.USER_LOGOUT);
+        verify(rtrService).revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT);
     }
 
     @Test
@@ -348,21 +330,21 @@ class OAuthApplicationServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("세션 소유권이 일치하지 않습니다");
 
-        verify(tokenFamilyRepository, never()).findByUuid(any());
+        verify(tokenFamilyStore, never()).findByUuid(any());
     }
 
     @Test
     @DisplayName("전체 기기 로그아웃 성공")
     void logoutAll_ShouldSucceed() {
         // given
-        when(tokenFamilyRepository.revokeAllByAccountId(USER_ID, RevokeReason.USER_LOGOUT)).thenReturn(3);
+        when(rtrService.revokeAllFamilies(USER_ID, RevokeReason.USER_LOGOUT)).thenReturn(3);
 
         // when
         int revokedCount = oauthApplicationService.logoutAll(USER_ID);
 
         // then
         assertThat(revokedCount).isEqualTo(3);
-        verify(tokenFamilyRepository).revokeAllByAccountId(USER_ID, RevokeReason.USER_LOGOUT);
+        verify(rtrService).revokeAllFamilies(USER_ID, RevokeReason.USER_LOGOUT);
     }
 
     @Test
@@ -370,12 +352,11 @@ class OAuthApplicationServiceTest {
     void refreshTokens_WithRevokedFamily_ShouldThrowException() {
         // given
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, FAMILY_UUID, USER_NICKNAME);
-        RefreshTokenEntity tokenEntity = new RefreshTokenEntity(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
+        RefreshTokenInfo tokenInfo = new RefreshTokenInfo(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(jwtProvider.generateTokenHash(REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
-        when(tokenService.findByTokenHash(TOKEN_HASH)).thenReturn(tokenEntity);
-        doNothing().when(rtrService).detectReuse(tokenEntity);
+        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(tokenInfo);
+        doNothing().when(rtrService).detectReuse(tokenInfo);
         doThrow(new FamilyRevokedException(FAMILY_ID))
                 .when(rtrService).validateFamilyActive(FAMILY_ID);
 

--- a/src/test/java/com/ktb/auth/service/RTRServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/RTRServiceTest.java
@@ -4,7 +4,8 @@ import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.exception.account.AccountNotFoundException;
 import com.ktb.auth.exception.family.FamilyRevokedException;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
@@ -62,13 +63,12 @@ class RTRServiceTest {
         when(tokenFamilyRepository.save(any(TokenFamily.class))).thenReturn(mockFamily);
 
         // when
-        TokenFamily family = rtrService.createFamily(USER_ID, DEVICE_INFO, CLIENT_IP);
+        TokenFamilyInfo familyInfo = rtrService.createFamily(USER_ID, DEVICE_INFO, CLIENT_IP);
 
         // then
-        assertThat(family).isNotNull();
-        assertThat(family.getDeviceInfo()).isEqualTo(DEVICE_INFO);
-        assertThat(family.getClientIp()).isEqualTo(CLIENT_IP);
-        assertThat(family.isRevoked()).isFalse();
+        assertThat(familyInfo).isNotNull();
+        assertThat(familyInfo.uuid()).isNotNull();
+        assertThat(familyInfo.active()).isTrue();
 
         verify(userAccountRepository).findById(USER_ID);
         verify(tokenFamilyRepository).save(any(TokenFamily.class));
@@ -92,7 +92,7 @@ class RTRServiceTest {
     @DisplayName("토큰 재사용 탐지 시 Family가 폐기되어야 한다")
     void detectReuse_WithUsedToken_ShouldRevokeFamily() {
         // given
-        RefreshTokenEntity usedToken = new RefreshTokenEntity(TOKEN_ID, FAMILY_ID, true, LocalDateTime.now().plusDays(7));
+        RefreshTokenInfo usedToken = new RefreshTokenInfo(TOKEN_ID, FAMILY_ID, true, LocalDateTime.now().plusDays(7));
 
         TokenFamily mockFamily = mock(TokenFamily.class);
         when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
@@ -109,7 +109,7 @@ class RTRServiceTest {
     @DisplayName("사용되지 않은 토큰은 재사용 탐지를 통과해야 한다")
     void detectReuse_WithUnusedToken_ShouldPass() {
         // given
-        RefreshTokenEntity unusedToken = new RefreshTokenEntity(TOKEN_ID, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
+        RefreshTokenInfo unusedToken = new RefreshTokenInfo(TOKEN_ID, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
 
         // when
         rtrService.detectReuse(unusedToken);
@@ -141,8 +141,7 @@ class RTRServiceTest {
 
         // when & then
         assertThatThrownBy(() -> rtrService.markAsUsed(TOKEN_ID))
-                .isInstanceOf(InvalidRefreshTokenException.class)
-                .hasMessageContaining("Refresh Token이 유효하지 않습니다");
+                .isInstanceOf(InvalidRefreshTokenException.class);
 
         verify(refreshTokenRepository).findById(TOKEN_ID);
     }

--- a/src/test/java/com/ktb/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/TokenServiceTest.java
@@ -1,19 +1,12 @@
 package com.ktb.auth.service;
 
-import com.ktb.auth.domain.RefreshToken;
-import com.ktb.auth.domain.TokenFamily;
-import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenEntity;
+import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenClaims;
 import com.ktb.auth.exception.token.InvalidAccessTokenException;
 import com.ktb.auth.exception.token.InvalidRefreshTokenException;
-import com.ktb.auth.jwt.JwtProperties;
 import com.ktb.auth.jwt.JwtProvider;
-import com.ktb.auth.repository.RefreshTokenRepository;
-import com.ktb.auth.repository.UserAccountRepository;
 import com.ktb.auth.service.impl.TokenServiceImpl;
-import com.ktb.common.config.WithMockCustomUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +34,7 @@ class TokenServiceTest {
     private JwtProvider jwtProvider;
 
     @Mock
-    private RefreshTokenRepository refreshTokenRepository;
+    private RefreshTokenStore refreshTokenStore;
 
     @InjectMocks
     private TokenServiceImpl tokenService;
@@ -150,44 +144,111 @@ class TokenServiceTest {
     }
 
     @Test
-    @DisplayName("Token Hash로 Refresh Token 조회가 성공해야 한다")
-    void findByTokenHash_WithValidHash_ShouldSucceed() {
+    @DisplayName("Refresh Token 발급이 성공해야 한다")
+    void issueRefreshToken_ShouldSucceed() {
         // given
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(mockFamily.getId()).thenReturn(1L);
-
-        RefreshToken mockToken = mock(RefreshToken.class);
-        when(mockToken.getId()).thenReturn(10L);
-        when(mockToken.getFamily()).thenReturn(mockFamily);
-        when(mockToken.getUsed()).thenReturn(false);
-        when(mockToken.getExpiresAt()).thenReturn(LocalDateTime.now().plusDays(7));
-
-        when(refreshTokenRepository.findByTokenHashWithFamily(TOKEN_HASH))
-                .thenReturn(Optional.of(mockToken));
+        when(jwtProvider.createRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn(VALID_REFRESH_TOKEN);
 
         // when
-        RefreshTokenEntity entity = tokenService.findByTokenHash(TOKEN_HASH);
+        String refreshToken = tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME);
 
         // then
-        assertThat(entity.id()).isEqualTo(10L);
-        assertThat(entity.familyId()).isEqualTo(1L);
-        assertThat(entity.used()).isFalse();
-        assertThat(entity.expiresAt()).isAfter(LocalDateTime.now());
-
-        verify(refreshTokenRepository).findByTokenHashWithFamily(TOKEN_HASH);
+        assertThat(refreshToken).isEqualTo(VALID_REFRESH_TOKEN);
+        verify(jwtProvider).createRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME);
     }
 
     @Test
-    @DisplayName("존재하지 않는 Token Hash 조회 시 예외가 발생해야 한다")
-    void findByTokenHash_WithNonExistentHash_ShouldThrowException() {
+    @DisplayName("저장된 Refresh Token 조회가 성공해야 한다")
+    void getStoredRefreshToken_WithValidToken_ShouldSucceed() {
         // given
-        when(refreshTokenRepository.findByTokenHashWithFamily(anyString()))
-                .thenReturn(Optional.empty());
+        RefreshTokenInfo expectedInfo = new RefreshTokenInfo(10L, 1L, false, LocalDateTime.now().plusDays(7));
+
+        when(jwtProvider.generateTokenHash(VALID_REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
+        when(refreshTokenStore.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(expectedInfo));
+
+        // when
+        RefreshTokenInfo info = tokenService.getStoredRefreshToken(VALID_REFRESH_TOKEN);
+
+        // then
+        assertThat(info.id()).isEqualTo(10L);
+        assertThat(info.familyId()).isEqualTo(1L);
+        assertThat(info.used()).isFalse();
+        assertThat(info.expiresAt()).isAfter(LocalDateTime.now());
+
+        verify(jwtProvider).generateTokenHash(VALID_REFRESH_TOKEN);
+        verify(refreshTokenStore).findByTokenHash(TOKEN_HASH);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Refresh Token 조회 시 예외가 발생해야 한다")
+    void getStoredRefreshToken_WithNonExistentToken_ShouldThrowException() {
+        // given
+        when(jwtProvider.generateTokenHash(anyString())).thenReturn("nonexistent-hash");
+        when(refreshTokenStore.findByTokenHash(anyString())).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> tokenService.findByTokenHash("nonexistent-hash"))
+        assertThatThrownBy(() -> tokenService.getStoredRefreshToken("nonexistent-token"))
                 .isInstanceOf(InvalidRefreshTokenException.class);
 
-        verify(refreshTokenRepository).findByTokenHashWithFamily("nonexistent-hash");
+        verify(refreshTokenStore).findByTokenHash("nonexistent-hash");
+    }
+
+    @Test
+    @DisplayName("Refresh Token 저장이 성공해야 한다")
+    void storeRefreshToken_ShouldSucceed() {
+        // given
+        Long familyId = 1L;
+        when(jwtProvider.generateTokenHash(VALID_REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
+        when(jwtProvider.refreshTokenDuration()).thenReturn(Duration.ofDays(14));
+
+        // when
+        tokenService.storeRefreshToken(familyId, VALID_REFRESH_TOKEN);
+
+        // then
+        verify(jwtProvider).generateTokenHash(VALID_REFRESH_TOKEN);
+        verify(refreshTokenStore).save(eq(familyId), eq(TOKEN_HASH), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("토큰 해시 생성이 성공해야 한다")
+    void generateTokenHash_ShouldSucceed() {
+        // given
+        when(jwtProvider.generateTokenHash(VALID_ACCESS_TOKEN)).thenReturn(TOKEN_HASH);
+
+        // when
+        String hash = tokenService.generateTokenHash(VALID_ACCESS_TOKEN);
+
+        // then
+        assertThat(hash).isEqualTo(TOKEN_HASH);
+        verify(jwtProvider).generateTokenHash(VALID_ACCESS_TOKEN);
+    }
+
+    @Test
+    @DisplayName("Refresh Token 유효 기간 조회가 성공해야 한다")
+    void getRefreshTokenDuration_ShouldSucceed() {
+        // given
+        Duration expectedDuration = Duration.ofDays(14);
+        when(jwtProvider.refreshTokenDuration()).thenReturn(expectedDuration);
+
+        // when
+        Duration duration = tokenService.getRefreshTokenDuration();
+
+        // then
+        assertThat(duration).isEqualTo(expectedDuration);
+        verify(jwtProvider).refreshTokenDuration();
+    }
+
+    @Test
+    @DisplayName("Access Token 만료 시간 조회가 성공해야 한다")
+    void getAccessTokenExpiresSeconds_ShouldSucceed() {
+        // given
+        when(jwtProvider.accessTokenExpiresSeconds()).thenReturn(600);
+
+        // when
+        long expiresSeconds = tokenService.getAccessTokenExpiresSeconds();
+
+        // then
+        assertThat(expiresSeconds).isEqualTo(600);
+        verify(jwtProvider).accessTokenExpiresSeconds();
     }
 }


### PR DESCRIPTION
## 요약
인증 도메인(OAuth, Token, RTR, Cookie)에 DIP/OCP 원칙을 적용하여 인프라 변경 시 영향 범위를 최소화하고 Redis 확장 구조를 준비했습니다.

## 변경사항

### 1. OAuthApplicationServiceImpl 직접 의존 제거
- JwtProvider, RefreshTokenRepository, TokenFamilyRepository 직접 의존 제거
- TokenService, RTRService, TokenFamilyStore 추상화 계층으로 교체

### 2. TokenService 유스케이스 중심 리팩터링
- `issueRefreshToken`, `storeRefreshToken`, `getStoredRefreshToken` 메서드 추가
- `RefreshTokenInfo` DTO 도입 (기존 RefreshTokenEntity 대체)

### 3. CookieService VO 기반 변경
- `Cookie` → `CookieSpec` VO 반환으로 jakarta.servlet 의존 제거
- Controller에서 `CookieSpec.toServletCookie()` 호출

### 4. RTRService 엔티티 노출 축소
- `TokenFamily` → `TokenFamilyInfo` DTO 반환으로 엔티티 캡슐화

### 5. Store 인터페이스 도입
- `RefreshTokenStore`, `TokenFamilyStore` 포트 인터페이스 추가
- `JpaRefreshTokenStore`, `JpaTokenFamilyStore` (@Primary)
- `RedisRefreshTokenStore`, `RedisTokenFamilyStore` (@Profile("redis") 스텁)

## 관련 Issue / Commit
 - closes #181 