### PR TITLE
fix:[#213]SSM Parameter Store import 경로를 DEPLOY_ENV 기반으로 변경

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -20,8 +20,8 @@ AWS_PROFILE=your_aws_profile_name
 AWS_PARAMETER_STORE_ENABLED=your_parameter_store_enabled
 AWS_PARAMETER_STORE_PATH=your_parameter_store_path
 
-# SSM Parameter Store 로딩 트리거 (핵심)
-SPRING_CONFIG_IMPORT=optional:aws-parameterstore:/qfeed/dev/be/
+# 배포 환경 결정 환경 변수
+DEPLOY_ENV=dev
 
 # AI Service URLs
 AI_FEEDBACK_BASE_URL=your_ai_feedback_base_url

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ spring:
       parameterstore:
         enabled: ${AWS_PARAMETER_STORE_ENABLED:true}
   config:
-    import: ${SPRING_CONFIG_IMPORT:optional:aws-parameterstore:/qfeed/dev/be/}
+    import: optional:aws-parameterstore:/qfeed/${DEPLOY_ENV:dev}/be/
 
   jpa:
     hibernate:


### PR DESCRIPTION
### 변경 배경
  배포 환경(dev/stg/prod)에 따라 Parameter Store 경로를 유연하게 사용하기 위해 설정 방식을 수정했습니다.

  ### 변경 내용
  - `spring.config.import`를 `SPRING_CONFIG_IMPORT` 직접 주입 방식에서 제거
  - `application.yaml`에서 환경 변수 기반 경로로 변경
    - `optional:aws-parameterstore:/qfeed/${DEPLOY_ENV:dev}/be/`
  - `.env_template`에 `DEPLOY_ENV=dev` 예시 추가
  - 기존 `SPRING_CONFIG_IMPORT` 템플릿 항목 제거

### 관련 커밋
 - #213 