### PR TITLE
feat: Dockerfile 및 dev 컨테이너 배포 CI/CD 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Git
+.git
+.gitignore
+
+# IDE
+.idea
+.vscode
+*.iml
+*.swp
+*.swo
+
+# Build
+build/
+.gradle/
+out/
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+
+# Documentation
+docs/
+*.md
+
+# Test
+src/test/
+
+# CI/CD
+.github/
+
+# Docker
+Dockerfile
+.dockerignore
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Misc
+gradlew.bat

--- a/.github/workflows/BE-CICD.yml
+++ b/.github/workflows/BE-CICD.yml
@@ -2,15 +2,20 @@ name: Backend CI/CD
 
 on:
   push:
-    branches: ["main", "dev"]
+    branches: [main, dev]
   pull_request:
-    branches:
-      - main
-      - dev
+    branches: [main, dev]
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
 
 env:
   JAVA_VERSION: '25'
-  GRADLE_VERSION: '8.5'
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: qfeed-ecr-backend
+  DEPLOY_RAW_BASE: https://raw.githubusercontent.com/100-hours-a-week/17-JinyUs-Q-Feed-Cloud/main/deploy/dev/backend
 
 jobs:
   ci:
@@ -38,8 +43,6 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Grant execute permission for gradlew
-        env:
-          AWS_S3_KEY_PREFIX: uploads
         run: chmod +x gradlew
 
       - name: Build with Gradle
@@ -49,18 +52,15 @@ jobs:
         run: ./gradlew test
 
       - name: Upload test reports
-        if: failure() || always()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
-          path: |
-            build/reports/tests/test/
-            retention-days: 7
-
-      - name: Build JAR
-        run: ./gradlew bootJar -x test
+          path: build/reports/tests/test/
+          retention-days: 7
 
       - name: Upload JAR artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: backend-jar
@@ -86,11 +86,103 @@ jobs:
                 "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
               }]
             }'
-  deploy:
-    name: Deploy to EC2
+
+  deploy-dev:
+    name: Deploy to Dev
     needs: ci
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/qfeed-dev-role-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set image tag
+        id: meta
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image=${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if image exists
+        id: check
+        run: |
+          aws ecr describe-images \
+            --repository-name ${{ env.ECR_REPOSITORY }} \
+            --image-ids imageTag=${{ steps.meta.outputs.short_sha }} \
+            > /dev/null 2>&1 && echo "exists=true" >> "$GITHUB_OUTPUT" || echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+        if: steps.check.outputs.exists == 'false'
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: ${{ steps.meta.outputs.image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy via SSM
+        id: ssm-deploy
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --targets '[{"Key":"tag:Name","Values":["qfeed-dev-ec2-backend"]}]' \
+            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL ${{ env.DEPLOY_RAW_BASE }}/deploy.sh -o /srv/qfeed/deploy.sh && curl -sfL ${{ env.DEPLOY_RAW_BASE }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --timeout-seconds 600 \
+            --comment "Deploy backend ${{ steps.meta.outputs.short_sha }}" \
+            --output text --query "Command.CommandId")
+          echo "command_id=${COMMAND_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for deployment
+        run: |
+          for i in $(seq 1 60); do
+            sleep 10
+            STATUS=$(aws ssm list-command-invocations \
+              --command-id "${{ steps.ssm-deploy.outputs.command_id }}" \
+              --query "CommandInvocations[0].Status" --output text 2>/dev/null || echo "Pending")
+            echo "  Status: ${STATUS} (${i}0s)"
+            if [ "$STATUS" = "Success" ]; then echo "Deploy OK"; exit 0; fi
+            if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "Deploy failed: ${STATUS}"
+              INSTANCE_ID=$(aws ssm list-command-invocations \
+                --command-id "${{ steps.ssm-deploy.outputs.command_id }}" \
+                --query "CommandInvocations[0].InstanceId" --output text)
+              aws ssm get-command-invocation \
+                --command-id "${{ steps.ssm-deploy.outputs.command_id }}" \
+                --instance-id "$INSTANCE_ID" \
+                --query "[StandardOutputContent,StandardErrorContent]" --output text || true
+              exit 1
+            fi
+          done
+          echo "Timed out"; exit 1
+
+      - name: Discord 알림 (Dev 배포 성공)
+        if: success()
+        continue-on-error: true
+        run: |
+          curl -sS -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\":[{\"title\":\"✅ BE Dev 배포 완료\",\"description\":\"이미지 \`${{ steps.meta.outputs.short_sha }}\` 배포 성공\",\"color\":3066993}]}"
+
+  # NOTE: prod 인프라 전환 완료 후 deploy-dev와 동일한 방식(OIDC+SSM)으로 교체 예정
+  deploy-prod:
+    name: Deploy to Prod
+    needs: ci
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
       - name: Checkout code
@@ -109,76 +201,55 @@ jobs:
           echo "jar_path=$JAR_FILE" >> $GITHUB_OUTPUT
           echo "Found JAR: $JAR_FILE"
 
-      - name: Determine Environment and Server
-        id: env
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "environment=prod" >> $GITHUB_OUTPUT
-            echo "ec2_host=${{ secrets.QFEED_EC2_HOST }}" >> $GITHUB_OUTPUT
-          else
-            echo "environment=dev" >> $GITHUB_OUTPUT
-            echo "ec2_host=${{ secrets.QFEED_EC2_DEV_HOST }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.QFEED_EC2_SSH_KEY }}" > ~/.ssh/qfeed-keypair-2.pem
           chmod 600 ~/.ssh/qfeed-keypair-2.pem
-          ssh-keyscan -H ${{ steps.env.outputs.ec2_host }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.QFEED_EC2_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Deploy to ${{ steps.env.outputs.environment }} server
+      - name: Deploy to prod server
         run: |
-          SERVER="${{ secrets.QFEED_EC2_USER }}@${{ steps.env.outputs.ec2_host }}"
+          SERVER="${{ secrets.QFEED_EC2_USER }}@${{ secrets.QFEED_EC2_HOST }}"
           SSH_KEY="~/.ssh/qfeed-keypair-2.pem"
           JAR_FILE="${{ steps.find-jar.outputs.jar_path }}"
 
-          # Upload JAR to server
-          echo "Uploading JAR to ${{ steps.env.outputs.environment }} server..."
+          echo "Uploading JAR to prod server..."
           scp -i $SSH_KEY "$JAR_FILE" $SERVER:/tmp/backend-1.0-SNAPSHOT.jar
 
-          # Execute deploy script on server
-          echo "Executing deploy script on ${{ steps.env.outputs.environment }} server..."
+          echo "Executing deploy script on prod server..."
           ssh -i $SSH_KEY $SERVER "sudo /srv/qfeed/deploy-be.sh /tmp/backend-1.0-SNAPSHOT.jar"
 
-          # Cleanup
           ssh -i $SSH_KEY $SERVER "rm -f /tmp/backend-1.0-SNAPSHOT.jar"
 
-          echo "Deployment to ${{ steps.env.outputs.environment }} completed successfully!"
+          echo "Deployment to prod completed successfully!"
 
-  # CI 실패 시 어떤 과정에서 실패했는지 Discord 알림
-  discord-notify-failure:
+  discord-ci-failure:
     name: Discord 알림 (CI 실패)
     runs-on: ubuntu-latest
-    needs: [ci, deploy]
-    if: always() && (needs.ci.result == 'failure' || needs.deploy.result == 'failure')
+    needs: ci
+    if: always() && needs.ci.result == 'failure'
     steps:
-      - name: 실패한 Job/Step 조회
+      - name: 실패한 Step 조회
         id: failed
         run: |
           RES=$(curl -sS -H "Authorization: Bearer ${{ github.token }}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs")
-          FAILED_JOB=$(echo "$RES" | jq -r '.jobs[] | select(.conclusion == "failure") | .name' | head -1)
-          FAILED_JOB_ID=$(echo "$RES" | jq -r '.jobs[] | select(.conclusion == "failure") | .id' | head -1)
+          FAILED_JOB_ID=$(echo "$RES" | jq -r '.jobs[] | select(.name == "CI - Build and Test") | .id')
           if [ -n "$FAILED_JOB_ID" ]; then
             STEPS_RES=$(curl -sS -H "Authorization: Bearer ${{ github.token }}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/jobs/$FAILED_JOB_ID")
             FAILED_STEP=$(echo "$STEPS_RES" | jq -r '.steps[] | select(.conclusion == "failure") | .name' | head -1)
-          else
-            FAILED_STEP="(확인 불가)"
           fi
-          [ -z "$FAILED_JOB" ] && FAILED_JOB="(알 수 없음)"
-          [ -z "$FAILED_STEP" ] && FAILED_STEP="(알 수 없음)"
-          echo "job=$FAILED_JOB" >> $GITHUB_OUTPUT
+          [ -z "$FAILED_STEP" ] && FAILED_STEP="(확인 불가)"
           echo "step=$FAILED_STEP" >> $GITHUB_OUTPUT
 
       - name: Discord 알림 (CI 실패)
         continue-on-error: true
         run: |
           PAYLOAD=$(jq -n \
-            --arg job "${{ steps.failed.outputs.job }}" \
             --arg step "${{ steps.failed.outputs.step }}" \
             --arg ref "${{ github.ref_name }}" \
             --arg sha "${{ github.sha }}" \
@@ -187,7 +258,7 @@ jobs:
             '{
               embeds: [{
                 title: "❌ BE CI 실패",
-                description: ("**실패한 Job:** " + $job + "\n**실패한 Step:** " + $step),
+                description: ("**실패한 Step:** " + $step),
                 color: 15158332,
                 fields: [
                   {name: "브랜치", value: $ref, inline: true},
@@ -200,3 +271,29 @@ jobs:
           curl -sS -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
+
+  discord-deploy-dev-failure:
+    name: Discord 알림 (Dev 배포 실패)
+    runs-on: ubuntu-latest
+    needs: deploy-dev
+    if: always() && needs.deploy-dev.result == 'failure'
+    steps:
+      - name: Discord 알림 (Dev 배포 실패)
+        continue-on-error: true
+        run: |
+          curl -sS -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\":[{\"title\":\"❌ BE Dev 배포 실패\",\"color\":15158332,\"fields\":[{\"name\":\"브랜치\",\"value\":\"${{ github.ref_name }}\",\"inline\":true},{\"name\":\"커밋\",\"value\":\"\`${{ github.sha }}\`\",\"inline\":true},{\"name\":\"워크플로우\",\"value\":\"[Run 보기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\"}]}]}"
+
+  discord-deploy-prod-failure:
+    name: Discord 알림 (Prod 배포 실패)
+    runs-on: ubuntu-latest
+    needs: deploy-prod
+    if: always() && needs.deploy-prod.result == 'failure'
+    steps:
+      - name: Discord 알림 (Prod 배포 실패)
+        continue-on-error: true
+        run: |
+          curl -sS -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\":[{\"title\":\"❌ BE Prod 배포 실패\",\"color\":15158332,\"fields\":[{\"name\":\"브랜치\",\"value\":\"${{ github.ref_name }}\",\"inline\":true},{\"name\":\"커밋\",\"value\":\"\`${{ github.sha }}\`\",\"inline\":true},{\"name\":\"워크플로우\",\"value\":\"[Run 보기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\"}]}]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ---- Build Stage ----
+FROM eclipse-temurin:25-jdk-alpine AS build
+WORKDIR /app
+
+# Gradle wrapper + 설정 먼저 복사 (의존성 캐시 레이어)
+COPY gradlew settings.gradle build.gradle gradle.properties ./
+COPY gradle ./gradle
+# 의존성 사전 다운로드 (캐시 레이어 목적 — 일부 의존성은 소스 없이 resolve 불가하므로 실패 허용)
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
+
+# 소스 복사 및 빌드
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon -x test \
+    && cp $(ls build/libs/*.jar | grep -v plain | head -1) build/libs/app.jar
+
+# ---- Runtime Stage ----
+FROM eclipse-temurin:25-jre-alpine
+WORKDIR /app
+
+COPY --from=build /app/build/libs/app.jar app.jar
+RUN apk add --no-cache curl \
+    && addgroup -S appgroup && adduser -S appuser -G appgroup \
+    && mkdir -p /app/logs && chown appuser:appgroup /app/logs
+USER appuser
+
+EXPOSE 8080 8081
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- Dockerfile (multi-stage build: JDK 25 → JRE Alpine) + .dockerignore 추가
- BE-CICD.yml에 `deploy-dev` job 추가: dev push → Docker build → ECR push → SSM SendCommand 배포
- 기존 CI/CD 자동 트리거 비활성화 (workflow_dispatch로 전환)
- ECR immutable tag 중복 방지 (describe-images 체크)

## Test plan
- [x] dev 브랜치 머지 후 deploy-dev job 자동 트리거 확인
- [x] ECR 이미지 push 성공 확인
- [x] SSM SendCommand → EC2 배포 성공 확인
- [x] 컨테이너 healthcheck (actuator/health) 통과 확인
- [x] 기존 워크플로우가 트리거되지 않는지 확인