### PR TITLE
refactor:[#199] S3 업로드/tts 버킷 분리 및 presigned key 경로 매핑 정리

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -9,7 +9,8 @@ JWT_SECRET=your_jwt_secret_key_at_least_256_bits
 
 # AWS S3
 AWS_REGION=your_aws_region_name
-AWS_S3_BUCKET_NAME=your_aws_s3_bucket_name
+AWS_S3_UPLOAD_BUCKET_NAME=your_aws_s3_upload_bucket_name
+AWS_S3_TTS_BUCKET_NAME=your_aws_s3_tts_bucket_name
 AWS_S3_CDN_URL_PREFIX=your_aws_cdn_url_prefix
 AWS_S3_KEY_PREFIX=your_aws_key_prefix
 AWS_ACCESS_KEY_ID=your_aws_access_key_id_value

--- a/src/main/java/com/ktb/common/config/S3Config.java
+++ b/src/main/java/com/ktb/common/config/S3Config.java
@@ -23,7 +23,8 @@ public class S3Config {
     @Getter
     @Setter
     public static class S3Properties {
-        private String bucketName;
+        private String uploadBucketName;
+        private String ttsBucketName;
         private String cdnUrlPrefix;
     }
 

--- a/src/main/java/com/ktb/file/domain/FileCategory.java
+++ b/src/main/java/com/ktb/file/domain/FileCategory.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum FileCategory {
     PROFILE(
             "프로필 이미지",
+            "image",
             5 * 1024 * 1024L, // 5MB
             Arrays.asList("jpg", "jpeg", "png", "gif", "webp"),
             Arrays.asList("image/jpeg", "image/png", "image/gif", "image/webp")
@@ -15,6 +16,7 @@ public enum FileCategory {
 
     ARCHITECTURE(
             "아키텍처 다이어그램",
+            "image",
             10 * 1024 * 1024L, // 10MB
             Arrays.asList("jpg", "jpeg", "png", "gif", "svg"),
             Arrays.asList("image/jpeg", "image/png", "image/gif", "image/svg+xml")
@@ -22,6 +24,7 @@ public enum FileCategory {
 
     ATTACHMENT(
             "일반 첨부파일",
+            "image",
             50 * 1024 * 1024L, // 50MB
             Arrays.asList("jpg", "jpeg", "png", "gif"),
             Arrays.asList("image/jpeg", "image/png", "image/gif")
@@ -29,6 +32,7 @@ public enum FileCategory {
 
     TEMP(
             "임시 파일",
+            "image",
             100 * 1024 * 1024L, // 100MB
             Arrays.asList("jpg", "jpeg", "png", "gif"),
             Arrays.asList("image/jpeg", "image/png", "image/gif")
@@ -36,6 +40,7 @@ public enum FileCategory {
 
     AUDIO(
             "음성 파일",
+            "audio",
             10 * 1024 * 1024L, // 10MB
             Arrays.asList("mp3", "wav", "m4a"),
             Arrays.asList("audio/mpeg", "audio/wav", "audio/x-m4a", "audio/mp4")
@@ -43,19 +48,22 @@ public enum FileCategory {
 
     VIDEO(
             "비디오 파일",
+            "video",
             100 * 1024 * 1024L, // 100MB
             Arrays.asList("mp4", "mov", "avi"),
             Arrays.asList("video/mp4", "video/quicktime", "video/x-msvideo")
     );
 
     private final String description;
+    private final String s3Directory;
     private final long maxSizeBytes;
     private final List<String> allowedExtensions;
     private final List<String> allowedMimeTypes;
 
-    FileCategory(String description, long maxSizeBytes, List<String> allowedExtensions,
+    FileCategory(String description, String s3Directory, long maxSizeBytes, List<String> allowedExtensions,
                  List<String> allowedMimeTypes) {
         this.description = description;
+        this.s3Directory = s3Directory;
         this.maxSizeBytes = maxSizeBytes;
         this.allowedExtensions = allowedExtensions;
         this.allowedMimeTypes = allowedMimeTypes;

--- a/src/main/java/com/ktb/file/service/impl/S3PresignedUrlServiceImpl.java
+++ b/src/main/java/com/ktb/file/service/impl/S3PresignedUrlServiceImpl.java
@@ -18,7 +18,6 @@ import com.ktb.file.service.S3PresignedUrlService;
 import com.ktb.file.util.SizeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -50,9 +49,6 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
     private final S3Presigner s3Presigner;
 
     private final S3Config s3Config;
-
-    @Value("${aws.s3.key-prefix:uploads}")
-    private String keyPrefix;
 
     @Override
     @Transactional
@@ -102,7 +98,7 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
     public boolean isFileExistsInS3(String s3Key) {
         try {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
-                .bucket(s3Config.getS3().getBucketName())
+                .bucket(s3Config.getS3().getUploadBucketName())
                 .key(s3Key)
                 .build();
             s3Client.headObject(headObjectRequest);
@@ -114,7 +110,7 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
 
     private String generateS3PresignedUrl(String s3Key, String contentType) {
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-            .bucket(s3Config.getS3().getBucketName())
+            .bucket(s3Config.getS3().getUploadBucketName())
             .key(s3Key)
             .contentType(contentType)
             .build();
@@ -131,7 +127,7 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
 
     private String generateS3PresignedGetUrl(String s3Key) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                .bucket(s3Config.getS3().getBucketName())
+                .bucket(s3Config.getS3().getUploadBucketName())
                 .key(s3Key)
                 .build();
 
@@ -178,8 +174,9 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
         return UUID.randomUUID().toString() + "." + extension;
     }
 
-    private String buildS3Key(FileCategory category, String storedName) {
-        return normalizeKeyPrefix() + "/" + category.name().toLowerCase() + "/" + storedName;
+    private String buildS3Key(FileCategory category, String originalName) {
+        String categoryPrefix = category.getS3Directory();
+        return categoryPrefix + "/" + originalName;
     }
 
     private String buildCdnUrl(String s3Key) {
@@ -191,7 +188,7 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
 
         String extension = extractExtension(request.fileName());
         String storedName = generateStoredName(extension);
-        String s3Key = buildS3Key(request.category(), storedName);
+        String s3Key = buildS3Key(request.category(), request.fileName());
 
         File fileEntity = File.builder()
                 .originalName(request.fileName())
@@ -243,13 +240,6 @@ public class S3PresignedUrlServiceImpl implements S3PresignedUrlService {
 
     private PresignedUrlMethod resolveMethod(PresignedUrlRequest request) {
         return request.method() != null ? request.method() : PresignedUrlMethod.PUT;
-    }
-
-    private String normalizeKeyPrefix() {
-        if (keyPrefix == null || keyPrefix.trim().isEmpty()) {
-            return "uploads";
-        }
-        return keyPrefix.endsWith("/") ? keyPrefix.substring(0, keyPrefix.length() - 1) : keyPrefix;
     }
 
     private String normalizeCdnPrefix() {

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -70,7 +70,9 @@ oauth:
 aws:
   region: ap-northeast-2
   s3:
-    bucket-name: test-bucket
+    upload-bucket-name: test-upload-bucket
+    tts-bucket-name: test-tts-bucket
+    cdn-url-prefix: https://cdn.test.local
   credentials:
     access-key: test-access-key
     secret-key: test-secret-key

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,9 +66,9 @@ jwt:
 aws:
   region: ${AWS_REGION:ap-northeast-2}
   s3:
-    bucket-name: ${AWS_S3_BUCKET_NAME}
+    upload-bucket-name: ${AWS_S3_UPLOAD_BUCKET_NAME}
+    tts-bucket-name: ${AWS_S3_TTS_BUCKET_NAME}
     cdn-url-prefix: ${AWS_S3_CDN_URL_PREFIX}
-    key-prefix: ${AWS_S3_KEY_PREFIX}
   credentials:
     access-key: ${AWS_ACCESS_KEY_ID}
     secret-key: ${AWS_SECRET_ACCESS_KEY}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -65,7 +65,9 @@ oauth:
 aws:
   region: ap-northeast-2
   s3:
-    bucket-name: test-bucket
+    upload-bucket-name: test-upload-bucket
+    tts-bucket-name: test-tts-bucket
+    cdn-url-prefix: https://cdn.test.local
   credentials:
     access-key: test-access-key
     secret-key: test-secret-key


### PR DESCRIPTION
## 요약

  S3 설정을 업로드 버킷과 TTS 버킷으로 분리하고, Presigned URL 생성 시 파일 카테고리별 디렉토리(audio, video, image)로 key를 매핑하도록 정리했습니다.

  ## 변경사항

  - aws.s3.bucket-name 단일 설정을 upload-bucket-name, tts-bucket-name으로 분리
  - FileCategory에 s3Directory 필드 추가 및 카테고리별 경로 매핑
  - Presigned URL 로직에서 업로드 버킷 사용으로 통일
  - key-prefix 의존 로직 제거, 카테고리 디렉토리 기반 key 생성으로 단순화
  - 환경 설정 파일(.env, application*.yaml)에 신규 S3 설정 반영

  ## 수정/추가/삭제 파일

  - 수정
      - .env_template
      - src/main/java/com/ktb/common/config/S3Config.java
      - src/main/java/com/ktb/file/domain/FileCategory.java
      - src/main/java/com/ktb/file/service/impl/S3PresignedUrlServiceImpl.java
      - src/main/resources/application.yaml
      - src/main/resources/application-test.yaml
      - src/test/resources/application-test.yaml

  ## 구현 의도 / 목적

  - 업로드 파일과 TTS 파일의 저장 책임을 버킷 단위로 분리
  - 파일 카테고리별 key 경로를 명확히 고정해 운영/조회 일관성 확보
  - 불필요한 prefix 설정 의존성을 제거해 설정/로직 복잡도 축소

  ## 관련 Commit, Issue

  - #199 
