### PR TITLE
fix:[#190]S3 클라이언트 생성간 DefaultCredentialsProvider설정

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -13,8 +13,8 @@ AWS_S3_UPLOAD_BUCKET_NAME=your_aws_s3_upload_bucket_name
 AWS_S3_TTS_BUCKET_NAME=your_aws_s3_tts_bucket_name
 AWS_S3_CDN_URL_PREFIX=your_aws_cdn_url_prefix
 AWS_S3_KEY_PREFIX=your_aws_key_prefix
-AWS_ACCESS_KEY_ID=your_aws_access_key_id_value
-AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key_value
+# 로컬에서 Instance Profile이 없을 때만 선택적으로 사용
+AWS_PROFILE=your_aws_profile_name
 
 # AWS Parameter Store
 AWS_PARAMETER_STORE_ENABLED=your_parameter_store_enabled

--- a/src/main/java/com/ktb/common/config/S3Config.java
+++ b/src/main/java/com/ktb/common/config/S3Config.java
@@ -5,8 +5,7 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -18,7 +17,6 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 public class S3Config {
     private String region;
     private S3Properties s3 = new S3Properties();
-    private CredentialsProperties credentials = new CredentialsProperties();
 
     @Getter
     @Setter
@@ -28,30 +26,19 @@ public class S3Config {
         private String cdnUrlPrefix;
     }
 
-    @Getter
-    @Setter
-    public static class CredentialsProperties {
-        private String accessKey;
-        private String secretKey;
-    }
-
     @Bean
     public S3Client s3Client() {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
-            credentials.getAccessKey(), credentials.getSecretKey());
         return S3Client.builder()
             .region(Region.of(region))
-            .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+            .credentialsProvider(DefaultCredentialsProvider.create())
             .build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(
-            credentials.getAccessKey(), credentials.getSecretKey());
         return S3Presigner.builder()
             .region(Region.of(region))
-            .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+            .credentialsProvider(DefaultCredentialsProvider.create())
             .build();
     }
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -81,9 +81,6 @@ aws:
     upload-bucket-name: test-upload-bucket
     tts-bucket-name: test-tts-bucket
     cdn-url-prefix: https://cdn.test.local
-  credentials:
-    access-key: test-access-key
-    secret-key: test-secret-key
 
 interview:
   session:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,9 +77,6 @@ aws:
     upload-bucket-name: ${AWS_S3_UPLOAD_BUCKET_NAME}
     tts-bucket-name: ${AWS_S3_TTS_BUCKET_NAME}
     cdn-url-prefix: ${AWS_S3_CDN_URL_PREFIX}
-  credentials:
-    access-key: ${AWS_ACCESS_KEY_ID}
-    secret-key: ${AWS_SECRET_ACCESS_KEY}
 
 ai:
   feedback:

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -76,9 +76,6 @@ aws:
     upload-bucket-name: test-upload-bucket
     tts-bucket-name: test-tts-bucket
     cdn-url-prefix: https://cdn.test.local
-  credentials:
-    access-key: test-access-key
-    secret-key: test-secret-key
 
 interview:
   session:


### PR DESCRIPTION
## Intro
 해당 PR 반영은 서버 컨테이너 배포 후 반영 필요합니다.
  
## 요약
  기존 S3 설정은 `AwsBasicCredentials + StaticCredentialsProvider`로 Access Key/Secret Key를 명시 주입하고 있었습니다.
  이 방식은 실행 환경(ECS/EKS/EC2 IAM Role, AWS Profile, 환경변수 체인) 활용이 어렵고, 설정 파일에 자격증명 키 구조를 유지해야 하는 부담이 있었습니다.

  이번 변경으로 AWS SDK 기본 자격증명 체인(`DefaultCredentialsProvider`)을 사용하도록 전환했습니다.
<img width="492" height="587" alt="image" src="https://github.com/user-attachments/assets/8fd20186-d7ce-40d9-b3dc-ba714bb50f95" />

  ## 변경 사항
  - `S3Client` 생성 시 `DefaultCredentialsProvider` 사용
  - `S3Presigner` 생성 시 `DefaultCredentialsProvider` 사용
  - `S3Config` 내 `CredentialsProperties(accessKey/secretKey)` 제거
  - 설정 파일에서 `aws.credentials.*` 제거

  ### 변경 파일
  - `src/main/java/com/ktb/common/config/S3Config.java`
  - `src/main/resources/application.yaml`
  - `src/main/resources/application-test.yaml`
  - `src/test/resources/application-test.yaml`

  ## 기대 효과
  - IAM Role 기반 인증(ECS Task Role, EKS IRSA, EC2 Role) 사용 가능
  - 로컬 개발 시 AWS 기본 체인(`AWS_PROFILE`, `~/.aws/credentials`, env vars) 그대로 사용 가능
  - 애플리케이션 설정에서 정적 키 의존 제거로 보안/운영 단순화

  ## 영향 범위
  - S3 업로드/조회/Presigned URL 발급 경로 전반 (`S3Client`, `S3Presigner` 공통 빈 사용 영역)

