### PR TITLE
feat: CI/CD에 Alloy 사이드카 배포 파일 다운로드 추가

### DIFF
--- a/.github/workflows/BE-CICD.yml
+++ b/.github/workflows/BE-CICD.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   ci:
     name: CI - Build and Test
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -91,7 +91,7 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     needs: ci
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
 
     steps:
@@ -192,7 +192,7 @@ jobs:
   deploy-prod:
     name: Deploy to Prod
     needs: ci
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
@@ -283,7 +283,7 @@ jobs:
 
   discord-ci-failure:
     name: Discord 알림 (CI 실패)
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: ci
     if: always() && needs.ci.result == 'failure'
     steps:
@@ -331,7 +331,7 @@ jobs:
 
   discord-deploy-dev-failure:
     name: Discord 알림 (Dev 배포 실패)
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: deploy-dev
     if: always() && needs.deploy-dev.result == 'failure'
     steps:
@@ -344,7 +344,7 @@ jobs:
 
   discord-deploy-prod-failure:
     name: Discord 알림 (Prod 배포 실패)
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     needs: deploy-prod
     if: always() && needs.deploy-prod.result == 'failure'
     steps:

--- a/.github/workflows/BE-CICD.yml
+++ b/.github/workflows/BE-CICD.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   ci:
     name: CI - Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm64
 
     steps:
       - name: Checkout code
@@ -91,7 +91,7 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm64
     if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
 
     steps:
@@ -141,7 +141,17 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --targets '[{"Key":"tag:Name","Values":["qfeed-dev-ec2-backend"]}]' \
-            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/deploy.sh -o /srv/qfeed/deploy.sh && curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --parameters '{
+              "commands":[
+                "set -e",
+                "mkdir -p /srv/qfeed/alloy",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/deploy.sh          -o /srv/qfeed/deploy.sh",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/alloy/config.alloy -o /srv/qfeed/alloy/config.alloy",
+                "cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"
+              ],
+              "executionTimeout":["600"]
+            }' \
             --timeout-seconds 600 \
             --comment "Deploy backend ${{ steps.meta.outputs.short_sha }}" \
             --output text --query "Command.CommandId")
@@ -182,7 +192,7 @@ jobs:
   deploy-prod:
     name: Deploy to Prod
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm64
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
@@ -232,7 +242,17 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --targets '[{"Key":"tag:Name","Values":["qfeed-prod-ec2-backend"]}]' \
-            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/deploy.sh -o /srv/qfeed/deploy.sh && curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --parameters '{
+              "commands":[
+                "set -e",
+                "mkdir -p /srv/qfeed/alloy",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/deploy.sh          -o /srv/qfeed/deploy.sh",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/alloy/config.alloy -o /srv/qfeed/alloy/config.alloy",
+                "cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"
+              ],
+              "executionTimeout":["600"]
+            }' \
             --timeout-seconds 600 \
             --comment "Deploy backend ${{ steps.meta.outputs.short_sha }}" \
             --output text --query "Command.CommandId")
@@ -263,7 +283,7 @@ jobs:
 
   discord-ci-failure:
     name: Discord 알림 (CI 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm64
     needs: ci
     if: always() && needs.ci.result == 'failure'
     steps:
@@ -311,7 +331,7 @@ jobs:
 
   discord-deploy-dev-failure:
     name: Discord 알림 (Dev 배포 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm64
     needs: deploy-dev
     if: always() && needs.deploy-dev.result == 'failure'
     steps:
@@ -324,7 +344,7 @@ jobs:
 
   discord-deploy-prod-failure:
     name: Discord 알림 (Prod 배포 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm64
     needs: deploy-prod
     if: always() && needs.deploy-prod.result == 'failure'
     steps:


### PR DESCRIPTION
## Summary

- 배포 시 EC2에 `alloy/config.alloy`를 추가로 다운로드하도록 SSM command 수정
- Backend 컨테이너와 함께 Alloy 사이드카가 기동되어 호스트 메트릭(Prometheus push) + 컨테이너 로그(Loki push) 수집
- CI/CD runner를 `ubuntu-24.04-arm64`로 변경 (EC2 ARM 아키텍처 일치)

## Changes

### SSM Deploy Command 변경 (Dev/Prod 동일)
```
Before: deploy.sh + docker-compose.yml 다운로드
After:  deploy.sh + docker-compose.yml + alloy/config.alloy 다운로드
```

### Runner 변경
- `ubuntu-latest` → `ubuntu-24.04-arm64` (전체 job)

## Test plan

- [x] Dev 브랜치 push 시 CI/CD 정상 실행
- [x] EC2에 alloy/config.alloy 다운로드 확인
- [x] Backend 컨테이너 + Alloy 컨테이너 동시 기동 확인
- [x] Grafana에서 Backend EC2 메트릭/로그 수신 확인