### PR TITLE
feat:[#229] 공통 Redis 설정 및 테스트 기반 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,12 +81,18 @@ dependencies {
     // ✅ Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // ✅ Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     // ✅ 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
+    testImplementation 'org.springframework.boot:spring-boot-data-redis-test'
+    testImplementation 'org.testcontainers:testcontainers:2.0.2'
+    testImplementation 'org.testcontainers:testcontainers-junit-jupiter:2.0.2'
 }
 tasks.test {
     useJUnitPlatform()

--- a/src/main/java/com/ktb/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/ktb/redis/config/RedisCacheConfig.java
@@ -1,0 +1,64 @@
+package com.ktb.redis.config;
+
+import com.ktb.redis.policy.CachePolicy;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    /**
+     *
+     * Default 캐시 정책
+     */
+    @Bean
+    public RedisCacheConfiguration defaultRedisCacheConfiguration(
+            RedisSerializationContext.SerializationPair<String> redisKeySerializer,
+            RedisSerializationContext.SerializationPair<Object> redisValueSerializer
+    ) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(redisKeySerializer)
+                .serializeValuesWith(redisValueSerializer)
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues();
+    }
+
+    /**
+     * Enum 기반 개별 캐시 정책
+     */
+    @Bean
+    public Map<String, RedisCacheConfiguration> redisCacheConfigurations(RedisCacheConfiguration defaultRedisCacheConfiguration) {
+        return Arrays.stream(CachePolicy.values())
+                .collect(Collectors.toMap(
+                        CachePolicy::getCacheName,
+                        policy -> defaultRedisCacheConfiguration.entryTtl(policy.getTtl())
+                ));
+    }
+
+    /**
+     * 실제 Redis CacheManager
+     */
+    @Bean
+    public RedisCacheManager redisCacheManager(
+            RedisConnectionFactory connectionFactory,
+            RedisCacheConfiguration defaultRedisCacheConfiguration,
+            Map<String, RedisCacheConfiguration> redisCacheConfigurations
+    ) {
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultRedisCacheConfiguration)
+                .withInitialCacheConfigurations(redisCacheConfigurations)
+                .transactionAware()
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/redis/config/RedisSerializationConfig.java
+++ b/src/main/java/com/ktb/redis/config/RedisSerializationConfig.java
@@ -1,0 +1,53 @@
+package com.ktb.redis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
+
+@Configuration
+public class RedisSerializationConfig {
+
+    /**
+     *  RedisTemplate에서 key 직렬화에 대하여 사용
+     */
+    @Bean
+    public StringRedisSerializer redisKeySerializer() {
+        return new StringRedisSerializer();
+    }
+
+    /**
+     *  RedisTemplate에서 value 직렬화에 대하여 사용
+     */
+    @Bean
+    public RedisSerializer<Object> redisValueSerializer() {
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        return GenericJacksonJsonRedisSerializer.builder()
+                .typeValidator(ptv)
+                .enableDefaultTyping(ptv)
+                .build();
+    }
+
+    /**
+     *  RedisCacheConfiguration에서 key 직렬화 정책으로 사용
+     */
+    @Bean
+    public RedisSerializationContext.SerializationPair<String> redisKeySerializationPair(StringRedisSerializer redisKeySerializer) {
+        return RedisSerializationContext.SerializationPair.fromSerializer(redisKeySerializer);
+    }
+
+    /**
+     *  RedisCacheConfiguration에서 value 직렬화 정책으로 사용
+     */
+    @Bean
+    public RedisSerializationContext.SerializationPair<Object> redisValueSerializationPair(RedisSerializer<Object> redisValueSerializer) {
+        return RedisSerializationContext.SerializationPair.fromSerializer(redisValueSerializer);
+    }
+}

--- a/src/main/java/com/ktb/redis/config/RedisTemplateConfig.java
+++ b/src/main/java/com/ktb/redis/config/RedisTemplateConfig.java
@@ -1,0 +1,37 @@
+package com.ktb.redis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisTemplateConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory,
+            StringRedisSerializer redisKeySerializer,
+            RedisSerializer<Object> redisValueSerializer
+            ) {
+
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(redisKeySerializer);
+        template.setHashKeySerializer(redisKeySerializer);
+        template.setValueSerializer(redisValueSerializer);
+        template.setHashValueSerializer(redisValueSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/ktb/redis/constant/CacheNames.java
+++ b/src/main/java/com/ktb/redis/constant/CacheNames.java
@@ -1,0 +1,8 @@
+package com.ktb.redis.constant;
+
+public final class CacheNames {
+    public static final String EXAMPLE_CACHE_NAME = "example cache name";
+
+    private CacheNames() {
+    }
+}

--- a/src/main/java/com/ktb/redis/policy/CachePolicy.java
+++ b/src/main/java/com/ktb/redis/policy/CachePolicy.java
@@ -1,0 +1,19 @@
+package com.ktb.redis.policy;
+
+import com.ktb.redis.constant.CacheNames;
+import lombok.Getter;
+
+import java.time.Duration;
+
+@Getter
+public enum CachePolicy {
+    EXAMPLE_POLICY(CacheNames.EXAMPLE_CACHE_NAME, Duration.ofMinutes(10));
+
+    private final String cacheName;
+    private final Duration ttl;
+
+    CachePolicy(String cacheName, Duration ttl) {
+        this.cacheName = cacheName;
+        this.ttl = ttl;
+    }
+}

--- a/src/test/java/com/ktb/fixture/RedisFixture.java
+++ b/src/test/java/com/ktb/fixture/RedisFixture.java
@@ -1,0 +1,10 @@
+package com.ktb.fixture;
+
+public class RedisFixture {
+
+    public record RedisTestUser(Long id, String name) {}
+
+    public static RedisTestUser createTestUser() {
+        return new RedisTestUser(1L, "name");
+    }
+}

--- a/src/test/java/com/ktb/redis/AbstractRedisContainerTest.java
+++ b/src/test/java/com/ktb/redis/AbstractRedisContainerTest.java
@@ -1,0 +1,39 @@
+package com.ktb.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+
+public class AbstractRedisContainerTest {
+
+    @SuppressWarnings("resource")
+    private static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine")
+                    .withExposedPorts(6379);
+
+    static {
+        REDIS.start();
+    }
+
+    @DynamicPropertySource
+    static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
+
+    @Autowired(required = false)
+    protected StringRedisTemplate stringRedisTemplate;
+
+    protected void clearRedis() {
+        if (stringRedisTemplate == null) {
+            return;
+        }
+
+        var keys = stringRedisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            stringRedisTemplate.delete(keys);
+        }
+    }
+}

--- a/src/test/java/com/ktb/redis/RedisCacheManagerTest.java
+++ b/src/test/java/com/ktb/redis/RedisCacheManagerTest.java
@@ -1,0 +1,48 @@
+package com.ktb.redis;
+
+import com.ktb.fixture.RedisFixture;
+import com.ktb.redis.config.RedisCacheConfig;
+import com.ktb.redis.config.RedisSerializationConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@Import({
+        RedisCacheConfig.class,
+        RedisSerializationConfig.class
+})
+public class RedisCacheManagerTest extends AbstractRedisContainerTest{
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private StringRedisTemplate redisCleaner;
+
+    @BeforeEach
+    void setUp() {
+        this.stringRedisTemplate = redisCleaner;
+        clearRedis();
+    }
+
+    @Test
+    void cache_manager_should_store_and_get_value() {
+        Cache cache = cacheManager.getCache("questionList");
+        RedisFixture.RedisTestUser user = RedisFixture.createTestUser();
+
+        cache.put("test:user:1", user);
+
+        RedisFixture.RedisTestUser cached = cache.get("test:user:1", RedisFixture.RedisTestUser.class);
+
+        assertThat(cached).isNotNull();
+        assertThat(cached).isEqualTo(user);
+    }
+}

--- a/src/test/java/com/ktb/redis/RedisConnectionTest.java
+++ b/src/test/java/com/ktb/redis/RedisConnectionTest.java
@@ -1,0 +1,25 @@
+package com.ktb.redis;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+public class RedisConnectionTest extends AbstractRedisContainerTest{
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Test
+    void redis_connection_should_work() {
+        try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+            String pong = connection.ping();
+            assertThat(pong).isEqualTo("PONG");
+        }
+    }
+}

--- a/src/test/java/com/ktb/redis/RedisTemplateTest.java
+++ b/src/test/java/com/ktb/redis/RedisTemplateTest.java
@@ -1,0 +1,51 @@
+package com.ktb.redis;
+
+import com.ktb.fixture.RedisFixture;
+import com.ktb.redis.config.RedisSerializationConfig;
+import com.ktb.redis.config.RedisTemplateConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataRedisTest
+@Import({
+        RedisSerializationConfig.class,
+        RedisTemplateConfig.class
+})
+public class RedisTemplateTest extends AbstractRedisContainerTest{
+
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisCleaner;
+
+    @BeforeEach
+    void setUp() {
+        this.stringRedisTemplate = redisCleaner;
+        clearRedis();
+    }
+
+    @Test
+    void redis_template_should_set_and_get_object() {
+        String key = "test:object:key";
+        RedisFixture.RedisTestUser user = RedisFixture.createTestUser();
+
+        redisTemplate.opsForValue().set(key, user, Duration.ofSeconds(30));
+
+        Object result = redisTemplate.opsForValue().get(key);
+
+        assertThat(result).isInstanceOf(RedisFixture.RedisTestUser.class);
+        assertThat((RedisFixture.RedisTestUser)result).isEqualTo(user);
+    }
+}

--- a/src/test/java/com/ktb/redis/StringRedisTemplateTest.java
+++ b/src/test/java/com/ktb/redis/StringRedisTemplateTest.java
@@ -1,0 +1,36 @@
+package com.ktb.redis;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+public class StringRedisTemplateTest extends AbstractRedisContainerTest{
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        this.stringRedisTemplate = redisTemplate;
+        clearRedis();
+    }
+
+    @Test
+    void string_redis_template_should_set_and_get_value() {
+        String key = "test:string:key";
+        String value = "hello redis";
+
+        stringRedisTemplate.opsForValue().set(key, value, Duration.ofSeconds(30));
+
+        String result = stringRedisTemplate.opsForValue().get(key);
+
+        assertThat(result).isEqualTo(value);
+    }
+}


### PR DESCRIPTION
## 요약
  Redis 공통 사용을 위한 기본 설정과 테스트 기반을 추가했습니다.

  직렬화 설정, `RedisTemplate`, `StringRedisTemplate`, `CacheManager` 구성을 분리했고, Testcontainers 기반의 Redis 테스트 코드를 함께 추가해 이후 도메인별 확장이 가능한 출발점을 마련

  ## 변경 내용
  - `build.gradle`
  - `src/main/java/com/ktb/redis/config/RedisCacheConfig.java`
  - `src/main/java/com/ktb/redis/config/RedisSerializationConfig.java`
  - `src/main/java/com/ktb/redis/config/RedisTemplateConfig.java`
  - `src/main/java/com/ktb/redis/constant/CacheNames.java`
  - `src/main/java/com/ktb/redis/policy/CachePolicy.java`
  - `src/test/java/com/ktb/fixture/RedisFixture.java`
  - `src/test/java/com/ktb/redis/AbstractRedisContainerTest.java`
  - `src/test/java/com/ktb/redis/RedisCacheManagerTest.java`
  - `src/test/java/com/ktb/redis/RedisConnectionTest.java`
  - `src/test/java/com/ktb/redis/RedisTemplateTest.java`
  - `src/test/java/com/ktb/redis/StringRedisTemplateTest.java`

  ## 구현의도
  이번 변경은 Redis를 도메인 로직에 바로 적용하기 위한 작업이라기보다, 공통 모듈 수준에서 재사용 가능한 기본 설정을 먼저 정리하는 데 목적이 있습니다.

  특히 다음을 의도했습니다.
  - Redis 연결, 직렬화, 캐시 설정을 공통 레벨에서 분리
  - 이후 도메인별 캐시명, TTL, serializer 정책을 추가할 수 있는 기반 마련
  - 실제 Redis 컨테이너 기반 테스트로 최소 동작 검증 가능하도록 구성

  ## 목적
  - Redis 도입 시 반복되는 설정 코드를 공통화하기 위함
  - 향후 캐시 적용 및 Redis 기반 기능 확장 시 초기 구현 비용을 줄이기 위함
  - Redis 관련 공통 설정 변경 시 기본 동작을 빠르게 검증할 수 있는 테스트 기반을 마련하기 위함

  ## 관련 커밋
  - #229 