### PR TITLE
fix: Dockerfile에서 MaxRAMPercentage 제거

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ USER appuser
 
 EXPOSE 8080 8081
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-Djava.security.egd=file:/dev/./urandom", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-javaagent:/app/opentelemetry-javaagent.jar", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- JVM 힙 설정을 `MaxRAMPercentage=75.0`에서 docker-compose `JAVA_TOOL_OPTIONS`의 `-Xmx` 고정값으로 전환
- OTel Agent 등 non-heap 소비자가 있는 환경에서 heap 과다 할당 방지

## Test plan
- [ ] Dev 배포 후 `docker stats`로 메모리 사용량 확인
- [ ] `/actuator/prometheus`에서 `jvm_memory_max_bytes` 변경 확인