### PR TITLE
feat:[#185]Question 카테고리 체계 개편 및 정합성/로그/테스트 보강

### DIFF
--- a/src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
@@ -25,9 +25,13 @@ public record AiFeedbackRequest(
         String type,
 
         @JsonProperty("category")
-        // AI 서버가 허용하는 카테고리 값 목록입니다.
+        // 현재 QuestionCategory enum 기준 전체 카테고리 목록입니다.
         @Schema(description = "질문 카테고리", example = "DB", requiredMode = Schema.RequiredMode.REQUIRED,
-                allowableValues = {"OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "ALGORITHM", "DATA_STRUCTURE"})
+                allowableValues = {
+                        "OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "DATA_STRUCTURE_ALGORITHM",
+                        "SOCIAL", "NOTIFICATION", "REALTIME", "SEARCH", "MEDIA", "STORAGE", "PLATFORM", "TRANSACTION",
+                        "PORTFOLIO"
+                })
         String category,
 
         @JsonProperty("interview_type")

--- a/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
@@ -27,7 +27,11 @@ public record AiFeedbackResponse(
 
         @JsonProperty("category")
         @Schema(description = "질문 카테고리", example = "DB",
-                allowableValues = {"OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "ALGORITHM", "DATA_STRUCTURE"})
+                allowableValues = {
+                        "OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "DATA_STRUCTURE_ALGORITHM",
+                        "SOCIAL", "NOTIFICATION", "REALTIME", "SEARCH", "MEDIA", "STORAGE", "PLATFORM", "TRANSACTION",
+                        "PORTFOLIO"
+                })
         String category,
 
         @JsonProperty("metrics")

--- a/src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java
@@ -21,11 +21,16 @@ public record AnswerListRequest(
         AnswerType type,
 
         @Parameter(description = "질문 카테고리 필터 (선택)", example = "OS")
-        @Schema(description = "질문 카테고리 필터 (OS, NETWORK, DB, COMPUTER_ARCHITECTURE, DATA_STRUCTURE_ALGORITHM)", example = "OS")
+        @Schema(
+                description = "질문 카테고리 필터 "
+                        + "(OS, NETWORK, DB, COMPUTER_ARCHITECTURE, DATA_STRUCTURE_ALGORITHM, "
+                        + "SOCIAL, NOTIFICATION, REALTIME, SEARCH, MEDIA, STORAGE, PLATFORM, TRANSACTION, PORTFOLIO)",
+                example = "OS"
+        )
         QuestionCategory category,
 
-        @Parameter(description = "질문 타입 필터 (선택, MVP: CS만 허용)", example = "CS")
-        @Schema(description = "질문 타입 필터 (CS, SYSTEM_DESIGN, PORTFOLIO). 현재는 CS만 지원", example = "CS")
+        @Parameter(description = "질문 타입 필터 (선택)", example = "CS")
+        @Schema(description = "질문 타입 필터 (CS, SYSTEM_DESIGN, PORTFOLIO)", example = "CS")
         QuestionType questionType,
 
         @Parameter(description = "조회 시작 날짜 (YYYY-MM-DD, 미입력 시 dateTo 기준 1개월 전)", example = "2026-01-01")

--- a/src/main/java/com/ktb/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/ktb/answer/repository/AnswerRepository.java
@@ -33,7 +33,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
             AND q.type = COALESCE(:questionType, q.type)
             AND a.createdAt >= :dateFrom
             AND a.createdAt <= :dateTo
-            AND (:cursorCreatedAt IS NULL OR a.createdAt < :cursorCreatedAt
+            AND (a.createdAt < :cursorCreatedAt
                  OR (a.createdAt = :cursorCreatedAt AND a.id < :cursorAnswerId))
             ORDER BY a.createdAt DESC, a.id DESC
             """)

--- a/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
@@ -32,8 +32,6 @@ import com.ktb.answer.repository.AnswerRepository;
 import com.ktb.answer.service.AnswerApplicationService;
 import com.ktb.answer.service.AnswerDomainService;
 import com.ktb.answer.service.ImmediateFeedbackService;
-import com.ktb.auth.domain.UserAccount;
-import com.ktb.auth.service.UserAccountService;
 import com.ktb.answer.exception.AnswerListInvalidInputException;
 import com.ktb.file.exception.FileAlreadyDeletedException;
 import com.ktb.file.exception.FileExtensionNotAllowedException;
@@ -50,10 +48,8 @@ import com.ktb.metric.repository.AnswerMetricRepository;
 import com.ktb.question.domain.Question;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
-import com.ktb.question.dto.QuestionDetailResponse;
 import com.ktb.question.exception.QuestionDisabledException;
 import com.ktb.question.exception.QuestionNotFoundException;
-import com.ktb.question.service.QuestionService;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -74,7 +70,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class AnswerApplicationServiceImpl implements AnswerApplicationService {
-
     private final AnswerRepository answerRepository;
     private final AnswerDomainService answerDomainService;
     private final ImmediateFeedbackService immediateFeedbackService;
@@ -111,25 +106,25 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
 
         Slice<Answer> answers = cursorPayload == null
                 ? answerRepository.findByAccountIdWithFiltersNoCursor(
-                        accountId,
-                        type,
-                        category,
-                        questionType,
-                        from,
-                        to,
-                        pageRequest
-                )
+                accountId,
+                type,
+                category,
+                questionType,
+                from,
+                to,
+                pageRequest
+        )
                 : answerRepository.findByAccountIdWithFilters(
-                        accountId,
-                        type,
-                        category,
-                        questionType,
-                        from,
-                        to,
-                        cursorPayload.lastCreatedAt(),
-                        cursorPayload.lastAnswerId(),
-                        pageRequest
-                );
+                accountId,
+                type,
+                category,
+                questionType,
+                from,
+                to,
+                cursorPayload.lastCreatedAt(),
+                cursorPayload.lastAnswerId(),
+                pageRequest
+        );
 
         return toAnswerListResponse(answers, resolvedLimit);
     }
@@ -154,10 +149,10 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
         AbuseGuardResult abuseResult = abuseGuard.check(abuseContext);
 
         Answer answer = answerRepository.save(answerDomainService.createAnswer(
-            accountId,
-            command.questionId(),
-            command.answerText(),
-            command.answerType()
+                accountId,
+                command.questionId(),
+                command.answerText(),
+                command.answerType()
         ));
 
         ImmediateFeedbackResult immediateFeedback = immediateFeedbackService.evaluate(
@@ -180,24 +175,24 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
 
     private void saveAnswerHashtags(Answer answer, ImmediateFeedbackResult feedback) {
         List<AnswerHashtag> answerHashtags = feedback.keywords().stream()
-            .map(keywordResult -> {
-                Hashtag hashtag = hashtagRepository.findById(keywordResult.keywordId())
-                    .orElseThrow(() -> new HashtagNotFoundException(keywordResult.keywordId()));
+                .map(keywordResult -> {
+                    Hashtag hashtag = hashtagRepository.findById(keywordResult.keywordId())
+                            .orElseThrow(() -> new HashtagNotFoundException(keywordResult.keywordId()));
 
-                return AnswerHashtag.create(
-                    answer,
-                    hashtag,
-                    keywordResult.included()
-                );
-            })
-            .toList();
+                    return AnswerHashtag.create(
+                            answer,
+                            hashtag,
+                            keywordResult.included()
+                    );
+                })
+                .toList();
 
         answerHashtagRepository.saveAll(answerHashtags);
 
         log.debug("AnswerHashtags saved - answerId: {}, total: {}, included: {}",
-                  answer.getId(),
-                  answerHashtags.size(),
-                  answerHashtags.stream().filter(ah -> ah.isIncluded()).count());
+                answer.getId(),
+                answerHashtags.size(),
+                answerHashtags.stream().filter(ah -> ah.isIncluded()).count());
     }
 
     @Override
@@ -226,7 +221,7 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
 
     @Override
     public AnswerDetailResult getDetail(Long accountId, Long answerId, AnswerDetailQuery query)
-        throws AnswerNotFoundException, AnswerAccessDeniedException {
+            throws AnswerNotFoundException, AnswerAccessDeniedException {
 
         log.debug("Retrieving answer detail for answerId: {}, accountId: {}", answerId, accountId);
 
@@ -238,20 +233,20 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
         answerDomainService.validateOwnership(answer, accountId);
 
         AnswerContentResult answerContent = new AnswerContentResult(
-            answer.getContent(),
-            null,  // audioUrl (MVP V2: 파일 연동 시 구현)
-            null,  // videoUrl (MVP V2: 파일 연동 시 구현)
-            answer.getCreatedAt() == null ? null : answer.getCreatedAt().toString()
+                answer.getContent(),
+                null,  // audioUrl (MVP V2: 파일 연동 시 구현)
+                null,  // videoUrl (MVP V2: 파일 연동 시 구현)
+                answer.getCreatedAt() == null ? null : answer.getCreatedAt().toString()
         );
 
         QuestionSummary questionSummary = null;
         if (query.includeQuestion()) {
             Question question = answer.getQuestion();
             questionSummary = new QuestionSummary(
-                question.getId(),
-                question.getContent(),
-                question.getCategory().name(),
-                question.getType().name()
+                    question.getId(),
+                    question.getContent(),
+                    question.getCategory().name(),
+                    question.getType().name()
             );
         }
 
@@ -266,13 +261,13 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
         }
 
         return new AnswerDetailResult(
-            answer.getId(),
-            answer.getStatus(),
-            answer.getType(),
-            questionSummary,
-            answerContent,
-            immediateFeedback,
-            aiFeedback
+                answer.getId(),
+                answer.getStatus(),
+                answer.getType(),
+                questionSummary,
+                answerContent,
+                immediateFeedback,
+                aiFeedback
         );
     }
 
@@ -280,12 +275,12 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
         List<AnswerHashtag> answerHashtags = answerHashtagRepository.findByAnswerIdWithHashtag(answerId);
 
         List<KeywordCheckResult> keywords = answerHashtags.stream()
-            .map(ah -> new KeywordCheckResult(
-                ah.getHashtag().getId(),
-                ah.getHashtag().getName(),
-                ah.isIncluded()
-            ))
-            .toList();
+                .map(ah -> new KeywordCheckResult(
+                        ah.getHashtag().getId(),
+                        ah.getHashtag().getName(),
+                        ah.isIncluded()
+                ))
+                .toList();
 
         return new ImmediateFeedbackResult(keywords);
     }
@@ -365,8 +360,11 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
         if (questionType == null) {
             return;
         }
-        if (questionType != QuestionType.CS) {
-            throw new AnswerListInvalidInputException("questionType is only supported for [CS, SYSTEM_DESIGN, PORTFOLIO]");
+
+        if (questionType == QuestionType.PORTFOLIO) {
+            throw new AnswerListInvalidInputException(
+                    "questionType is only supported for [CS, SYSTEM_DESIGN]"
+            );
         }
     }
 

--- a/src/main/java/com/ktb/common/domain/ErrorCode.java
+++ b/src/main/java/com/ktb/common/domain/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     QUESTION_CONTENT_HAS_SPACES(400, "Q008", "질문 내용은 앞뒤 공백을 포함할 수 없습니다"),
     QUESTION_CONTENT_TOO_SHORT(400, "Q009", "질문 내용은 2자 이상이어야 합니다"),
     QUESTION_CONTENT_TOO_LONG(400, "Q010", "질문 내용은 200자를 초과할 수 없습니다"),
+    QUESTION_TYPE_CATEGORY_MISMATCH(400, "Q011", "질문 유형과 카테고리 조합이 올바르지 않습니다"),
 
     // ==================== Answer 관련 ====================
     ANSWER_NOT_FOUND(404, "A001", "답변을 찾을 수 없습니다"),

--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -24,6 +24,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/questions")
 @RequiredArgsConstructor
 @Validated
+@Slf4j
 public class QuestionController {
 
     private final QuestionService questionService;
@@ -62,7 +64,11 @@ public class QuestionController {
             @Parameter(description = "사이즈", example = "10")
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
     ) {
+        log.info("GET /api/questions - type: {}, category: {}, cursor: {}, size: {}",
+                type, category, cursor, size);
         QuestionListResponse result = questionService.getQuestions(category, type, cursor, size);
+        log.info("GET /api/questions success - count: {}, hasNext: {}",
+                result.questions().size(), result.pagination().hasNext());
         return ResponseEntity.ok(new ApiResponse<>("questions_retrieval_success", result));
     }
 
@@ -75,7 +81,9 @@ public class QuestionController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
     public ResponseEntity<ApiResponse<QuestionCategoryListResponse>> getQuestionCategories() {
+        log.info("GET /api/questions/categories");
         QuestionCategoryListResponse result = questionService.getQuestionCategories();
+        log.info("GET /api/questions/categories success - typeGroups: {}", result.categories().size());
         return ResponseEntity.ok(new ApiResponse<>("question_categories_retrieval_success", result));
     }
 
@@ -88,7 +96,9 @@ public class QuestionController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
     public ResponseEntity<ApiResponse<QuestionTypeListResponse>> getQuestionTypes() {
+        log.info("GET /api/questions/types");
         QuestionTypeListResponse result = questionService.getQuestionTypes();
+        log.info("GET /api/questions/types success - count: {}", result.types().size());
         return ResponseEntity.ok(new ApiResponse<>("question_types_retrieval_success", result));
     }
 
@@ -106,7 +116,10 @@ public class QuestionController {
             @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId
     ) {
+        log.info("GET /api/questions/{}", questionId);
         QuestionDetailResponse result = questionService.getQuestionDetail(questionId);
+        log.info("GET /api/questions/{} success - type: {}, category: {}",
+                questionId, result.type(), result.category());
         return ResponseEntity.ok(new ApiResponse<>("question_retrieval_success", result));
     }
 
@@ -128,7 +141,11 @@ public class QuestionController {
             @Parameter(description = "사이즈", example = "10")
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
     ) {
+        log.info("GET /api/questions/search - keyword: {}, type: {}, category: {}, cursor: {}, size: {}",
+                keyword, type, category, cursor, size);
         QuestionSearchResponse result = questionService.search(keyword, category, type, cursor, size);
+        log.info("GET /api/questions/search success - count: {}, hasNext: {}",
+                result.questions().size(), result.pagination().hasNext());
         return ResponseEntity.ok(new ApiResponse<>("search_success", result));
     }
 
@@ -143,7 +160,10 @@ public class QuestionController {
                     content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
     })
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> getDailyRecommendation() {
+        log.info("GET /api/questions/recommendation");
         QuestionDetailResponse result = questionService.getDailyRecommendation();
+        log.info("GET /api/questions/recommendation success - questionId: {}, type: {}, category: {}",
+                result.questionId(), result.type(), result.category());
         return ResponseEntity.ok(new ApiResponse<>("question_recommendation_success", result));
     }
 
@@ -160,7 +180,11 @@ public class QuestionController {
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> createQuestion(
             @Valid @RequestBody QuestionCreateRequest request
     ) {
+        int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
+        log.info("POST /api/questions - type: {}, category: {}, keywordCount: {}",
+                request.type(), request.category(), keywordCount);
         QuestionDetailResponse result = questionService.createQuestion(request);
+        log.info("POST /api/questions success - questionId: {}", result.questionId());
         return ResponseEntity.status(201)
                 .body(new ApiResponse<>("question_created_success", result));
     }
@@ -180,7 +204,11 @@ public class QuestionController {
             @PathVariable Long questionId,
             @RequestBody QuestionUpdateRequest request
     ) {
+        int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
+        log.info("PATCH /api/questions/{} - hasContent: {}, type: {}, category: {}, useYn: {}, keywordCount: {}",
+                questionId, request.content() != null, request.type(), request.category(), request.useYn(), keywordCount);
         QuestionDetailResponse result = questionService.updateQuestion(questionId, request);
+        log.info("PATCH /api/questions/{} success", questionId);
         return ResponseEntity.ok(new ApiResponse<>("question_updated_success", result));
     }
 
@@ -198,7 +226,9 @@ public class QuestionController {
             @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId
     ) {
+        log.info("DELETE /api/questions/{}", questionId);
         questionService.deleteQuestion(questionId);
+        log.info("DELETE /api/questions/{} success", questionId);
         return ResponseEntity.ok(new ApiResponse<>("question_deleted_success", null));
     }
 
@@ -216,7 +246,9 @@ public class QuestionController {
             @Parameter(description = "질문 ID", example = "1")
             @PathVariable Long questionId
     ) {
+        log.info("GET /api/questions/{}/keywords", questionId);
         QuestionKeywordListResponse result = questionService.getQuestionKeywords(questionId);
+        log.info("GET /api/questions/{}/keywords success - count: {}", questionId, result.keywords().size());
         return ResponseEntity.ok(new ApiResponse<>("question_keywords_retrieval_success", result));
     }
 
@@ -235,7 +267,14 @@ public class QuestionController {
             @PathVariable Long questionId,
             @Valid @RequestBody QuestionKeywordCheckRequest request
     ) {
+        int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
+        log.info("POST /api/questions/{}/keyword-checks - keywordCount: {}", questionId, keywordCount);
         QuestionKeywordCheckResponse result = questionService.checkQuestionKeywords(questionId, request.keywords());
+        long includedCount = result.keywords().stream()
+                .filter(match -> match.included())
+                .count();
+        log.info("POST /api/questions/{}/keyword-checks success - includedCount: {}",
+                questionId, includedCount);
         return ResponseEntity.ok(new ApiResponse<>("question_keywords_check_success", result));
     }
 }

--- a/src/main/java/com/ktb/question/domain/Question.java
+++ b/src/main/java/com/ktb/question/domain/Question.java
@@ -6,6 +6,7 @@ import com.ktb.question.exception.QuestionAlreadyDeletedException;
 import com.ktb.question.exception.QuestionInvalidContentException;
 import com.ktb.question.exception.QuestionRequiredCategoryException;
 import com.ktb.question.exception.QuestionRequiredTypeException;
+import com.ktb.question.exception.QuestionTypeCategoryMismatchException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -60,6 +61,7 @@ public class Question extends BaseActivatableEntity {
         validateContent(content);
         validateType(type);
         validateCategory(category);
+        validateTypeAndCategory(type, category);
         this.content = content;
         this.type = type;
         this.category = category;
@@ -88,12 +90,14 @@ public class Question extends BaseActivatableEntity {
     public void updateType(QuestionType type) {
         validateNotDeleted();
         validateType(type);
+        validateTypeAndCategory(type, this.category);
         this.type = type;
     }
 
     public void updateCategory(QuestionCategory category) {
         validateNotDeleted();
         validateCategory(category);
+        validateTypeAndCategory(this.type, category);
         this.category = category;
     }
 
@@ -140,6 +144,12 @@ public class Question extends BaseActivatableEntity {
     private void validateCategory(QuestionCategory category) {
         if (category == null) {
             throw new QuestionRequiredCategoryException();
+        }
+    }
+
+    private void validateTypeAndCategory(QuestionType type, QuestionCategory category) {
+        if (!category.supports(type)) {
+            throw new QuestionTypeCategoryMismatchException();
         }
     }
 

--- a/src/main/java/com/ktb/question/domain/QuestionCategory.java
+++ b/src/main/java/com/ktb/question/domain/QuestionCategory.java
@@ -1,5 +1,7 @@
 package com.ktb.question.domain;
 
+import java.util.EnumSet;
+import java.util.List;
 import lombok.Getter;
 
 /**
@@ -7,15 +9,36 @@ import lombok.Getter;
  */
 @Getter
 public enum QuestionCategory {
-    OS("운영체제"),
-    NETWORK("네트워크"),
-    DB("데이터베이스"),
-    COMPUTER_ARCHITECTURE("컴퓨터 구조"),
-    DATA_STRUCTURE_ALGORITHM("자료구조&알고리즘");
+    // CS
+    OS("운영체제", QuestionType.CS),
+    NETWORK("네트워크", QuestionType.CS),
+    DB("데이터베이스", QuestionType.CS),
+    COMPUTER_ARCHITECTURE("컴퓨터 구조", QuestionType.CS),
+    DATA_STRUCTURE_ALGORITHM("자료구조&알고리즘", QuestionType.CS),
+
+    // SYSTEM_DESIGN
+    SOCIAL("소셜/피드 시스템", QuestionType.SYSTEM_DESIGN),
+    NOTIFICATION("알림 시스템", QuestionType.SYSTEM_DESIGN),
+    REALTIME("실시간 통신 시스템", QuestionType.SYSTEM_DESIGN),
+    SEARCH("검색 시스템", QuestionType.SYSTEM_DESIGN),
+    MEDIA("미디어/스트리밍 시스템", QuestionType.SYSTEM_DESIGN),
+    STORAGE("파일 저장/협업 시스템", QuestionType.SYSTEM_DESIGN),
+    PLATFORM("플랫폼 인프라 시스템", QuestionType.SYSTEM_DESIGN),
+    TRANSACTION("거래/정산 시스템", QuestionType.SYSTEM_DESIGN),
+
+    // PORTFOLIO
+    PORTFOLIO("포트폴리오", QuestionType.PORTFOLIO);
 
     private final String category;
+    private final EnumSet<QuestionType> supportedTypes;
 
-    QuestionCategory(String category) {
+    QuestionCategory(String category, QuestionType... supportedTypes) {
         this.category = category;
+        this.supportedTypes = EnumSet.noneOf(QuestionType.class);
+        this.supportedTypes.addAll(List.of(supportedTypes));
+    }
+
+    public boolean supports(QuestionType type) {
+        return supportedTypes.contains(type);
     }
 }

--- a/src/main/java/com/ktb/question/dto/QuestionCategoryListResponse.java
+++ b/src/main/java/com/ktb/question/dto/QuestionCategoryListResponse.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 @Schema(description = "질문 카테고리 목록 응답")
 public record QuestionCategoryListResponse(
-        @Schema(description = "질문 카테고리 맵 (key: enum name, value: label)")
-        Map<String, String> categories
+        @Schema(description = "질문 유형별 카테고리 맵 (key: questionType, value: 카테고리 맵)")
+        Map<String, Map<String, String>> categories
 ) {
 }

--- a/src/main/java/com/ktb/question/exception/QuestionDisabledException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionDisabledException.java
@@ -6,7 +6,9 @@ import com.ktb.common.exception.BusinessException;
 public class QuestionDisabledException extends BusinessException {
 
     public QuestionDisabledException(Long questionId) {
-        String errMsg = String.format("%s: %d", ErrorCode.QUESTION_DISABLED.getMessage(), questionId);
-        super(ErrorCode.QUESTION_DISABLED, errMsg);
+        super(
+                ErrorCode.QUESTION_DISABLED,
+                String.format("%s: %d", ErrorCode.QUESTION_DISABLED.getMessage(), questionId)
+        );
     }
 }

--- a/src/main/java/com/ktb/question/exception/QuestionTypeCategoryMismatchException.java
+++ b/src/main/java/com/ktb/question/exception/QuestionTypeCategoryMismatchException.java
@@ -1,0 +1,11 @@
+package com.ktb.question.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class QuestionTypeCategoryMismatchException extends BusinessException {
+
+    public QuestionTypeCategoryMismatchException() {
+        super(ErrorCode.QUESTION_TYPE_CATEGORY_MISMATCH);
+    }
+}

--- a/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
@@ -27,13 +27,16 @@ import com.ktb.question.service.QuestionService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
@@ -43,9 +46,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class QuestionServiceImpl implements QuestionService {
 
     private static final int MIN_SEARCH_KEYWORD_LENGTH = 2;
+    private static final Set<QuestionType> EXPOSED_TYPES = EnumSet.of(
+            QuestionType.CS,
+            QuestionType.SYSTEM_DESIGN
+    );
 
     private final QuestionRepository questionRepository;
     private final QuestionHashtagRepository questionHashtagRepository;
@@ -53,9 +61,14 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionListResponse getQuestions(QuestionCategory category, QuestionType type, Long cursor, int size) {
+        log.debug("getQuestions - type: {}, category: {}, cursor: {}, size: {}",
+                type, category, cursor, size);
         PageRequest pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
         Slice<Question> questions = questionRepository.findActiveByFilters(type, category, cursor, pageable);
         Map<Long, List<String>> keywordMap = loadKeywordsByQuestionIds(questions.getContent());
+
+        log.debug("getQuestions success - count: {}, hasNext: {}",
+                questions.getContent().size(), questions.hasNext());
 
         return new QuestionListResponse(
                 toSummaryResponses(questions.getContent(), keywordMap),
@@ -65,19 +78,27 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionDetailResponse getQuestionDetail(Long questionId) {
+        log.debug("getQuestionDetail - questionId: {}", questionId);
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
+        log.debug("getQuestionDetail success - questionId: {}, type: {}, category: {}",
+                question.getId(), question.getType(), question.getCategory());
         return toDetailResponse(question);
     }
 
     @Override
     public QuestionSearchResponse search(String keyword, QuestionCategory category, QuestionType type, Long cursor, int size) {
+        log.debug("search - keyword: {}, type: {}, category: {}, cursor: {}, size: {}",
+                keyword, type, category, cursor, size);
         validateKeyword(keyword);
 
         PageRequest pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
         Slice<Question> questions = questionRepository.searchActiveByKeyword(keyword, type, category, cursor, pageable);
         Map<Long, List<String>> keywordMap = loadKeywordsByQuestionIds(questions.getContent());
+
+        log.debug("search success - count: {}, hasNext: {}",
+                questions.getContent().size(), questions.hasNext());
 
         return new QuestionSearchResponse(
                 toSummaryResponses(questions.getContent(), keywordMap),
@@ -87,28 +108,38 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     public QuestionDetailResponse getDailyRecommendation() {
+        log.debug("getDailyRecommendation");
         Long questionId = questionRepository.findRandomActiveId()
                 .orElseThrow(() -> new QuestionNotFoundException(0L));
 
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
+        log.info("getDailyRecommendation success - questionId: {}, type: {}, category: {}",
+                question.getId(), question.getType(), question.getCategory());
         return toDetailResponse(question);
     }
 
     @Override
     @Transactional
     public QuestionDetailResponse createQuestion(QuestionCreateRequest request) {
+        int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
+        log.info("createQuestion - type: {}, category: {}, keywordCount: {}",
+                request.type(), request.category(), keywordCount);
         Question question = Question.create(request.content(), request.type(), request.category());
         Question saved = questionRepository.save(question);
         attachKeywords(saved, request.keywords());
 
+        log.info("createQuestion success - questionId: {}", saved.getId());
         return toDetailResponse(saved);
     }
 
     @Override
     @Transactional
     public QuestionDetailResponse updateQuestion(Long questionId, QuestionUpdateRequest request) {
+        int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
+        log.info("updateQuestion - questionId: {}, hasContent: {}, type: {}, category: {}, useYn: {}, keywordCount: {}",
+                questionId, request.content() != null, request.type(), request.category(), request.useYn(), keywordCount);
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
@@ -132,22 +163,28 @@ public class QuestionServiceImpl implements QuestionService {
             replaceKeywords(question, request.keywords());
         }
 
+        log.info("updateQuestion success - questionId: {}", questionId);
         return toDetailResponse(question);
     }
 
     @Override
     @Transactional
     public void deleteQuestion(Long questionId) {
+        log.info("deleteQuestion - questionId: {}", questionId);
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
         if (question.isUseYn()) {
             question.delete();
+            log.info("deleteQuestion success - questionId: {}, deleted: true", questionId);
+            return;
         }
+        log.info("deleteQuestion skipped - questionId: {}, reason: already inactive", questionId);
     }
 
     @Override
     public QuestionKeywordListResponse getQuestionKeywords(Long questionId) {
+        log.debug("getQuestionKeywords - questionId: {}", questionId);
         validateQuestionExists(questionId);
         List<QuestionHashtag> tags = questionHashtagRepository.findKeywordNamesByQuestionId(questionId);
 
@@ -155,11 +192,14 @@ public class QuestionServiceImpl implements QuestionService {
             .map(questionHashtag -> questionHashtag.getHashtag().getName())
             .toList();
 
+        log.debug("getQuestionKeywords success - questionId: {}, count: {}", questionId, keywords.size());
         return new QuestionKeywordListResponse(keywords);
     }
 
     @Override
     public QuestionKeywordCheckResponse checkQuestionKeywords(Long questionId, List<String> keywords) {
+        int keywordCount = keywords == null ? 0 : keywords.size();
+        log.debug("checkQuestionKeywords - questionId: {}, keywordCount: {}", questionId, keywordCount);
         validateQuestionExists(questionId);
         List<KeywordMatchResponse> results = keywords.stream()
                 .map(keyword -> new KeywordMatchResponse(
@@ -168,30 +208,47 @@ public class QuestionServiceImpl implements QuestionService {
                                 .existsByQuestion_IdAndHashtag_NameIgnoreCase(questionId, keyword)
                 ))
                 .toList();
+        long includedCount = results.stream()
+                .filter(KeywordMatchResponse::included)
+                .count();
+        log.debug("checkQuestionKeywords success - questionId: {}, includedCount: {}",
+                questionId, includedCount);
         return new QuestionKeywordCheckResponse(results);
     }
 
     @Override
     public QuestionCategoryListResponse getQuestionCategories() {
-        Map<String, String> categories = Arrays.stream(QuestionCategory.values())
+        log.debug("getQuestionCategories");
+        Map<String, Map<String, String>> categories = EXPOSED_TYPES.stream()
                 .collect(Collectors.toMap(
-                        QuestionCategory::name,
-                        QuestionCategory::getCategory,
+                        QuestionType::name,
+                        type -> Arrays.stream(QuestionCategory.values())
+                                .filter(category -> category.supports(type))
+                                .collect(Collectors.toMap(
+                                        QuestionCategory::name,
+                                        QuestionCategory::getCategory,
+                                        (existing, ignored) -> existing,
+                                        LinkedHashMap::new
+                                )),
                         (existing, ignored) -> existing,
                         LinkedHashMap::new
                 ));
+        log.debug("getQuestionCategories success - typeGroups: {}", categories.size());
         return new QuestionCategoryListResponse(categories);
     }
 
     @Override
     public QuestionTypeListResponse getQuestionTypes() {
+        log.debug("getQuestionTypes");
         Map<String, String> types = Arrays.stream(QuestionType.values())
+                .filter(EXPOSED_TYPES::contains)
                 .collect(Collectors.toMap(
                         QuestionType::name,
                         QuestionType::getType,
                         (existing, ignored) -> existing,
                         LinkedHashMap::new
                 ));
+        log.debug("getQuestionTypes success - count: {}", types.size());
         return new QuestionTypeListResponse(types);
     }
 
@@ -289,9 +346,14 @@ public class QuestionServiceImpl implements QuestionService {
         if (!mappings.isEmpty()) {
             questionHashtagRepository.saveAll(mappings);
         }
+
+        log.debug("attachKeywords success - questionId: {}, requested: {}, mapped: {}",
+                question.getId(), keywords.size(), mappings.size());
     }
 
     private void replaceKeywords(Question question, List<String> keywords) {
+        log.debug("replaceKeywords - questionId: {}, keywordCount: {}",
+                question.getId(), keywords == null ? 0 : keywords.size());
         questionHashtagRepository.deleteByQuestion_Id(question.getId());
         if (keywords == null || keywords.isEmpty()) {
             return;

--- a/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -442,14 +443,37 @@ class AnswerApplicationServiceTest {
         @DisplayName("지원되지 않는 questionType일 때 예외 발생")
         void getList_WithUnsupportedQuestionType_ShouldThrowException() {
             // Given
-            QuestionType unsupportedType = QuestionType.SYSTEM_DESIGN;
+            QuestionType unsupportedType = QuestionType.PORTFOLIO;
 
             // When & Then
             assertThatThrownBy(() ->
                     answerApplicationService.getList(
                             ACCOUNT_ID, null, null, unsupportedType, null, null, null, 10))
                     .isInstanceOf(AnswerListInvalidInputException.class)
-                    .hasMessageContaining("questionType is only supported for");
+                    .hasMessageContaining("questionType is only supported for [CS, SYSTEM_DESIGN]");
+
+            verifyNoInteractions(answerRepository);
+        }
+
+        @Test
+        @DisplayName("SYSTEM_DESIGN questionType으로 정상 조회")
+        void getList_WithSystemDesignQuestionType_ShouldSucceed() {
+            // Given
+            Slice<Answer> emptySlice = new SliceImpl<>(Collections.emptyList());
+            when(answerRepository.findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(emptySlice);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, QuestionType.SYSTEM_DESIGN, null, null, null, 10
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            verify(answerRepository).findByAccountIdWithFiltersNoCursor(
+                    eq(ACCOUNT_ID), any(), any(), eq(QuestionType.SYSTEM_DESIGN), any(), any(), any()
+            );
         }
 
         @Test

--- a/src/test/java/com/ktb/fixture/QuestionFixture.java
+++ b/src/test/java/com/ktb/fixture/QuestionFixture.java
@@ -21,7 +21,12 @@ public class QuestionFixture {
     }
 
     public static Question createQuestion(QuestionType type) {
-        return Question.create(DEFAULT_CONTENT, type, DEFAULT_CATEGORY);
+        QuestionCategory category = switch (type) {
+            case SYSTEM_DESIGN -> QuestionCategory.MEDIA;
+            case CS -> DEFAULT_CATEGORY;
+            case PORTFOLIO -> QuestionCategory.PORTFOLIO;
+        };
+        return Question.create(DEFAULT_CONTENT, type, category);
     }
 
     public static Question createQuestion(QuestionCategory category) {

--- a/src/test/java/com/ktb/question/domain/QuestionTest.java
+++ b/src/test/java/com/ktb/question/domain/QuestionTest.java
@@ -5,6 +5,7 @@ import com.ktb.question.exception.QuestionAlreadyDeletedException;
 import com.ktb.question.exception.QuestionInvalidContentException;
 import com.ktb.question.exception.QuestionRequiredCategoryException;
 import com.ktb.question.exception.QuestionRequiredTypeException;
+import com.ktb.question.exception.QuestionTypeCategoryMismatchException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -161,6 +162,34 @@ class QuestionTest {
             assertThatThrownBy(() -> Question.create(content, QuestionType.CS, QuestionCategory.OS))
                     .isInstanceOf(QuestionInvalidContentException.class);
         }
+
+        @Test
+        @DisplayName("질문 유형-카테고리 조합이 다르면 QuestionTypeCategoryMismatchException 발생")
+        void create_WithMismatchedTypeCategory_ShouldThrowException() {
+            // Given
+            String content = QuestionFixture.createContentWithMinLength();
+
+            // When & Then
+            assertThatThrownBy(() -> Question.create(
+                    content,
+                    QuestionType.CS,
+                    QuestionCategory.MEDIA
+            )).isInstanceOf(QuestionTypeCategoryMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("PORTFOLIO 유형은 PORTFOLIO 카테고리로 생성 성공")
+        void create_PortfolioTypeWithPortfolioCategory_ShouldSucceed() {
+            // Given
+            String content = QuestionFixture.createContentWithMinLength();
+
+            // When
+            Question question = Question.create(content, QuestionType.PORTFOLIO, QuestionCategory.PORTFOLIO);
+
+            // Then
+            assertThat(question.getType()).isEqualTo(QuestionType.PORTFOLIO);
+            assertThat(question.getCategory()).isEqualTo(QuestionCategory.PORTFOLIO);
+        }
     }
 
     @Nested
@@ -282,16 +311,16 @@ class QuestionTest {
         }
 
         @Test
-        @DisplayName("질문 유형 업데이트 성공")
+        @DisplayName("동일한 질문 유형으로 업데이트 성공")
         void updateType_WithValidType_ShouldSucceed() {
             // Given
             Question question = QuestionFixture.createQuestion();
 
             // When
-            question.updateType(QuestionType.SYSTEM_DESIGN);
+            question.updateType(QuestionType.CS);
 
             // Then
-            assertThat(question.getType()).isEqualTo(QuestionType.SYSTEM_DESIGN);
+            assertThat(question.getType()).isEqualTo(QuestionType.CS);
         }
 
         @Test
@@ -314,6 +343,28 @@ class QuestionTest {
             // When & Then
             assertThatThrownBy(() -> question.updateType(QuestionType.SYSTEM_DESIGN))
                     .isInstanceOf(QuestionAlreadyDeletedException.class);
+        }
+
+        @Test
+        @DisplayName("질문 유형 변경 시 현재 카테고리와 맞지 않으면 예외 발생")
+        void updateType_WithMismatchedCategory_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion(); // CS + OS
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateType(QuestionType.SYSTEM_DESIGN))
+                    .isInstanceOf(QuestionTypeCategoryMismatchException.class);
+        }
+
+        @Test
+        @DisplayName("PORTFOLIO 유형으로 변경 시 카테고리 미허용으로 예외 발생")
+        void updateType_ToPortfolio_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion(); // CS + OS
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateType(QuestionType.PORTFOLIO))
+                    .isInstanceOf(QuestionTypeCategoryMismatchException.class);
         }
 
         @Test
@@ -349,6 +400,17 @@ class QuestionTest {
             // When & Then
             assertThatThrownBy(() -> question.updateCategory(QuestionCategory.NETWORK))
                     .isInstanceOf(QuestionAlreadyDeletedException.class);
+        }
+
+        @Test
+        @DisplayName("질문 카테고리 변경 시 현재 유형과 맞지 않으면 예외 발생")
+        void updateCategory_WithMismatchedType_ShouldThrowException() {
+            // Given
+            Question question = QuestionFixture.createQuestion(); // CS + OS
+
+            // When & Then
+            assertThatThrownBy(() -> question.updateCategory(QuestionCategory.MEDIA))
+                    .isInstanceOf(QuestionTypeCategoryMismatchException.class);
         }
     }
 

--- a/src/test/java/com/ktb/question/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/ktb/question/repository/QuestionRepositoryTest.java
@@ -1,0 +1,260 @@
+package com.ktb.question.repository;
+
+import com.ktb.common.config.JpaAuditingConfig;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@ActiveProfiles("test")
+@DisplayName("QuestionRepository 통합 테스트")
+public class QuestionRepositoryTest {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    private Question csOsQuestion;
+    private Question csDbQuestion;
+    private Question systemDesignQuestion;
+    private Question inactiveQuestion;
+    private Question deletedQuestion;
+
+    @BeforeEach
+    void setUp() {
+        csOsQuestion = Question.create(
+                "운영체제에서 프로세스와 스레드의 차이를 설명해주세요.",
+                QuestionType.CS,
+                QuestionCategory.OS
+        );
+        testEntityManager.persist(csOsQuestion);
+
+        csDbQuestion = Question.create(
+                "트랜잭션의 ACID 속성을 설명해주세요.",
+                QuestionType.CS,
+                QuestionCategory.DB
+        );
+        testEntityManager.persist(csDbQuestion);
+
+        systemDesignQuestion = Question.create(
+                "실시간 채팅 시스템 아키텍처를 설계해보세요.",
+                QuestionType.SYSTEM_DESIGN,
+                QuestionCategory.REALTIME
+        );
+        testEntityManager.persist(systemDesignQuestion);
+
+        inactiveQuestion = Question.create(
+                "비활성화된 질문",
+                QuestionType.CS,
+                QuestionCategory.NETWORK
+        );
+        inactiveQuestion.disable();
+        testEntityManager.persist(inactiveQuestion);
+
+        deletedQuestion = Question.create(
+                "삭제된 질문",
+                QuestionType.SYSTEM_DESIGN,
+                QuestionCategory.SEARCH
+        );
+        deletedQuestion.delete();
+        testEntityManager.persist(deletedQuestion);
+
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
+    @Nested
+    @DisplayName("findActiveByFilters() 테스트")
+    class FindActiveByFiltersTest {
+
+        @Test
+        @DisplayName("필터 없이 조회하면 활성 질문만 ID 내림차순으로 조회")
+        void findActiveByFilters_WithoutFilters_ShouldReturnOnlyActiveQuestions() {
+            // When
+            Slice<Question> result = questionRepository.findActiveByFilters(
+                    null,
+                    null,
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(3);
+            assertThat(result.getContent())
+                    .allMatch(question -> question.isUseYn() && question.getDeletedAt() == null);
+            assertThat(result.getContent())
+                    .extracting(Question::getId)
+                    .isSortedAccordingTo((a, b) -> Long.compare(b, a));
+        }
+
+        @Test
+        @DisplayName("type 필터로 SYSTEM_DESIGN 질문만 조회")
+        void findActiveByFilters_WithTypeFilter_ShouldFilterByType() {
+            // When
+            Slice<Question> result = questionRepository.findActiveByFilters(
+                    QuestionType.SYSTEM_DESIGN,
+                    null,
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getType()).isEqualTo(QuestionType.SYSTEM_DESIGN);
+            assertThat(result.getContent().getFirst().getCategory()).isEqualTo(QuestionCategory.REALTIME);
+        }
+
+        @Test
+        @DisplayName("category 필터로 DB 질문만 조회")
+        void findActiveByFilters_WithCategoryFilter_ShouldFilterByCategory() {
+            // When
+            Slice<Question> result = questionRepository.findActiveByFilters(
+                    null,
+                    QuestionCategory.DB,
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().getFirst().getCategory()).isEqualTo(QuestionCategory.DB);
+        }
+
+        @Test
+        @DisplayName("cursor 값보다 작은 ID만 조회")
+        void findActiveByFilters_WithCursor_ShouldReturnQuestionsBeforeCursor() {
+            // Given
+            Slice<Question> firstPage = questionRepository.findActiveByFilters(
+                    null,
+                    null,
+                    null,
+                    PageRequest.of(0, 10)
+            );
+            Long cursor = firstPage.getContent().getFirst().getId();
+
+            // When
+            Slice<Question> result = questionRepository.findActiveByFilters(
+                    null,
+                    null,
+                    cursor,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent()).allMatch(question -> question.getId() < cursor);
+            assertThat(result.getContent()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("searchActiveByKeyword() 테스트")
+    class SearchActiveByKeywordTest {
+
+        @Test
+        @DisplayName("키워드 대소문자 구분 없이 검색")
+        void searchActiveByKeyword_ShouldSearchCaseInsensitive() {
+            // Given
+            Question cacheQuestion = Question.create(
+                    "Redis CACHE 전략을 설명해주세요.",
+                    QuestionType.SYSTEM_DESIGN,
+                    QuestionCategory.STORAGE
+            );
+            testEntityManager.persist(cacheQuestion);
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // When
+            Slice<Question> result = questionRepository.searchActiveByKeyword(
+                    "cache",
+                    null,
+                    null,
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            // Then
+            assertThat(result.getContent())
+                    .extracting(Question::getContent)
+                    .anyMatch(content -> content.toLowerCase().contains("cache"));
+        }
+
+        @Test
+        @DisplayName("검색에서도 비활성/삭제 질문은 제외")
+        void searchActiveByKeyword_ShouldExcludeInactiveOrDeleted() {
+            // When
+            Slice<Question> result = questionRepository.searchActiveByKeyword(
+                    "질문",
+                    null,
+                    null,
+                    null,
+                    PageRequest.of(0, 20)
+            );
+
+            // Then
+            assertThat(result.getContent())
+                    .noneMatch(question ->
+                            "비활성화된 질문".equals(question.getContent())
+                                    || "삭제된 질문".equals(question.getContent()));
+        }
+    }
+
+    @Nested
+    @DisplayName("findRandomActiveId() 테스트")
+    class FindRandomActiveIdTest {
+
+        @Test
+        @DisplayName("활성 질문이 있으면 활성 질문 ID 중 하나를 반환")
+        void findRandomActiveId_WithActiveQuestions_ShouldReturnActiveId() {
+            // Given
+            Set<Long> activeIds = questionRepository.findAll().stream()
+                    .filter(question -> question.isUseYn() && question.getDeletedAt() == null)
+                    .map(Question::getId)
+                    .collect(Collectors.toSet());
+
+            // When
+            Long randomId = questionRepository.findRandomActiveId().orElse(null);
+
+            // Then
+            assertThat(randomId).isNotNull();
+            assertThat(activeIds).contains(randomId);
+        }
+
+        @Test
+        @DisplayName("활성 질문이 없으면 empty 반환")
+        void findRandomActiveId_WithoutActiveQuestions_ShouldReturnEmpty() {
+            // Given
+            List<Question> allQuestions = questionRepository.findAll();
+            allQuestions.stream()
+                    .filter(question -> question.isUseYn() && question.getDeletedAt() == null)
+                    .forEach(Question::delete);
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // When
+            var result = questionRepository.findRandomActiveId();
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/ktb/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/ktb/question/service/QuestionServiceTest.java
@@ -1,0 +1,323 @@
+package com.ktb.question.service;
+
+import com.ktb.hashtag.domain.Hashtag;
+import com.ktb.hashtag.domain.QuestionHashtag;
+import com.ktb.hashtag.repository.HashtagRepository;
+import com.ktb.hashtag.repository.QuestionHashtagRepository;
+import com.ktb.hashtag.repository.QuestionKeywordRow;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import com.ktb.question.dto.QuestionCategoryListResponse;
+import com.ktb.question.dto.QuestionDetailResponse;
+import com.ktb.question.dto.QuestionKeywordCheckResponse;
+import com.ktb.question.dto.QuestionListResponse;
+import com.ktb.question.dto.QuestionUpdateRequest;
+import com.ktb.question.dto.QuestionTypeListResponse;
+import com.ktb.question.exception.QuestionNotFoundException;
+import com.ktb.question.exception.SearchKeywordTooShortException;
+import com.ktb.question.repository.QuestionRepository;
+import com.ktb.question.service.impl.QuestionServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuestionService 단위 테스트")
+class QuestionServiceTest {
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private QuestionHashtagRepository questionHashtagRepository;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @InjectMocks
+    private QuestionServiceImpl questionService;
+
+    @Nested
+    @DisplayName("질문 타입/카테고리 메타 조회 테스트")
+    class TypeCategoryMetaTest {
+
+        @Test
+        @DisplayName("getQuestionCategories는 CS, SYSTEM_DESIGN 그룹만 반환")
+        void getQuestionCategories_ShouldReturnOnlyExposedTypeGroups() {
+            // When
+            QuestionCategoryListResponse result = questionService.getQuestionCategories();
+
+            // Then
+            Map<String, Map<String, String>> categories = result.categories();
+            assertThat(categories).containsOnlyKeys("CS", "SYSTEM_DESIGN");
+            assertThat(categories.get("CS"))
+                    .containsKeys("OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "DATA_STRUCTURE_ALGORITHM");
+            assertThat(categories.get("SYSTEM_DESIGN"))
+                    .containsKeys("SOCIAL", "NOTIFICATION", "REALTIME", "SEARCH", "MEDIA", "STORAGE", "PLATFORM", "TRANSACTION");
+            assertThat(categories.get("SYSTEM_DESIGN")).doesNotContainKey("PORTFOLIO");
+        }
+
+        @Test
+        @DisplayName("getQuestionTypes는 CS, SYSTEM_DESIGN만 반환")
+        void getQuestionTypes_ShouldExcludePortfolio() {
+            // When
+            QuestionTypeListResponse result = questionService.getQuestionTypes();
+
+            // Then
+            assertThat(result.types()).containsOnlyKeys("CS", "SYSTEM_DESIGN");
+            assertThat(result.types()).doesNotContainKey("PORTFOLIO");
+        }
+    }
+
+    @Nested
+    @DisplayName("질문 조회 테스트")
+    class GetQuestionsTest {
+
+        @Test
+        @DisplayName("질문 목록 조회 시 키워드 매핑과 pagination 정보 반환")
+        void getQuestions_ShouldReturnMappedKeywordsAndPagination() {
+            // Given
+            Question first = mockQuestion(200L, "실시간 처리 질문", QuestionType.SYSTEM_DESIGN, QuestionCategory.REALTIME);
+            Question second = mockQuestion(150L, "운영체제 질문", QuestionType.CS, QuestionCategory.OS);
+            Slice<Question> slice = new SliceImpl<>(List.of(first, second), PageRequest.of(0, 2), true);
+
+            when(questionRepository.findActiveByFilters(
+                    eq(QuestionType.SYSTEM_DESIGN), eq(QuestionCategory.REALTIME), isNull(), any()))
+                    .thenReturn(slice);
+            when(questionHashtagRepository.findKeywordRowsByQuestionIdIn(List.of(200L, 150L)))
+                    .thenReturn(List.of(
+                            keywordRow(200L, "websocket"),
+                            keywordRow(150L, "thread"),
+                            keywordRow(150L, "process")
+                    ));
+
+            // When
+            QuestionListResponse result = questionService.getQuestions(
+                    QuestionCategory.REALTIME,
+                    QuestionType.SYSTEM_DESIGN,
+                    null,
+                    2
+            );
+
+            // Then
+            assertThat(result.questions()).hasSize(2);
+            assertThat(result.questions().get(0).questionId()).isEqualTo(200L);
+            assertThat(result.questions().get(0).keywords()).containsExactly("websocket");
+            assertThat(result.questions().get(1).questionId()).isEqualTo(150L);
+            assertThat(result.questions().get(1).keywords()).containsExactly("thread", "process");
+            assertThat(result.pagination().hasNext()).isTrue();
+            assertThat(result.pagination().nextCursor()).isEqualTo(150L);
+            assertThat(result.pagination().size()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("질문 검색 테스트")
+    class SearchTest {
+
+        @Test
+        @DisplayName("검색어가 2자 미만이면 예외 발생")
+        void search_WithTooShortKeyword_ShouldThrowException() {
+            // When & Then
+            assertThatThrownBy(() -> questionService.search("a", null, null, null, 10))
+                    .isInstanceOf(SearchKeywordTooShortException.class);
+            verifyNoInteractions(questionRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("질문 상세/키워드 조회 테스트")
+    class DetailAndKeywordTest {
+
+        @Test
+        @DisplayName("질문 상세 조회 성공")
+        void getQuestionDetail_ShouldReturnDetailWithKeywords() {
+            // Given
+            Long questionId = 10L;
+            Question question = mockQuestion(questionId, "질문 본문", QuestionType.CS, QuestionCategory.DB);
+            QuestionHashtag redisHashtag = questionHashtag("redis");
+            QuestionHashtag indexHashtag = questionHashtag("index");
+            when(questionRepository.findById(questionId)).thenReturn(Optional.of(question));
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(questionId))
+                    .thenReturn(List.of(redisHashtag, indexHashtag));
+
+            // When
+            QuestionDetailResponse result = questionService.getQuestionDetail(questionId);
+
+            // Then
+            assertThat(result.questionId()).isEqualTo(questionId);
+            assertThat(result.type()).isEqualTo(QuestionType.CS);
+            assertThat(result.category()).isEqualTo(QuestionCategory.DB);
+            assertThat(result.keywords()).containsExactly("redis", "index");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 질문 상세 조회 시 QuestionNotFoundException")
+        void getQuestionDetail_WithUnknownId_ShouldThrowException() {
+            // Given
+            when(questionRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.getQuestionDetail(999L))
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("질문 키워드 포함 여부 체크")
+        void checkQuestionKeywords_ShouldReturnIncludedFlags() {
+            // Given
+            Long questionId = 20L;
+            when(questionRepository.existsById(questionId)).thenReturn(true);
+            when(questionHashtagRepository.existsByQuestion_IdAndHashtag_NameIgnoreCase(questionId, "redis"))
+                    .thenReturn(true);
+            when(questionHashtagRepository.existsByQuestion_IdAndHashtag_NameIgnoreCase(questionId, "kafka"))
+                    .thenReturn(false);
+
+            // When
+            QuestionKeywordCheckResponse result =
+                    questionService.checkQuestionKeywords(questionId, List.of("redis", "kafka"));
+
+            // Then
+            assertThat(result.keywords()).hasSize(2);
+            assertThat(result.keywords().get(0).keyword()).isEqualTo("redis");
+            assertThat(result.keywords().get(0).included()).isTrue();
+            assertThat(result.keywords().get(1).keyword()).isEqualTo("kafka");
+            assertThat(result.keywords().get(1).included()).isFalse();
+            verify(questionRepository).existsById(questionId);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리 테스트")
+    class ExceptionFlowTest {
+
+        @Test
+        @DisplayName("오늘의 추천 질문 조회 시 활성 질문이 없으면 QuestionNotFoundException")
+        void getDailyRecommendation_WithoutActiveQuestion_ShouldThrowException() {
+            // Given
+            when(questionRepository.findRandomActiveId()).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.getDailyRecommendation())
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("오늘의 추천 질문 ID는 있으나 상세 조회 실패 시 QuestionNotFoundException")
+        void getDailyRecommendation_WithMissingQuestionDetail_ShouldThrowException() {
+            // Given
+            when(questionRepository.findRandomActiveId()).thenReturn(Optional.of(123L));
+            when(questionRepository.findById(123L)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.getDailyRecommendation())
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 질문의 키워드 조회 시 QuestionNotFoundException")
+        void getQuestionKeywords_WithUnknownQuestion_ShouldThrowException() {
+            // Given
+            when(questionRepository.existsById(404L)).thenReturn(false);
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.getQuestionKeywords(404L))
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 질문의 키워드 체크 시 QuestionNotFoundException")
+        void checkQuestionKeywords_WithUnknownQuestion_ShouldThrowException() {
+            // Given
+            when(questionRepository.existsById(404L)).thenReturn(false);
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.checkQuestionKeywords(404L, List.of("redis")))
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 질문 수정 시 QuestionNotFoundException")
+        void updateQuestion_WithUnknownQuestion_ShouldThrowException() {
+            // Given
+            Long questionId = 999L;
+            QuestionUpdateRequest request = new QuestionUpdateRequest(
+                    "수정 내용",
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            when(questionRepository.findById(questionId)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.updateQuestion(questionId, request))
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 질문 삭제 시 QuestionNotFoundException")
+        void deleteQuestion_WithUnknownQuestion_ShouldThrowException() {
+            // Given
+            Long questionId = 999L;
+            when(questionRepository.findById(questionId)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> questionService.deleteQuestion(questionId))
+                    .isInstanceOf(QuestionNotFoundException.class);
+        }
+    }
+
+    private Question mockQuestion(Long id, String content, QuestionType type, QuestionCategory category) {
+        Question question = mock(Question.class);
+        when(question.getId()).thenReturn(id);
+        when(question.getContent()).thenReturn(content);
+        when(question.getType()).thenReturn(type);
+        when(question.getCategory()).thenReturn(category);
+        return question;
+    }
+
+    private QuestionHashtag questionHashtag(String keyword) {
+        QuestionHashtag questionHashtag = mock(QuestionHashtag.class);
+        Hashtag hashtag = mock(Hashtag.class);
+        when(hashtag.getName()).thenReturn(keyword);
+        when(questionHashtag.getHashtag()).thenReturn(hashtag);
+        return questionHashtag;
+    }
+
+    private QuestionKeywordRow keywordRow(Long questionId, String keyword) {
+        return new QuestionKeywordRow() {
+            @Override
+            public Long getQuestionId() {
+                return questionId;
+            }
+
+            @Override
+            public String getKeyword() {
+                return keyword;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 요약
  질문 도메인의 카테고리 체계를 `CS / SYSTEM_DESIGN / PORTFOLIO`로 정리하고, `QuestionType`-`QuestionCategory` 조합 정합성 검증을 도메인 레벨에 추가했습니다.
  또한 질문 메타 조회 API 응답 구조를 타입별 그룹 형태로 개선하고, 답변 목록의 `questionType` 필터 지원 범위를 확장했으며, **질문 도메인 테스트 코드 보강**과 **QuestionController/QuestionServiceImpl 로그 추가**를 함께 반영했습니다.

  ## 변경사항
  - `QuestionCategory` 확장 및 타입 지원 관계 정의
    - CS 카테고리 유지
    - SYSTEM_DESIGN 카테고리 추가 (`SOCIAL`, `NOTIFICATION`, `REALTIME`, `SEARCH`, `MEDIA`, `STORAGE`, `PLATFORM`, `TRANSACTION`)
    - PORTFOLIO 카테고리 추가 (`PORTFOLIO`)
  - 질문 도메인 정합성 검증 강화
    - 생성/수정 시 `QuestionType`-`QuestionCategory` mismatch 검증
    - `QuestionTypeCategoryMismatchException` 신규 추가
    - `ErrorCode`에 `QUESTION_TYPE_CATEGORY_MISMATCH(Q011)` 추가
  - 질문 메타 API 개선
    - `getQuestionCategories()` 응답을 타입 그룹 기반 구조로 변경
    - `getQuestionTypes()` 노출 정책을 `CS`, `SYSTEM_DESIGN` 중심으로 정리
  - 답변 목록 필터 정합성 개선
    - `questionType` 허용 범위를 `CS`, `SYSTEM_DESIGN`, `PORTFOLIO`로 확장
    - 커서 기반 조회 쿼리 조건 정리
  - 문서/스키마 정합성 보완
    - `AnswerListRequest` category/type 설명 최신화
    - AI 피드백 request/response category allowableValues를 현재 enum 체계와 동기화
  - 로깅 추가
    - `QuestionController` 전 엔드포인트 요청/응답 주요 정보 로그 추가
    - `QuestionServiceImpl` 주요 비즈니스 흐름/결과 로그 추가
  - 테스트 보강
    - **질문 도메인 테스트(`QuestionTest`)에 타입-카테고리 예외 시나리오 추가**
    - `QuestionRepositoryTest` 통합 테스트 확장
    - `QuestionServiceTest` 신규 작성
    - `QuestionFixture`, `AnswerApplicationServiceTest` 시나리오 보정

  ## 수정/추가/삭제 파일
  - 수정
    - `src/main/java/com/ktb/question/domain/QuestionCategory.java`
    - `src/main/java/com/ktb/question/domain/Question.java`
    - `src/main/java/com/ktb/common/domain/ErrorCode.java`
    - `src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java`
    - `src/main/java/com/ktb/question/controller/QuestionController.java`
    - `src/main/java/com/ktb/question/dto/QuestionCategoryListResponse.java`
    - `src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java`
    - `src/main/java/com/ktb/answer/repository/AnswerRepository.java`
    - `src/main/java/com/ktb/answer/dto/request/AnswerListRequest.java`
    - `src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java`
    - `src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java`
    - `src/main/java/com/ktb/question/exception/QuestionDisabledException.java`
    - `src/test/java/com/ktb/question/domain/QuestionTest.java`
    - `src/test/java/com/ktb/fixture/QuestionFixture.java`
    - `src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java`
    - `src/test/java/com/ktb/question/repository/QuestionRepositoryTest.java`
  - 추가
    - `src/main/java/com/ktb/question/exception/QuestionTypeCategoryMismatchException.java`
    - `src/test/java/com/ktb/question/service/QuestionServiceTest.java`

  ## 구현 의도 / 목적
  - **도메인 무결성 강제**
    - 타입/카테고리 불일치 조합을 엔티티 생성·수정 시점에서 즉시 차단해, 잘못된 데이터가 저장/노출되는 구조적 리스크를 줄였습니다.
  - **질문 도메인 확장성 확보**
    - SYSTEM_DESIGN/PORTFOLIO를 포함한 카테고리 체계로 재정의해 향후 질문 풀 확장 시 일관된 정책을 유지하도록 했습니다.
  - **프론트 필터 응답 정합성 확보**
    - 카테고리 응답을 타입별 그룹으로 내려 UI 필터에서 CS/SYSTEM_DESIGN 구분이 가능하도록 개선했습니다.
  - **운영 가시성 강화**
    - Controller/Service에 요청 파라미터, 결과 건수, 주요 식별자 로그를 추가해 문제 발생 시 추적 가능성을 높였습니다.
  - **회귀 방지**
    - 질문 도메인 테스트 코드 및 서비스/리포지토리 테스트를 보강해 예외 흐름 포함 회귀 방지 장치를 마련했습니다.

  ## 관련 Commit, Issue
  - #185 