### PR TITLE
feat: OTel Java Agent 추가 및 logback 로그 파이프라인 전환

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,11 @@ WORKDIR /app
 
 COPY --from=build /app/build/libs/app.jar app.jar
 RUN apk add --no-cache curl \
-    && addgroup -S appgroup && adduser -S appuser -G appgroup \
-    && mkdir -p /app/logs && chown appuser:appgroup /app/logs
+    && curl -fsSL -o opentelemetry-javaagent.jar \
+       https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.20.1/opentelemetry-javaagent.jar \
+    && addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 EXPOSE 8080 8081
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-Djava.security.egd=file:/dev/./urandom", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,4 @@
 <configuration>
-    <property name="LOG_HOME" value="./logs" />
     <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
     <appender name="STDOUT"
@@ -9,33 +8,14 @@
         </filter>
         <encoder>
             <Pattern>
-                [%d{yyyy-MM-dd HH:mm:ss}] [%level] [%logger{0}] [%X{traceId}] %msg%n
+                [%d{yyyy-MM-dd HH:mm:ss.SSS}] [%level] [%logger{0}] [%X{trace_id}] [%X{span_id}] %msg%n
             </Pattern>
-        </encoder>
-    </appender>
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
-        <file>${LOG_HOME}/app.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <!-- rollover daily -->
-            <fileNamePattern>${LOG_HOME}/%d{yyyy/MM, aux}/app-%d{yyyy-MM-dd}.%i.zip</fileNamePattern>
-            <!-- each file should be at most 10MB, keep 60 days worth of history, but at most 10GB -->
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>60</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
-        </rollingPolicy>
-        <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}] [%level] [%logger{0}] [%X{traceId}] %msg%n</pattern>
         </encoder>
     </appender>
 
     <!-- LOG everything at INFO level -->
     <root level="INFO">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
     </root>
 
 </configuration>


### PR DESCRIPTION
## Summary
- OTel Java Agent v2.20.1을 Docker 이미지에 추가하여 자동 계측(trace_id/span_id MDC 주입) 활성화
- logback FILE appender 제거, STDOUT 단일 파이프라인으로 전환 (Docker → Alloy → Loki)
- 타임스탬프 밀리세컨드 정밀도 추가

## Changes
### Dockerfile
- OTel Java Agent JAR 다운로드 (`v2.20.1`)
- ENTRYPOINT에 `-javaagent:/app/opentelemetry-javaagent.jar` 추가
- `/app/logs` 디렉토리 생성 제거 (FILE appender 제거에 따라 불필요)

### logback.xml
- FILE appender + RollingFileAppender 전체 제거
- STDOUT 패턴에 `%X{trace_id}` `%X{span_id}` 추가 (OTel Agent MDC 키)
- 타임스탬프 `HH:mm:ss` → `HH:mm:ss.SSS` (밀리세컨드 정밀도)

## Background
- Loki 도입으로 로그 수집이 STDOUT → Docker log → Alloy → Loki 파이프라인으로 전환됨
- 컨테이너 내 파일 로그는 재시작 시 유실되고 Loki와 중복되므로 제거
- OTel Agent는 현재 exporter=none (trace/metric 미전송), MDC 주입만 활성화
- 향후 Tempo 도입 시 OTEL_TRACES_EXPORTER=otlp로 전환하면 분산 추적 연동 가능

## Test plan
- [ ] Docker 빌드 성공 확인
- [ ] 로그 출력에 trace_id/span_id 포함 확인
- [ ] /actuator/prometheus 엔드포인트 정상 응답 확인
- [ ] 기존 기능 정상 동작 확인 (API 테스트)