### PR TITLE
Feat/#224 미읽음 알림 상태 SSE 구독 기능 추가

### DIFF
--- a/src/main/java/com/ktb/notification/controller/UserNotificationController.java
+++ b/src/main/java/com/ktb/notification/controller/UserNotificationController.java
@@ -2,20 +2,22 @@ package com.ktb.notification.controller;
 
 import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.common.dto.ApiResponse;
-import com.ktb.notification.dto.response.UnreadCountResponse;
 import com.ktb.notification.dto.response.UserNotificationResponse;
 import com.ktb.notification.service.UserNotificationService;
+import com.ktb.notification.sse.SseEmitterRegistry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "User Notification API", description = "사용자 알림 API")
 @RestController
@@ -31,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserNotificationController {
 
     private final UserNotificationService userNotificationService;
+    private final SseEmitterRegistry sseEmitterRegistry;
 
     @GetMapping
     @Operation(summary = "알림 목록 조회", description = "내 알림 목록을 조회합니다.")
@@ -50,20 +54,23 @@ public class UserNotificationController {
         return ResponseEntity.ok(new ApiResponse<>("notifications_retrieval_success", result));
     }
 
-    @GetMapping("/unread")
-    @Operation(summary = "안읽은 알림 여부 조회", description = "안읽은 알림 여부를 조회합니다.")
+    @GetMapping(value = "/unread", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Operation(summary = "안읽은 알림 구독", description = "안읽은 알림 존재 여부를 SSE로 구독합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 연결 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
     })
-    public ResponseEntity<ApiResponse<UnreadCountResponse>> getUnreadCount(
-            @AuthenticationPrincipal SecurityUserAccount principal
-    ) {
-        UnreadCountResponse result = userNotificationService.getUnreadCount(
-                principal.getAccount().getId()
-        );
-        return ResponseEntity.ok(new ApiResponse<>("unread_count_retrieval_success", result));
+    public SseEmitter subscribeUnread(@AuthenticationPrincipal SecurityUserAccount principal) {
+        Long accountId = principal.getAccount().getId();
+        SseEmitter emitter = sseEmitterRegistry.register(accountId);
+        try {
+            boolean hasUnread = userNotificationService.hasUnread(accountId);
+            emitter.send(SseEmitter.event().name("unread").data(hasUnread));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+        return emitter;
     }
 
     @PatchMapping("/{notificationId}")

--- a/src/main/java/com/ktb/notification/service/UserNotificationService.java
+++ b/src/main/java/com/ktb/notification/service/UserNotificationService.java
@@ -1,7 +1,6 @@
 package com.ktb.notification.service;
 
 import com.ktb.notification.domain.enums.NotificationTypeCd;
-import com.ktb.notification.dto.response.UnreadCountResponse;
 import com.ktb.notification.dto.response.UserNotificationResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +9,7 @@ public interface UserNotificationService {
 
     Page<UserNotificationResponse> getNotifications(Long accountId, Pageable pageable);
 
-    UnreadCountResponse getUnreadCount(Long accountId);
+    boolean hasUnread(Long accountId);
 
     UserNotificationResponse markAsRead(Long accountId, Long notificationId);
 

--- a/src/main/java/com/ktb/notification/service/impl/UserNotificationServiceImpl.java
+++ b/src/main/java/com/ktb/notification/service/impl/UserNotificationServiceImpl.java
@@ -5,13 +5,13 @@ import com.ktb.auth.service.UserAccountService;
 import com.ktb.notification.domain.Notice;
 import com.ktb.notification.domain.UserNotification;
 import com.ktb.notification.domain.enums.NotificationTypeCd;
-import com.ktb.notification.dto.response.UnreadCountResponse;
 import com.ktb.notification.dto.response.UserNotificationResponse;
 import com.ktb.notification.exception.NoticeNotFoundException;
 import com.ktb.notification.exception.UserNotificationNotFoundException;
 import com.ktb.notification.repository.NoticeRepository;
 import com.ktb.notification.repository.UserNotificationRepository;
 import com.ktb.notification.service.UserNotificationService;
+import com.ktb.notification.sse.UnreadEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +26,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     private final UserNotificationRepository userNotificationRepository;
     private final UserAccountService userAccountService;
     private final NoticeRepository noticeRepository;
+    private final UnreadEventPublisher unreadEventPublisher;
 
     @Override
     public Page<UserNotificationResponse> getNotifications(Long accountId, Pageable pageable) {
@@ -34,9 +35,8 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     }
 
     @Override
-    public UnreadCountResponse getUnreadCount(Long accountId) {
-        long count = userNotificationRepository.countUnreadByAccountId(accountId);
-        return UnreadCountResponse.of(count);
+    public boolean hasUnread(Long accountId) {
+        return userNotificationRepository.countUnreadByAccountId(accountId) > 0;
     }
 
     @Override
@@ -48,13 +48,18 @@ public class UserNotificationServiceImpl implements UserNotificationService {
 
         notification.markAsRead();
 
+        boolean hasUnread = userNotificationRepository.countUnreadByAccountId(accountId) > 0;
+        unreadEventPublisher.publish(accountId, hasUnread);
+
         return UserNotificationResponse.from(notification);
     }
 
     @Override
     @Transactional
     public int markAllAsRead(Long accountId) {
-        return userNotificationRepository.markAllAsReadByAccountId(accountId);
+        int count = userNotificationRepository.markAllAsReadByAccountId(accountId);
+        unreadEventPublisher.publish(accountId, false);
+        return count;
     }
 
     @Override
@@ -79,6 +84,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
         );
 
         userNotificationRepository.save(notification);
+        unreadEventPublisher.publish(accountId, true);
     }
 
     @Override
@@ -97,5 +103,6 @@ public class UserNotificationServiceImpl implements UserNotificationService {
         UserNotification notification = UserNotification.createFromNotice(account, notice);
 
         userNotificationRepository.save(notification);
+        unreadEventPublisher.publish(accountId, true);
     }
 }

--- a/src/main/java/com/ktb/notification/sse/LocalUnreadEventPublisher.java
+++ b/src/main/java/com/ktb/notification/sse/LocalUnreadEventPublisher.java
@@ -1,0 +1,16 @@
+package com.ktb.notification.sse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LocalUnreadEventPublisher implements UnreadEventPublisher {
+
+    private final SseEmitterRegistry sseEmitterRegistry;
+
+    @Override
+    public void publish(Long accountId, boolean hasUnread) {
+        sseEmitterRegistry.send(accountId, hasUnread);
+    }
+}

--- a/src/main/java/com/ktb/notification/sse/SseEmitterRegistry.java
+++ b/src/main/java/com/ktb/notification/sse/SseEmitterRegistry.java
@@ -1,0 +1,48 @@
+package com.ktb.notification.sse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Component
+public class SseEmitterRegistry {
+
+    private final ConcurrentHashMap<Long, CopyOnWriteArrayList<SseEmitter>> emitters =
+            new ConcurrentHashMap<>();
+
+    public SseEmitter register(Long accountId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emitters.computeIfAbsent(accountId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+        emitter.onCompletion(() -> remove(accountId, emitter));
+        emitter.onTimeout(() -> remove(accountId, emitter));
+        emitter.onError(e -> remove(accountId, emitter));
+        return emitter;
+    }
+
+    public void send(Long accountId, boolean hasUnread) {
+        List<SseEmitter> list = emitters.getOrDefault(accountId, new CopyOnWriteArrayList<>());
+        List<SseEmitter> dead = new ArrayList<>();
+        for (SseEmitter emitter : list) {
+            try {
+                emitter.send(SseEmitter.event().name("unread").data(hasUnread));
+            } catch (IOException e) {
+                log.debug("SSE emitter dead for accountId={}, removing", accountId);
+                dead.add(emitter);
+            }
+        }
+        dead.forEach(e -> remove(accountId, e));
+    }
+
+    private void remove(Long accountId, SseEmitter emitter) {
+        CopyOnWriteArrayList<SseEmitter> list = emitters.get(accountId);
+        if (list != null) {
+            list.remove(emitter);
+        }
+    }
+}

--- a/src/main/java/com/ktb/notification/sse/UnreadEventPublisher.java
+++ b/src/main/java/com/ktb/notification/sse/UnreadEventPublisher.java
@@ -1,0 +1,5 @@
+package com.ktb.notification.sse;
+
+public interface UnreadEventPublisher {
+    void publish(Long accountId, boolean hasUnread);
+}


### PR DESCRIPTION
## 요약
미읽음 알림 상태 조회 방식을 단건 count 응답에서 SSE 구독 방식으로 전환했습니다.
알림 생성 및 읽음 처리 시점에 미읽음 여부를 실시간으로 브로드캐스트할 수 있도록 로컬 SSE 발행 구조를 추가했습니다.

## 변경사항

### 1. 미읽음 알림 조회 API를 SSE 구독으로 전환
- `UserNotificationController`의 `/api/notifications/unread` 엔드포인트를 `text/event-stream` 기반 SSE 구독 API로 변경
- 최초 구독 시 현재 미읽음 여부를 즉시 `unread` 이벤트로 전송하도록 구성

### 2. 미읽음 상태 응답 모델 단순화
- `UserNotificationService`의 `getUnreadCount()`를 `hasUnread()`로 변경
- 미읽음 개수 응답 DTO 대신 boolean 기반 상태 전달로 정리

### 3. 계정별 SSE emitter 관리 구조 추가
- `SseEmitterRegistry` 추가
- 계정별 다중 SSE emitter 등록/제거 및 브로드캐스트 처리
- 끊어진 emitter는 전송 실패 시 정리되도록 구성

### 4. 미읽음 상태 이벤트 발행 추상화 추가
- `UnreadEventPublisher` 인터페이스 추가
- `LocalUnreadEventPublisher` 구현체 추가
- 현재는 로컬 SSE 전송을 담당하고, 추후 다른 발행 방식으로 확장 가능하도록 분리

### 5. 알림 상태 변경 시 실시간 이벤트 발행 연결
- 알림 생성 시 `hasUnread = true` 발행
- 개별 읽음 처리 후 남은 미읽음 여부 재계산 후 발행
- 전체 읽음 처리 시 `hasUnread = false` 발행

## 관련 Commit / Issue
- Commit: `dba64345`
- Closes #224 
