### PR TITLE
feat: CI/CD Alloy 사이드카 배포 + ARM runner 전환 (Prod 반영)

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -20,8 +20,8 @@ AWS_PROFILE=your_aws_profile_name
 AWS_PARAMETER_STORE_ENABLED=your_parameter_store_enabled
 AWS_PARAMETER_STORE_PATH=your_parameter_store_path
 
-# SSM Parameter Store 로딩 트리거 (핵심)
-SPRING_CONFIG_IMPORT=optional:aws-parameterstore:/qfeed/dev/be/
+# 배포 환경 결정 환경 변수
+DEPLOY_ENV=dev
 
 # AI Service URLs
 AI_FEEDBACK_BASE_URL=your_ai_feedback_base_url

--- a/.github/workflows/BE-CICD.yml
+++ b/.github/workflows/BE-CICD.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   ci:
     name: CI - Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -91,7 +91,7 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
 
     steps:
@@ -141,7 +141,17 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --targets '[{"Key":"tag:Name","Values":["qfeed-dev-ec2-backend"]}]' \
-            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/deploy.sh -o /srv/qfeed/deploy.sh && curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --parameters '{
+              "commands":[
+                "set -e",
+                "mkdir -p /srv/qfeed/alloy",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/deploy.sh          -o /srv/qfeed/deploy.sh",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_DEV }}/alloy/config.alloy -o /srv/qfeed/alloy/config.alloy",
+                "cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"
+              ],
+              "executionTimeout":["600"]
+            }' \
             --timeout-seconds 600 \
             --comment "Deploy backend ${{ steps.meta.outputs.short_sha }}" \
             --output text --query "Command.CommandId")
@@ -182,7 +192,7 @@ jobs:
   deploy-prod:
     name: Deploy to Prod
     needs: ci
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
@@ -232,7 +242,17 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \
             --targets '[{"Key":"tag:Name","Values":["qfeed-prod-ec2-backend"]}]' \
-            --parameters '{"commands":["mkdir -p /srv/qfeed && curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/deploy.sh -o /srv/qfeed/deploy.sh && curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml && cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"],"executionTimeout":["600"]}' \
+            --parameters '{
+              "commands":[
+                "set -e",
+                "mkdir -p /srv/qfeed/alloy",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/deploy.sh          -o /srv/qfeed/deploy.sh",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/docker-compose.yml -o /srv/qfeed/docker-compose.yml",
+                "curl -sfL ${{ env.DEPLOY_RAW_BASE_PROD }}/alloy/config.alloy -o /srv/qfeed/alloy/config.alloy",
+                "cd /srv/qfeed && bash deploy.sh ${{ steps.meta.outputs.short_sha }}"
+              ],
+              "executionTimeout":["600"]
+            }' \
             --timeout-seconds 600 \
             --comment "Deploy backend ${{ steps.meta.outputs.short_sha }}" \
             --output text --query "Command.CommandId")
@@ -263,7 +283,7 @@ jobs:
 
   discord-ci-failure:
     name: Discord 알림 (CI 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: ci
     if: always() && needs.ci.result == 'failure'
     steps:
@@ -311,7 +331,7 @@ jobs:
 
   discord-deploy-dev-failure:
     name: Discord 알림 (Dev 배포 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: deploy-dev
     if: always() && needs.deploy-dev.result == 'failure'
     steps:
@@ -324,7 +344,7 @@ jobs:
 
   discord-deploy-prod-failure:
     name: Discord 알림 (Prod 배포 실패)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: deploy-prod
     if: always() && needs.deploy-prod.result == 'failure'
     steps:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ spring:
       parameterstore:
         enabled: ${AWS_PARAMETER_STORE_ENABLED:true}
   config:
-    import: ${SPRING_CONFIG_IMPORT:optional:aws-parameterstore:/qfeed/dev/be/}
+    import: optional:aws-parameterstore:/qfeed/${DEPLOY_ENV:dev}/be/
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary

dev에서 검증 완료된 CI/CD 변경사항을 main(Prod)에 반영합니다.

- 배포 시 EC2에 `docker-compose.yml`과 `alloy/config.alloy`를 추가로 다운로드하도록 SSM command 수정
- BE 컨테이너와 함께 Alloy 사이드카가 기동되어 호스트 메트릭(Prometheus push) + 컨테이너 로그(Loki push) 수집
- CI/CD runner를 `ubuntu-24.04-arm`으로 변경 (EC2 ARM 아키텍처 일치)

## Dev 검증 결과

- CI/CD 정상 실행 확인
- BE 컨테이너 + Alloy 컨테이너 동시 기동 확인
- 헬스체크 정상 통과 확인

## Test plan

- [x] main 머지 후 Prod 배포 정상 실행
- [x] Prod BE EC2에서 BE + Alloy 컨테이너 기동 확인
- [x] Grafana에서 Prod BE EC2 메트릭/로그 수신 확인