### PR TITLE
Feat/#178 refresh token cache

### DIFF
--- a/src/main/java/com/ktb/auth/dto/jwt/RefreshTokenInfo.java
+++ b/src/main/java/com/ktb/auth/dto/jwt/RefreshTokenInfo.java
@@ -6,6 +6,7 @@ public record RefreshTokenInfo(
         Long id,
         Long familyId,
         boolean used,
-        LocalDateTime expiresAt
+        LocalDateTime expiresAt,
+        String tokenHash
 ) {
 }

--- a/src/main/java/com/ktb/auth/exception/token/TokenReuseDetectedException.java
+++ b/src/main/java/com/ktb/auth/exception/token/TokenReuseDetectedException.java
@@ -8,7 +8,12 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenReuseDetectedException extends BusinessException {
 
     public TokenReuseDetectedException(Long familyId) {
-        log.error("{} Family 폐기됨: {}", ErrorCode.TOKEN_REUSE_DETECTED , familyId);
+        log.error("{} Family 폐기됨: {}", ErrorCode.TOKEN_REUSE_DETECTED, familyId);
+        super(ErrorCode.TOKEN_REUSE_DETECTED);
+    }
+
+    public TokenReuseDetectedException(String familyUuid) {
+        log.error("{} Family 폐기됨: {}", ErrorCode.TOKEN_REUSE_DETECTED, familyUuid);
         super(ErrorCode.TOKEN_REUSE_DETECTED);
     }
 }

--- a/src/main/java/com/ktb/auth/repository/TokenFamilyRepository.java
+++ b/src/main/java/com/ktb/auth/repository/TokenFamilyRepository.java
@@ -1,6 +1,7 @@
 package com.ktb.auth.repository;
 
 import com.ktb.auth.domain.TokenFamily;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -12,6 +13,16 @@ import org.springframework.stereotype.Repository;
 public interface TokenFamilyRepository extends JpaRepository<TokenFamily, Long> {
 
     Optional<TokenFamily> findByUuid(String uuid);
+
+    /**
+     * 계정의 활성 Family UUID 목록 조회 (Redis 상태 일괄 무효화 용)
+     * 만료된 Family는 Redis TTL도 이미 만료됐으므로 제외
+     */
+    @Query("SELECT f.uuid FROM TokenFamily f " +
+           "WHERE f.account.id = :accountId " +
+           "AND f.revoked = false " +
+           "AND f.expiresAt > CURRENT_TIMESTAMP")
+    List<String> findActiveUuidsByAccountId(@Param("accountId") Long accountId);
 
     /**
      * 계정의 모든 Family 무효화 (로그아웃 전체)

--- a/src/main/java/com/ktb/auth/service/RTRService.java
+++ b/src/main/java/com/ktb/auth/service/RTRService.java
@@ -1,43 +1,11 @@
 package com.ktb.auth.service;
 
-import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.dto.TokenFamilyInfo;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 
 public interface RTRService {
 
     /**
-     * 토큰 재사용 탐지
-     */
-    void detectReuse(RefreshTokenInfo tokenInfo);
-
-    /**
-     * Family 폐기
-     */
-    void revokeFamily(Long familyId, RevokeReason reason);
-
-    /**
-     * 토큰 사용 처리
-     */
-    void markAsUsed(Long refreshTokenId);
-
-    /**
-     * Family 생성 (새 세션 시작)
+     * Family 생성 (새 세션 시작 - 로그인 시)
      */
     TokenFamilyInfo createFamily(Long accountId, String deviceInfo, String clientIp);
-
-    /**
-     * Family 활성 상태 확인
-     */
-    void validateFamilyActive(Long familyId);
-
-    /**
-     * 계정의 모든 Family 폐기 (전체 로그아웃)
-     *
-     * @param accountId 계정 ID
-     * @param reason    폐기 사유
-     * @return 폐기된 Family 수
-     */
-    int revokeAllFamilies(Long accountId, RevokeReason reason);
 }
-

--- a/src/main/java/com/ktb/auth/service/RefreshTokenStore.java
+++ b/src/main/java/com/ktb/auth/service/RefreshTokenStore.java
@@ -23,4 +23,11 @@ public interface RefreshTokenStore {
      * @return RefreshTokenInfo (Optional)
      */
     Optional<RefreshTokenInfo> findByTokenHash(String tokenHash);
+
+    /**
+     * 토큰 사용 처리 (used=true, 캐시 무효화 포함)
+     *
+     * @param tokenId Refresh Token ID
+     */
+    void markAsUsed(Long tokenId);
 }

--- a/src/main/java/com/ktb/auth/service/TokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/TokenFamilyStore.java
@@ -1,23 +1,41 @@
 package com.ktb.auth.service;
 
+import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.dto.TokenFamilyInfo;
-
 import java.util.Optional;
 
 public interface TokenFamilyStore {
 
     /**
      * UUID로 Token Family 조회
-     *
-     * @param uuid Family UUID
-     * @return TokenFamilyInfo (Optional)
      */
     Optional<TokenFamilyInfo> findByUuid(String uuid);
 
     /**
-     * Family 마지막 사용 시각 업데이트
+     * 로그인 시 Family 초기 상태 등록 (currentHash, revoked=0)
      *
-     * @param uuid Family UUID
+     * @param familyUuid Family UUID
+     * @param tokenHash  최초 refresh token 해시
+     * @param ttlMillis  TTL (밀리초)
      */
-    void updateLastUsed(String uuid);
+    void initFamilyState(String familyUuid, String tokenHash, long ttlMillis);
+
+    /**
+     * 토큰 교체 (RTR Rotate) — 원자적 compare-and-swap
+     *
+     * @return 1=성공, -1=key 없음(만료), -2=revoked, -3=재사용 감지(revoke 처리됨)
+     */
+    int rotateFamilyToken(String familyUuid, String oldHash, String newHash, long ttlMillis);
+
+    /**
+     * Family 폐기 (로그아웃, 재사용 감지 시)
+     */
+    void revokeFamilyState(String familyUuid, RevokeReason reason);
+
+    /**
+     * 계정의 모든 Family 폐기 (전체 로그아웃)
+     *
+     * @return 폐기된 Family 수
+     */
+    int revokeAllFamilyStates(Long accountId, RevokeReason reason);
 }

--- a/src/main/java/com/ktb/auth/service/TokenService.java
+++ b/src/main/java/com/ktb/auth/service/TokenService.java
@@ -1,9 +1,7 @@
 package com.ktb.auth.service;
 
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenClaims;
-
 import java.time.Duration;
 import java.util.List;
 
@@ -30,23 +28,7 @@ public interface TokenService {
     RefreshTokenClaims validateRefreshToken(String refreshToken);
 
     /**
-     * Refresh Token 저장
-     *
-     * @param familyId     Token Family ID
-     * @param refreshToken Refresh Token 문자열
-     */
-    void storeRefreshToken(Long familyId, String refreshToken);
-
-    /**
-     * 저장된 Refresh Token 조회
-     *
-     * @param refreshToken Refresh Token 문자열
-     * @return RefreshTokenInfo
-     */
-    RefreshTokenInfo getStoredRefreshToken(String refreshToken);
-
-    /**
-     * 토큰 해시 생성
+     * 토큰 해시 생성 (SHA-256)
      */
     String generateTokenHash(String token);
 
@@ -60,4 +42,3 @@ public interface TokenService {
      */
     long getAccessTokenExpiresSeconds();
 }
-

--- a/src/main/java/com/ktb/auth/service/impl/JpaRefreshTokenStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/JpaRefreshTokenStore.java
@@ -4,18 +4,17 @@ import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
+import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.repository.RefreshTokenRepository;
 import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.service.RefreshTokenStore;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Primary
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class JpaRefreshTokenStore implements RefreshTokenStore {
@@ -45,7 +44,16 @@ public class JpaRefreshTokenStore implements RefreshTokenStore {
                         token.getId(),
                         token.getFamily().getId(),
                         token.getUsed(),
-                        token.getExpiresAt()
+                        token.getExpiresAt(),
+                        token.getTokenHash()
                 ));
+    }
+
+    @Override
+    @Transactional
+    public void markAsUsed(Long tokenId) {
+        RefreshToken token = refreshTokenRepository.findById(tokenId)
+                .orElseThrow(InvalidRefreshTokenException::new);
+        token.markAsUsed();
     }
 }

--- a/src/main/java/com/ktb/auth/service/impl/JpaTokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/JpaTokenFamilyStore.java
@@ -1,23 +1,28 @@
 package com.ktb.auth.service.impl;
 
+import com.ktb.auth.domain.RefreshToken;
+import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.dto.TokenFamilyInfo;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
+import com.ktb.auth.repository.RefreshTokenRepository;
 import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.service.TokenFamilyStore;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Primary
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class JpaTokenFamilyStore implements TokenFamilyStore {
 
     private final TokenFamilyRepository tokenFamilyRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public Optional<TokenFamilyInfo> findByUuid(String uuid) {
@@ -31,11 +36,63 @@ public class JpaTokenFamilyStore implements TokenFamilyStore {
 
     @Override
     @Transactional
-    public void updateLastUsed(String uuid) {
-        tokenFamilyRepository.findByUuid(uuid)
-                .ifPresentOrElse(
-                    TokenFamily::updateLastUsed,
-                        () -> { throw new TokenFamilyNotFoundException(uuid); }
-                );
+    public void initFamilyState(String familyUuid, String tokenHash, long ttlMillis) {
+        TokenFamily family = tokenFamilyRepository.findByUuid(familyUuid)
+                .orElseThrow(() -> new TokenFamilyNotFoundException(familyUuid));
+
+        LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofMillis(ttlMillis));
+        RefreshToken token = RefreshToken.builder()
+                .family(family)
+                .tokenHash(tokenHash)
+                .expiresAt(expiresAt)
+                .build();
+        refreshTokenRepository.save(token);
+    }
+
+    @Override
+    @Transactional
+    public int rotateFamilyToken(String familyUuid, String oldHash, String newHash, long ttlMillis) {
+        TokenFamily family = tokenFamilyRepository.findByUuid(familyUuid).orElse(null);
+        if (family == null || family.isExpired()) {
+            return -1;
+        }
+        if (family.isRevoked()) {
+            return -2;
+        }
+
+        RefreshToken oldToken = refreshTokenRepository.findByTokenHashWithFamily(oldHash).orElse(null);
+        if (oldToken == null || oldToken.getUsed()) {
+            family.revoke(RevokeReason.REUSE_DETECTED);
+            return -3;
+        }
+
+        oldToken.markAsUsed();
+        LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofMillis(ttlMillis));
+        RefreshToken newToken = RefreshToken.builder()
+                .family(family)
+                .tokenHash(newHash)
+                .expiresAt(expiresAt)
+                .build();
+        refreshTokenRepository.save(newToken);
+        family.updateLastUsed();
+        return 1;
+    }
+
+    @Override
+    @Transactional
+    public void revokeFamilyState(String familyUuid, RevokeReason reason) {
+        TokenFamily family = tokenFamilyRepository.findByUuid(familyUuid)
+                .orElseThrow(() -> new TokenFamilyNotFoundException(familyUuid));
+        family.revoke(reason);
+    }
+
+    @Override
+    @Transactional
+    public int revokeAllFamilyStates(Long accountId, RevokeReason reason) {
+        return tokenFamilyRepository.revokeAllByAccountId(accountId, reason);
+    }
+
+    public List<String> findActiveUuids(Long accountId) {
+        return tokenFamilyRepository.findActiveUuidsByAccountId(accountId);
     }
 }

--- a/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
@@ -13,13 +13,14 @@ import com.ktb.auth.dto.OAuthLoginResult;
 import com.ktb.auth.dto.TokenFamilyInfo;
 import com.ktb.auth.dto.UserInfo;
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenRefreshResult;
 import com.ktb.auth.dto.response.KakaoUserInfoResponse;
 import com.ktb.auth.exception.family.FamilyOwnershipException;
-import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
 import com.ktb.auth.exception.oauth.OAuthProviderException;
 import com.ktb.auth.exception.oauth.UnsupportedProviderException;
+import com.ktb.auth.exception.family.FamilyRevokedException;
+import com.ktb.auth.exception.token.InvalidRefreshTokenException;
+import com.ktb.auth.exception.token.TokenReuseDetectedException;
 import com.ktb.auth.service.OAuthApplicationService;
 import com.ktb.auth.service.OAuthDomainService;
 import com.ktb.auth.service.RTRService;
@@ -136,7 +137,8 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
                 payload.nickname()
         );
 
-        tokenService.storeRefreshToken(family.id(), refreshToken);
+        long ttlMillis = tokenService.getRefreshTokenDuration().toMillis();
+        tokenFamilyStore.initFamilyState(family.uuid(), tokenService.generateTokenHash(refreshToken), ttlMillis);
 
         return new OAuthLoginResult(
                 accessToken,
@@ -146,32 +148,34 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     }
 
     @Override
-    @Transactional
     public TokenRefreshResult refreshTokens(String refreshToken) {
         RefreshTokenClaims claims = tokenService.validateRefreshToken(refreshToken);
 
-        RefreshTokenInfo tokenInfo = tokenService.getStoredRefreshToken(refreshToken);
+        String oldHash = tokenService.generateTokenHash(refreshToken);
+        String newRefreshToken = tokenService.issueRefreshToken(
+                claims.userId(),
+                claims.familyUuid(),
+                claims.userNickname()
+        );
+        String newHash = tokenService.generateTokenHash(newRefreshToken);
+        long ttlMillis = tokenService.getRefreshTokenDuration().toMillis();
 
-        rtrService.detectReuse(tokenInfo);
-        rtrService.validateFamilyActive(tokenInfo.familyId());
-        rtrService.markAsUsed(tokenInfo.id());
+        int result = tokenFamilyStore.rotateFamilyToken(
+                claims.familyUuid(), oldHash, newHash, ttlMillis
+        );
 
-        TokenFamilyInfo family = tokenFamilyStore.findByUuid(claims.familyUuid())
-                .orElseThrow(() -> new TokenFamilyNotFoundException(claims.familyUuid()));
+        switch (result) {
+            case 1 -> { }
+            case -1 -> throw new InvalidRefreshTokenException();
+            case -2 -> throw new FamilyRevokedException();
+            case -3 -> throw new TokenReuseDetectedException(claims.familyUuid());
+        }
 
         String newAccessToken = tokenService.issueAccessToken(
                 claims.userId(),
                 DEFAULT_ROLES,
                 claims.userNickname()
         );
-        String newRefreshToken = tokenService.issueRefreshToken(
-                claims.userId(),
-                claims.familyUuid(),
-                claims.userNickname()
-        );
-
-        tokenFamilyStore.updateLastUsed(claims.familyUuid());
-        tokenService.storeRefreshToken(family.id(), newRefreshToken);
 
         log.info("Token Refresh 성공: userId={}, familyUuid={}", claims.userId(), claims.familyUuid());
 
@@ -191,8 +195,7 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
             throw new FamilyOwnershipException();
         }
 
-        RefreshTokenInfo tokenInfo = tokenService.getStoredRefreshToken(refreshToken);
-        rtrService.revokeFamily(tokenInfo.familyId(), RevokeReason.USER_LOGOUT);
+        tokenFamilyStore.revokeFamilyState(claims.familyUuid(), RevokeReason.USER_LOGOUT);
 
         log.info("로그아웃 성공: accountId={}, familyUuid={}", accountId, claims.familyUuid());
     }
@@ -200,7 +203,7 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     @Override
     @Transactional
     public int logoutAll(Long accountId) {
-        int count = rtrService.revokeAllFamilies(accountId, RevokeReason.USER_LOGOUT);
+        int count = tokenFamilyStore.revokeAllFamilyStates(accountId, RevokeReason.USER_LOGOUT);
 
         log.info("전체 로그아웃 성공: accountId={}, revokedCount={}", accountId, count);
         return count;

--- a/src/main/java/com/ktb/auth/service/impl/RTRServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/RTRServiceImpl.java
@@ -1,18 +1,12 @@
 package com.ktb.auth.service.impl;
 
-import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.dto.TokenFamilyInfo;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.exception.account.AccountNotFoundException;
-import com.ktb.auth.exception.family.FamilyRevokedException;
-import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
-import com.ktb.auth.exception.token.TokenReuseDetectedException;
 import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.repository.UserAccountRepository;
 import com.ktb.auth.service.RTRService;
-import com.ktb.auth.service.RefreshTokenStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,32 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RTRServiceImpl implements RTRService {
 
-    private final RefreshTokenStore refreshTokenStore;
     private final TokenFamilyRepository tokenFamilyRepository;
     private final UserAccountRepository userAccountRepository;
-
-    @Override
-    public void detectReuse(RefreshTokenInfo tokenInfo) {
-        if (tokenInfo.used()) {
-            revokeFamily(tokenInfo.familyId(), RevokeReason.REUSE_DETECTED);
-            throw new TokenReuseDetectedException(tokenInfo.familyId());
-        }
-    }
-
-    @Override
-    @Transactional
-    public void revokeFamily(Long familyId, RevokeReason reason) {
-        TokenFamily family = tokenFamilyRepository.findById(familyId)
-                .orElseThrow(() -> new TokenFamilyNotFoundException(familyId));
-
-        family.revoke(reason);
-    }
-
-    @Override
-    @Transactional
-    public void markAsUsed(Long refreshTokenId) {
-        refreshTokenStore.markAsUsed(refreshTokenId);
-    }
 
     @Override
     @Transactional
@@ -63,21 +33,5 @@ public class RTRServiceImpl implements RTRService {
                 savedFamily.getUuid(),
                 savedFamily.isValid()
         );
-    }
-
-    @Override
-    public void validateFamilyActive(Long familyId) {
-        TokenFamily family = tokenFamilyRepository.findById(familyId)
-                .orElseThrow(() -> new TokenFamilyNotFoundException(familyId));
-
-        if (family.isRevoked() || family.isExpired()) {
-            throw new FamilyRevokedException();
-        }
-    }
-
-    @Override
-    @Transactional
-    public int revokeAllFamilies(Long accountId, RevokeReason reason) {
-        return tokenFamilyRepository.revokeAllByAccountId(accountId, reason);
     }
 }

--- a/src/main/java/com/ktb/auth/service/impl/RTRServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/RTRServiceImpl.java
@@ -1,6 +1,5 @@
 package com.ktb.auth.service.impl;
 
-import com.ktb.auth.domain.RefreshToken;
 import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
@@ -9,12 +8,11 @@ import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.exception.account.AccountNotFoundException;
 import com.ktb.auth.exception.family.FamilyRevokedException;
 import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
-import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.exception.token.TokenReuseDetectedException;
-import com.ktb.auth.repository.RefreshTokenRepository;
 import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.repository.UserAccountRepository;
 import com.ktb.auth.service.RTRService;
+import com.ktb.auth.service.RefreshTokenStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RTRServiceImpl implements RTRService {
 
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenStore refreshTokenStore;
     private final TokenFamilyRepository tokenFamilyRepository;
     private final UserAccountRepository userAccountRepository;
 
@@ -48,10 +46,7 @@ public class RTRServiceImpl implements RTRService {
     @Override
     @Transactional
     public void markAsUsed(Long refreshTokenId) {
-        RefreshToken token = refreshTokenRepository.findById(refreshTokenId)
-                .orElseThrow(InvalidRefreshTokenException::new);
-
-        token.markAsUsed();
+        refreshTokenStore.markAsUsed(refreshTokenId);
     }
 
     @Override

--- a/src/main/java/com/ktb/auth/service/impl/RedisRefreshTokenStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/RedisRefreshTokenStore.java
@@ -2,39 +2,126 @@ package com.ktb.auth.service.impl;
 
 import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.service.RefreshTokenStore;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 /**
- * Redis 기반 Refresh Token 저장소 구현체 (캐시 레이어)
- * Redis 프로파일 활성화 시 사용
+ * Redis 기반 Refresh Token 저장소 구현체 (Cache-Aside 패턴)
+ * DB가 Source of Truth, Redis는 읽기 캐시
  * <p>
- * TODO: Redis 도입 시 구현 완료 필요
- * - RedisTemplate 주입
- * - Cache-Aside 패턴 적용
- * - JpaRefreshTokenStore를 fallback으로 사용
+ * Key 설계:
+ * - auth:refresh:hash:{tokenHash} → "{id}|{familyId}|{used}|{expiresAtIso}"
+ * - auth:refresh:id:{tokenId}     → tokenHash (역방향 인덱스, markAsUsed 시 무효화용)
  */
 @Slf4j
 @Service
+@Primary
 @Profile("redis")
 @RequiredArgsConstructor
 public class RedisRefreshTokenStore implements RefreshTokenStore {
 
+    private static final String HASH_KEY_PREFIX = "auth:refresh:hash:";
+    private static final String ID_KEY_PREFIX = "auth:refresh:id:";
+    private static final String FIELD_DELIMITER = "|";
+
+    private static final RedisScript<Void> SET_WITH_EXPIRE_PAIR = RedisScript.of(
+        "redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])\n"
+        + "redis.call('SET', KEYS[2], ARGV[2], 'EX', ARGV[3])\n"
+        + "return nil",
+        Void.class
+    );
+
     private final JpaRefreshTokenStore jpaStore;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     public void save(Long familyId, String tokenHash, LocalDateTime expiresAt) {
         jpaStore.save(familyId, tokenHash, expiresAt);
-        log.debug("Redis 캐시에 Refresh Token 저장 (미구현, JPA fallback): familyId={}", familyId);
+
+        jpaStore.findByTokenHash(tokenHash).ifPresent(info -> {
+            long ttlSeconds = computeTtlSeconds(info.expiresAt());
+            if (ttlSeconds <= 0) {
+                return;
+            }
+            String hashKey = HASH_KEY_PREFIX + tokenHash;
+            String idKey = ID_KEY_PREFIX + info.id();
+            String value = serialize(info);
+
+            redisTemplate.execute(
+                SET_WITH_EXPIRE_PAIR,
+                List.of(hashKey, idKey),
+                value, tokenHash, String.valueOf(ttlSeconds)
+            );
+            log.debug("RefreshToken 캐시 PUT: tokenId={}", info.id());
+        });
     }
 
     @Override
     public Optional<RefreshTokenInfo> findByTokenHash(String tokenHash) {
-        log.debug("Redis 캐시에서 Refresh Token 조회 (미구현, JPA fallback): tokenHash={}", tokenHash);
-        return jpaStore.findByTokenHash(tokenHash);
+        String cached = redisTemplate.opsForValue().get(HASH_KEY_PREFIX + tokenHash);
+        if (cached != null) {
+            log.debug("RefreshToken 캐시 HIT: tokenHash={}...", tokenHash.substring(0, 8));
+            return Optional.of(deserialize(cached, tokenHash));
+        }
+
+        log.debug("RefreshToken 캐시 MISS: tokenHash={}...", tokenHash.substring(0, 8));
+        Optional<RefreshTokenInfo> result = jpaStore.findByTokenHash(tokenHash);
+        result.ifPresent(info -> {
+            long ttlSeconds = computeTtlSeconds(info.expiresAt());
+            if (ttlSeconds <= 0) {
+                return;
+            }
+            redisTemplate.opsForValue().set(
+                HASH_KEY_PREFIX + tokenHash, serialize(info), ttlSeconds, TimeUnit.SECONDS
+            );
+            redisTemplate.opsForValue().set(
+                ID_KEY_PREFIX + info.id(), tokenHash, ttlSeconds, TimeUnit.SECONDS
+            );
+        });
+        return result;
+    }
+
+    @Override
+    public void markAsUsed(Long tokenId) {
+        jpaStore.markAsUsed(tokenId);
+
+        String tokenHash = redisTemplate.opsForValue().get(ID_KEY_PREFIX + tokenId);
+        if (tokenHash != null) {
+            redisTemplate.delete(HASH_KEY_PREFIX + tokenHash);
+            redisTemplate.delete(ID_KEY_PREFIX + tokenId);
+            log.debug("RefreshToken 캐시 무효화: tokenId={}", tokenId);
+        }
+    }
+
+    private String serialize(RefreshTokenInfo info) {
+        return info.id() + FIELD_DELIMITER
+            + info.familyId() + FIELD_DELIMITER
+            + info.used() + FIELD_DELIMITER
+            + info.expiresAt().toString();
+    }
+
+    private RefreshTokenInfo deserialize(String value, String tokenHash) {
+        String[] parts = value.split("\\" + FIELD_DELIMITER, 4);
+        return new RefreshTokenInfo(
+            Long.parseLong(parts[0]),
+            Long.parseLong(parts[1]),
+            Boolean.parseBoolean(parts[2]),
+            LocalDateTime.parse(parts[3]),
+            tokenHash
+        );
+    }
+
+    private long computeTtlSeconds(LocalDateTime expiresAt) {
+        return Duration.between(LocalDateTime.now(), expiresAt).toSeconds();
     }
 }

--- a/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
@@ -1,39 +1,113 @@
 package com.ktb.auth.service.impl;
 
+import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.dto.TokenFamilyInfo;
 import com.ktb.auth.service.TokenFamilyStore;
+import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 /**
- * Redis 기반 Token Family 저장소 구현체 (캐시 레이어)
- * Redis 프로파일 활성화 시 사용
+ * Redis 기반 Token Family State Store
  * <p>
- * TODO: Redis 도입 시 구현 완료 필요
- * - RedisTemplate 주입
- * - Cache-Aside 패턴 적용
- * - JpaTokenFamilyStore를 fallback으로 사용
+ * Key: auth:family:{familyUuid}  (HASH)
+ * Fields:
+ *   currentHash  → SHA256(현재 유효한 refresh token)
+ *   revoked      → "0" | "1"
+ * TTL: 갱신 성공 시마다 refresh token 만료 시간으로 리셋
  */
 @Slf4j
 @Service
+@Primary
 @Profile("redis")
 @RequiredArgsConstructor
 public class RedisTokenFamilyStore implements TokenFamilyStore {
 
+    private static final String KEY_PREFIX = "auth:family:";
+    private static final String FIELD_CURRENT_HASH = "currentHash";
+    private static final String FIELD_REVOKED = "revoked";
+    private static final String REVOKED_FALSE = "0";
+    private static final String REVOKED_TRUE = "1";
+
+    /**
+     * 원자적 RTR Rotate (compare-and-swap)
+     * 반환값: 1=성공, -1=key 없음, -2=revoked, -3=reuse 감지(revoke 처리됨)
+     */
+    private static final RedisScript<Long> ROTATE_SCRIPT = RedisScript.of(
+        "local h = redis.call('HMGET', KEYS[1], 'currentHash', 'revoked')\n"
+        + "local currentHash = h[1]\n"
+        + "local revoked = h[2]\n"
+        + "if currentHash == false then return -1 end\n"
+        + "if revoked == '1' then return -2 end\n"
+        + "if currentHash ~= ARGV[1] then\n"
+        + "  redis.call('HSET', KEYS[1], 'revoked', '1')\n"
+        + "  return -3\n"
+        + "end\n"
+        + "redis.call('HSET', KEYS[1], 'currentHash', ARGV[2])\n"
+        + "redis.call('PEXPIRE', KEYS[1], ARGV[3])\n"
+        + "return 1",
+        Long.class
+    );
+
     private final JpaTokenFamilyStore jpaStore;
+    private final StringRedisTemplate redisTemplate;
 
     @Override
     public Optional<TokenFamilyInfo> findByUuid(String uuid) {
-        log.debug("Redis 캐시에서 Token Family 조회 (미구현, JPA fallback): uuid={}", uuid);
         return jpaStore.findByUuid(uuid);
     }
 
     @Override
-    public void updateLastUsed(String uuid) {
-        jpaStore.updateLastUsed(uuid);
-        log.debug("Redis 캐시에 Token Family 마지막 사용 시각 업데이트 (미구현, JPA fallback): uuid={}", uuid);
+    public void initFamilyState(String familyUuid, String tokenHash, long ttlMillis) {
+        jpaStore.initFamilyState(familyUuid, tokenHash, ttlMillis);
+
+        String key = familyKey(familyUuid);
+        redisTemplate.opsForHash().put(key, FIELD_CURRENT_HASH, tokenHash);
+        redisTemplate.opsForHash().put(key, FIELD_REVOKED, REVOKED_FALSE);
+        redisTemplate.expire(key, Duration.ofMillis(ttlMillis));
+        log.debug("Family 초기 상태 등록: familyUuid={}", familyUuid);
+    }
+
+    @Override
+    public int rotateFamilyToken(String familyUuid, String oldHash, String newHash, long ttlMillis) {
+        Long result = redisTemplate.execute(
+            ROTATE_SCRIPT,
+            List.of(familyKey(familyUuid)),
+            oldHash, newHash, String.valueOf(ttlMillis)
+        );
+        int code = (result != null) ? result.intValue() : -1;
+
+        if (code == -3) {
+            log.warn("RefreshToken 재사용 감지 (Redis): familyUuid={}", familyUuid);
+            jpaStore.revokeFamilyState(familyUuid, RevokeReason.REUSE_DETECTED);
+        }
+        return code;
+    }
+
+    @Override
+    public void revokeFamilyState(String familyUuid, RevokeReason reason) {
+        redisTemplate.opsForHash().put(familyKey(familyUuid), FIELD_REVOKED, REVOKED_TRUE);
+        jpaStore.revokeFamilyState(familyUuid, reason);
+        log.debug("Family 폐기: familyUuid={}, reason={}", familyUuid, reason);
+    }
+
+    @Override
+    public int revokeAllFamilyStates(Long accountId, RevokeReason reason) {
+        List<String> activeUuids = jpaStore.findActiveUuids(accountId);
+        activeUuids.forEach(uuid ->
+            redisTemplate.opsForHash().put(familyKey(uuid), FIELD_REVOKED, REVOKED_TRUE)
+        );
+        return jpaStore.revokeAllFamilyStates(accountId, reason);
+    }
+
+    private String familyKey(String familyUuid) {
+        return KEY_PREFIX + familyUuid;
     }
 }

--- a/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/TokenServiceImpl.java
@@ -1,16 +1,13 @@
 package com.ktb.auth.service.impl;
 
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenClaims;
 import com.ktb.auth.exception.token.InvalidAccessTokenException;
 import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.jwt.JwtProvider;
-import com.ktb.auth.service.RefreshTokenStore;
 import com.ktb.auth.service.TokenService;
 import io.jsonwebtoken.Claims;
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +25,6 @@ public class TokenServiceImpl implements TokenService {
     private static final String CLAIM_FAMILY_UUID = "familyUuid";
 
     private final JwtProvider jwtProvider;
-    private final RefreshTokenStore refreshTokenStore;
 
     @Override
     public String issueAccessToken(Long accountId, List<String> roles, String nickname) {
@@ -75,21 +71,6 @@ public class TokenServiceImpl implements TokenService {
         } catch (Exception e) {
             throw new InvalidRefreshTokenException();
         }
-    }
-
-    @Override
-    @Transactional
-    public void storeRefreshToken(Long familyId, String refreshToken) {
-        String tokenHash = generateTokenHash(refreshToken);
-        LocalDateTime expiresAt = LocalDateTime.now().plus(getRefreshTokenDuration());
-        refreshTokenStore.save(familyId, tokenHash, expiresAt);
-    }
-
-    @Override
-    public RefreshTokenInfo getStoredRefreshToken(String refreshToken) {
-        String tokenHash = generateTokenHash(refreshToken);
-        return refreshTokenStore.findByTokenHash(tokenHash)
-                .orElseThrow(InvalidRefreshTokenException::new);
     }
 
     @Override

--- a/src/test/java/com/ktb/auth/service/JpaTokenFamilyStoreTest.java
+++ b/src/test/java/com/ktb/auth/service/JpaTokenFamilyStoreTest.java
@@ -1,0 +1,176 @@
+package com.ktb.auth.service;
+
+import com.ktb.auth.domain.RefreshToken;
+import com.ktb.auth.domain.RevokeReason;
+import com.ktb.auth.domain.TokenFamily;
+import com.ktb.auth.dto.TokenFamilyInfo;
+import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
+import com.ktb.auth.repository.RefreshTokenRepository;
+import com.ktb.auth.repository.TokenFamilyRepository;
+import com.ktb.auth.service.impl.JpaTokenFamilyStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JpaTokenFamilyStore 단위 테스트")
+class JpaTokenFamilyStoreTest {
+
+    @Mock
+    private TokenFamilyRepository tokenFamilyRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private JpaTokenFamilyStore jpaStore;
+
+    private static final String FAMILY_UUID = "family-uuid-123";
+    private static final String OLD_HASH = "old-hash";
+    private static final String NEW_HASH = "new-hash";
+    private static final long TTL_MILLIS = 14L * 24 * 60 * 60 * 1000; // 14일
+
+    // ── findByUuid (구 validateFamilyActive 매핑) ──
+
+    @Test
+    @DisplayName("활성 Family 조회 시 active=true인 TokenFamilyInfo 반환")
+    void findByUuid_WithActiveFamily_ShouldReturnActiveInfo() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(mockFamily.getId()).thenReturn(1L);
+        when(mockFamily.getUuid()).thenReturn(FAMILY_UUID);
+        when(mockFamily.isValid()).thenReturn(true);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        Optional<TokenFamilyInfo> result = jpaStore.findByUuid(FAMILY_UUID);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().active()).isTrue();
+        verify(tokenFamilyRepository).findByUuid(FAMILY_UUID);
+    }
+
+    @Test
+    @DisplayName("폐기된 Family 조회 시 active=false인 TokenFamilyInfo 반환")
+    void findByUuid_WithRevokedFamily_ShouldReturnInactiveInfo() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(mockFamily.getId()).thenReturn(1L);
+        when(mockFamily.getUuid()).thenReturn(FAMILY_UUID);
+        when(mockFamily.isValid()).thenReturn(false);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        Optional<TokenFamilyInfo> result = jpaStore.findByUuid(FAMILY_UUID);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().active()).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 Family 조회 시 active=false인 TokenFamilyInfo 반환")
+    void findByUuid_WithExpiredFamily_ShouldReturnInactiveInfo() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(mockFamily.getId()).thenReturn(1L);
+        when(mockFamily.getUuid()).thenReturn(FAMILY_UUID);
+        when(mockFamily.isValid()).thenReturn(false);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        Optional<TokenFamilyInfo> result = jpaStore.findByUuid(FAMILY_UUID);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().active()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Family 조회 시 Optional.empty 반환")
+    void findByUuid_WithNonExistentFamily_ShouldReturnEmpty() {
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.empty());
+
+        Optional<TokenFamilyInfo> result = jpaStore.findByUuid(FAMILY_UUID);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정상 토큰 교체 시 기존 토큰 used=true 처리 후 1 반환")
+    void rotateFamilyToken_WithFreshToken_ShouldMarkOldTokenAsUsedAndReturn1() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(mockFamily.isExpired()).thenReturn(false);
+        when(mockFamily.isRevoked()).thenReturn(false);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        RefreshToken oldToken = mock(RefreshToken.class);
+        when(oldToken.getUsed()).thenReturn(false);
+        when(refreshTokenRepository.findByTokenHashWithFamily(OLD_HASH)).thenReturn(Optional.of(oldToken));
+
+        int result = jpaStore.rotateFamilyToken(FAMILY_UUID, OLD_HASH, NEW_HASH, TTL_MILLIS);
+
+        assertThat(result).isEqualTo(1);
+        verify(oldToken).markAsUsed();
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("이미 사용된 토큰으로 교체 시도 시 Family 폐기 후 -3 반환")
+    void rotateFamilyToken_WithReuseDetected_ShouldRevokeFamilyAndReturnReuse() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(mockFamily.isExpired()).thenReturn(false);
+        when(mockFamily.isRevoked()).thenReturn(false);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        RefreshToken usedToken = mock(RefreshToken.class);
+        when(usedToken.getUsed()).thenReturn(true);
+        when(refreshTokenRepository.findByTokenHashWithFamily(OLD_HASH)).thenReturn(Optional.of(usedToken));
+
+        int result = jpaStore.rotateFamilyToken(FAMILY_UUID, OLD_HASH, NEW_HASH, TTL_MILLIS);
+
+        assertThat(result).isEqualTo(-3);
+        verify(mockFamily).revoke(RevokeReason.REUSE_DETECTED);
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("[Edge Case] 존재하지 않는 토큰 해시로 교체 시도 시 Family 폐기 후 -3 반환")
+    void rotateFamilyToken_WithNonExistentOldToken_ShouldRevokeFamilyAndReturnReuse() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(mockFamily.isExpired()).thenReturn(false);
+        when(mockFamily.isRevoked()).thenReturn(false);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        when(refreshTokenRepository.findByTokenHashWithFamily(OLD_HASH)).thenReturn(Optional.empty());
+
+        int result = jpaStore.rotateFamilyToken(FAMILY_UUID, OLD_HASH, NEW_HASH, TTL_MILLIS);
+
+        assertThat(result).isEqualTo(-3);
+        verify(mockFamily).revoke(RevokeReason.REUSE_DETECTED);
+    }
+
+    @Test
+    @DisplayName("Family 폐기 성공")
+    void revokeFamilyState_ShouldSucceed() {
+        TokenFamily mockFamily = mock(TokenFamily.class);
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(mockFamily));
+
+        jpaStore.revokeFamilyState(FAMILY_UUID, RevokeReason.USER_LOGOUT);
+
+        verify(mockFamily).revoke(RevokeReason.USER_LOGOUT);
+    }
+
+    @Test
+    @DisplayName("[Edge Case] 존재하지 않는 Family 폐기 시도 시 예외 발생")
+    void revokeFamilyState_WithNonExistentFamily_ShouldThrowException() {
+        when(tokenFamilyRepository.findByUuid(FAMILY_UUID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> jpaStore.revokeFamilyState(FAMILY_UUID, RevokeReason.USER_LOGOUT))
+                .isInstanceOf(TokenFamilyNotFoundException.class);
+
+        verify(tokenFamilyRepository).findByUuid(FAMILY_UUID);
+    }
+}

--- a/src/test/java/com/ktb/auth/service/OAuthApplicationServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/OAuthApplicationServiceTest.java
@@ -14,17 +14,18 @@ import com.ktb.auth.dto.OAuthExchangePayload;
 import com.ktb.auth.dto.OAuthLoginResult;
 import com.ktb.auth.dto.TokenFamilyInfo;
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenRefreshResult;
 import com.ktb.auth.dto.response.KakaoUserInfoResponse;
 import com.ktb.auth.exception.family.FamilyRevokedException;
 import com.ktb.auth.exception.oauth.InvalidExchangeCodeException;
+import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.exception.oauth.InvalidStateException;
 import com.ktb.auth.exception.oauth.OAuthProviderException;
 import com.ktb.auth.exception.token.TokenReuseDetectedException;
 import com.ktb.auth.service.impl.OAuthApplicationServiceImpl;
 import com.ktb.common.domain.ErrorCode;
 import com.ktb.common.exception.BusinessException;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +33,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -221,6 +223,8 @@ class OAuthApplicationServiceTest {
         when(rtrService.createFamily(USER_ID, DEVICE_INFO, CLIENT_IP)).thenReturn(familyInfo);
         when(tokenService.issueAccessToken(USER_ID, List.of("ROLE_USER"), USER_NICKNAME)).thenReturn(ACCESS_TOKEN);
         when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn(REFRESH_TOKEN);
+        when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
+        when(tokenService.getRefreshTokenDuration()).thenReturn(Duration.ofDays(14));
 
         // when
         OAuthLoginResult result = oauthApplicationService.exchange(EXCHANGE_CODE);
@@ -230,7 +234,7 @@ class OAuthApplicationServiceTest {
         assertThat(result.refreshToken()).isEqualTo(REFRESH_TOKEN);
         assertThat(result.user().nickname()).isEqualTo("신규유저");
         assertThat(result.user().isNewUser()).isTrue();
-        verify(tokenService).storeRefreshToken(FAMILY_ID, REFRESH_TOKEN);
+        verify(tokenFamilyStore).initFamilyState(eq(FAMILY_UUID), eq(TOKEN_HASH), anyLong());
     }
 
     @Test
@@ -252,51 +256,47 @@ class OAuthApplicationServiceTest {
     void refreshTokens_ShouldSucceed() {
         // given
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
-        RefreshTokenInfo tokenInfo = new RefreshTokenInfo(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
-        TokenFamilyInfo familyInfo = new TokenFamilyInfo(FAMILY_ID, FAMILY_UUID, true);
+        String newRefreshToken = "new.refresh.token";
+        String newAccessToken = "new.access.token";
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(tokenInfo);
-        doNothing().when(rtrService).detectReuse(tokenInfo);
-        doNothing().when(rtrService).validateFamilyActive(FAMILY_ID);
-        doNothing().when(rtrService).markAsUsed(100L);
-        when(tokenFamilyStore.findByUuid(FAMILY_UUID)).thenReturn(Optional.of(familyInfo));
-        when(tokenService.issueAccessToken(USER_ID, List.of("ROLE_USER"), USER_NICKNAME)).thenReturn("new.access.token");
-        when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
+        when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn("old-hash");
+        when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn(newRefreshToken);
+        when(tokenService.generateTokenHash(newRefreshToken)).thenReturn("new-hash");
+        when(tokenService.getRefreshTokenDuration()).thenReturn(Duration.ofDays(14));
+        when(tokenFamilyStore.rotateFamilyToken(eq(FAMILY_UUID), eq("old-hash"), eq("new-hash"), anyLong()))
+                .thenReturn(1);
+        when(tokenService.issueAccessToken(USER_ID, List.of("ROLE_USER"), USER_NICKNAME)).thenReturn(newAccessToken);
         when(tokenService.getAccessTokenExpiresSeconds()).thenReturn(600L);
 
         // when
         TokenRefreshResult result = oauthApplicationService.refreshTokens(REFRESH_TOKEN);
 
         // then
-        assertThat(result.accessToken()).isEqualTo("new.access.token");
-        assertThat(result.refreshToken()).isEqualTo("new.refresh.token");
+        assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(result.refreshToken()).isEqualTo(newRefreshToken);
         assertThat(result.expiresIn()).isEqualTo(600);
-
-        verify(rtrService).markAsUsed(100L);
-        verify(tokenFamilyStore).updateLastUsed(FAMILY_UUID);
-        verify(tokenService).storeRefreshToken(FAMILY_ID, "new.refresh.token");
+        verify(tokenFamilyStore).rotateFamilyToken(eq(FAMILY_UUID), eq("old-hash"), eq("new-hash"), anyLong());
     }
 
     @Test
     @DisplayName("[Edge Case] 재사용된 Refresh Token으로 갱신 시 Family가 폐기되어야 한다")
     void refreshTokens_WithReusedToken_ShouldRevokeFamily() {
         // given
-        RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, FAMILY_UUID, USER_NICKNAME);
-        RefreshTokenInfo usedToken = new RefreshTokenInfo(100L, FAMILY_ID, true, LocalDateTime.now().plusDays(7));
+        RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(usedToken);
-        doThrow(new TokenReuseDetectedException(FAMILY_ID))
-                .when(rtrService).detectReuse(usedToken);
+        when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn("stale-hash");
+        when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
+        when(tokenService.generateTokenHash("new.refresh.token")).thenReturn("new-hash");
+        when(tokenService.getRefreshTokenDuration()).thenReturn(Duration.ofDays(14));
+        when(tokenFamilyStore.rotateFamilyToken(eq(FAMILY_UUID), eq("stale-hash"), eq("new-hash"), anyLong()))
+                .thenReturn(-3);
 
         // when & then
         assertThatThrownBy(() -> oauthApplicationService.refreshTokens(REFRESH_TOKEN))
                 .isInstanceOf(TokenReuseDetectedException.class)
                 .hasMessageContaining(TOKEN_REUSE_DETECTED.getMessage());
-
-        verify(rtrService).detectReuse(usedToken);
-        verify(tokenService, never()).issueAccessToken(any(), any(), any());
     }
 
     @Test
@@ -304,16 +304,13 @@ class OAuthApplicationServiceTest {
     void logout_ShouldSucceed() {
         // given
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
-        RefreshTokenInfo tokenInfo = new RefreshTokenInfo(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
-
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(tokenInfo);
 
         // when
         oauthApplicationService.logout(USER_ID, REFRESH_TOKEN);
 
         // then
-        verify(rtrService).revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT);
+        verify(tokenFamilyStore).revokeFamilyState(FAMILY_UUID, RevokeReason.USER_LOGOUT);
     }
 
     @Test
@@ -321,7 +318,7 @@ class OAuthApplicationServiceTest {
     void logout_WithDifferentUser_ShouldThrowException() {
         // given
         Long otherUserId = 999L;
-        RefreshTokenClaims claims = new RefreshTokenClaims(otherUserId, FAMILY_UUID, USER_NICKNAME);
+        RefreshTokenClaims claims = new RefreshTokenClaims(otherUserId, USER_NICKNAME, FAMILY_UUID);
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
 
@@ -337,34 +334,33 @@ class OAuthApplicationServiceTest {
     @DisplayName("전체 기기 로그아웃 성공")
     void logoutAll_ShouldSucceed() {
         // given
-        when(rtrService.revokeAllFamilies(USER_ID, RevokeReason.USER_LOGOUT)).thenReturn(3);
+        when(tokenFamilyStore.revokeAllFamilyStates(USER_ID, RevokeReason.USER_LOGOUT)).thenReturn(3);
 
         // when
-        int revokedCount = oauthApplicationService.logoutAll(USER_ID);
+        int count = oauthApplicationService.logoutAll(USER_ID);
 
         // then
-        assertThat(revokedCount).isEqualTo(3);
-        verify(rtrService).revokeAllFamilies(USER_ID, RevokeReason.USER_LOGOUT);
+        assertThat(count).isEqualTo(3);
+        verify(tokenFamilyStore).revokeAllFamilyStates(USER_ID, RevokeReason.USER_LOGOUT);
     }
 
     @Test
     @DisplayName("[Edge Case] 폐기된 Family의 Refresh Token 사용 시 예외가 발생해야 한다")
     void refreshTokens_WithRevokedFamily_ShouldThrowException() {
         // given
-        RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, FAMILY_UUID, USER_NICKNAME);
-        RefreshTokenInfo tokenInfo = new RefreshTokenInfo(100L, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
+        RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
-        when(tokenService.getStoredRefreshToken(REFRESH_TOKEN)).thenReturn(tokenInfo);
-        doNothing().when(rtrService).detectReuse(tokenInfo);
-        doThrow(new FamilyRevokedException(FAMILY_ID))
-                .when(rtrService).validateFamilyActive(FAMILY_ID);
+        when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn("stale-hash");
+        when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
+        when(tokenService.generateTokenHash("new.refresh.token")).thenReturn("new-hash");
+        when(tokenService.getRefreshTokenDuration()).thenReturn(Duration.ofDays(14));
+        when(tokenFamilyStore.rotateFamilyToken(eq(FAMILY_UUID), eq("stale-hash"), eq("new-hash"), anyLong()))
+                .thenReturn(-2);
 
         // when & then
         assertThatThrownBy(() -> oauthApplicationService.refreshTokens(REFRESH_TOKEN))
                 .isInstanceOf(FamilyRevokedException.class)
                 .hasMessageContaining(FAMILY_REVOKED.getMessage());
-
-        verify(rtrService).validateFamilyActive(FAMILY_ID);
     }
 }

--- a/src/test/java/com/ktb/auth/service/RTRServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/RTRServiceTest.java
@@ -1,20 +1,13 @@
 package com.ktb.auth.service;
 
-import com.ktb.auth.domain.RefreshToken;
-import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.domain.TokenFamily;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.dto.TokenFamilyInfo;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.exception.account.AccountNotFoundException;
-import com.ktb.auth.exception.family.FamilyRevokedException;
-import com.ktb.auth.exception.family.TokenFamilyNotFoundException;
-import com.ktb.auth.exception.token.InvalidRefreshTokenException;
 import com.ktb.auth.repository.RefreshTokenRepository;
 import com.ktb.auth.repository.TokenFamilyRepository;
 import com.ktb.auth.repository.UserAccountRepository;
 import com.ktb.auth.service.impl.RTRServiceImpl;
-import com.ktb.common.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,7 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,170 +78,5 @@ class RTRServiceTest {
 
         verify(userAccountRepository).findById(USER_ID);
         verify(tokenFamilyRepository, never()).save(any());
-    }
-
-    @Test
-    @DisplayName("토큰 재사용 탐지 시 Family가 폐기되어야 한다")
-    void detectReuse_WithUsedToken_ShouldRevokeFamily() {
-        // given
-        RefreshTokenInfo usedToken = new RefreshTokenInfo(TOKEN_ID, FAMILY_ID, true, LocalDateTime.now().plusDays(7));
-
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
-
-        // when & then
-        assertThatThrownBy(() -> rtrService.detectReuse(usedToken))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("토큰 재사용이 탐지되었습니다");
-
-        verify(mockFamily).revoke(RevokeReason.REUSE_DETECTED);
-    }
-
-    @Test
-    @DisplayName("사용되지 않은 토큰은 재사용 탐지를 통과해야 한다")
-    void detectReuse_WithUnusedToken_ShouldPass() {
-        // given
-        RefreshTokenInfo unusedToken = new RefreshTokenInfo(TOKEN_ID, FAMILY_ID, false, LocalDateTime.now().plusDays(7));
-
-        // when
-        rtrService.detectReuse(unusedToken);
-
-        // then
-        verify(tokenFamilyRepository, never()).findById(any());
-    }
-
-    @Test
-    @DisplayName("토큰 사용 처리가 성공해야 한다")
-    void markAsUsed_ShouldSucceed() {
-        // given
-        RefreshToken mockToken = mock(RefreshToken.class);
-        when(refreshTokenRepository.findById(TOKEN_ID)).thenReturn(Optional.of(mockToken));
-
-        // when
-        rtrService.markAsUsed(TOKEN_ID);
-
-        // then
-        verify(mockToken).markAsUsed();
-        verify(refreshTokenRepository).findById(TOKEN_ID);
-    }
-
-    @Test
-    @DisplayName("[Edge Case] 존재하지 않는 RefreshToken 사용 처리 시 예외가 발생해야 한다")
-    void markAsUsed_WithNonExistentToken_ShouldThrowException() {
-        // given
-        when(refreshTokenRepository.findById(TOKEN_ID)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> rtrService.markAsUsed(TOKEN_ID))
-                .isInstanceOf(InvalidRefreshTokenException.class);
-
-        verify(refreshTokenRepository).findById(TOKEN_ID);
-    }
-
-    @Test
-    @DisplayName("Family 활성 상태 확인 - 정상 케이스")
-    void validateFamilyActive_WithActiveFamily_ShouldPass() {
-        // given
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(mockFamily.isRevoked()).thenReturn(false);
-        when(mockFamily.isExpired()).thenReturn(false);
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
-
-        // when
-        rtrService.validateFamilyActive(FAMILY_ID);
-
-        // then
-        verify(tokenFamilyRepository).findById(FAMILY_ID);
-        verify(mockFamily).isRevoked();
-        verify(mockFamily).isExpired();
-    }
-
-    @Test
-    @DisplayName("폐기된 Family 확인 시 예외가 발생해야 한다")
-    void validateFamilyActive_WithRevokedFamily_ShouldThrowException() {
-        // given
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(mockFamily.isRevoked()).thenReturn(true);
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
-
-        // when & then
-        assertThatThrownBy(() -> rtrService.validateFamilyActive(FAMILY_ID))
-                .isInstanceOf(FamilyRevokedException.class);
-
-        verify(tokenFamilyRepository).findById(FAMILY_ID);
-    }
-
-    @Test
-    @DisplayName("만료된 Family 확인 시 예외가 발생해야 한다")
-    void validateFamilyActive_WithExpiredFamily_ShouldThrowException() {
-        // given
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(mockFamily.isRevoked()).thenReturn(false);
-        when(mockFamily.isExpired()).thenReturn(true);
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
-
-        // when & then
-        assertThatThrownBy(() -> rtrService.validateFamilyActive(FAMILY_ID))
-                .isInstanceOf(FamilyRevokedException.class);
-
-        verify(tokenFamilyRepository).findById(FAMILY_ID);
-    }
-
-    @Test
-    @DisplayName("[Edge Case] 존재하지 않는 Family 조회 시 예외가 발생해야 한다")
-    void validateFamilyActive_WithNonExistentFamily_ShouldThrowException() {
-        // given
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> rtrService.validateFamilyActive(FAMILY_ID))
-                .isInstanceOf(TokenFamilyNotFoundException.class);
-
-        verify(tokenFamilyRepository).findById(FAMILY_ID);
-    }
-
-    @Test
-    @DisplayName("Family 폐기가 성공해야 한다")
-    void revokeFamily_ShouldSucceed() {
-        // given
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
-
-        // when
-        rtrService.revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT);
-
-        // then
-        verify(mockFamily).revoke(RevokeReason.USER_LOGOUT);
-        verify(tokenFamilyRepository).findById(FAMILY_ID);
-    }
-
-    @Test
-    @DisplayName("[Edge Case] 이미 폐기된 Family 재폐기 시도 - 멱등성 확인")
-    void revokeFamily_AlreadyRevoked_ShouldBeIdempotent() {
-        // given
-        TokenFamily mockFamily = mock(TokenFamily.class);
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.of(mockFamily));
-
-        // when
-        rtrService.revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT);
-        rtrService.revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT);
-
-        // then
-        // revoke()가 두 번 호출되어도 예외가 발생하지 않아야 함 (멱등성)
-        verify(mockFamily, times(2)).revoke(RevokeReason.USER_LOGOUT);
-        verify(tokenFamilyRepository, times(2)).findById(FAMILY_ID);
-    }
-
-    @Test
-    @DisplayName("[Edge Case] 존재하지 않는 Family 폐기 시도 시 예외가 발생해야 한다")
-    void revokeFamily_WithNonExistentFamily_ShouldThrowException() {
-        // given
-        when(tokenFamilyRepository.findById(FAMILY_ID)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> rtrService.revokeFamily(FAMILY_ID, RevokeReason.USER_LOGOUT))
-                .isInstanceOf(TokenFamilyNotFoundException.class);
-
-        verify(tokenFamilyRepository).findById(FAMILY_ID);
     }
 }

--- a/src/test/java/com/ktb/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/TokenServiceTest.java
@@ -1,7 +1,6 @@
 package com.ktb.auth.service;
 
 import com.ktb.auth.dto.jwt.RefreshTokenClaims;
-import com.ktb.auth.dto.jwt.RefreshTokenInfo;
 import com.ktb.auth.dto.jwt.TokenClaims;
 import com.ktb.auth.exception.token.InvalidAccessTokenException;
 import com.ktb.auth.exception.token.InvalidRefreshTokenException;
@@ -17,13 +16,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,9 +28,6 @@ class TokenServiceTest {
 
     @Mock
     private JwtProvider jwtProvider;
-
-    @Mock
-    private RefreshTokenStore refreshTokenStore;
 
     @InjectMocks
     private TokenServiceImpl tokenService;
@@ -155,58 +148,6 @@ class TokenServiceTest {
         // then
         assertThat(refreshToken).isEqualTo(VALID_REFRESH_TOKEN);
         verify(jwtProvider).createRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME);
-    }
-
-    @Test
-    @DisplayName("저장된 Refresh Token 조회가 성공해야 한다")
-    void getStoredRefreshToken_WithValidToken_ShouldSucceed() {
-        // given
-        RefreshTokenInfo expectedInfo = new RefreshTokenInfo(10L, 1L, false, LocalDateTime.now().plusDays(7));
-
-        when(jwtProvider.generateTokenHash(VALID_REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
-        when(refreshTokenStore.findByTokenHash(TOKEN_HASH)).thenReturn(Optional.of(expectedInfo));
-
-        // when
-        RefreshTokenInfo info = tokenService.getStoredRefreshToken(VALID_REFRESH_TOKEN);
-
-        // then
-        assertThat(info.id()).isEqualTo(10L);
-        assertThat(info.familyId()).isEqualTo(1L);
-        assertThat(info.used()).isFalse();
-        assertThat(info.expiresAt()).isAfter(LocalDateTime.now());
-
-        verify(jwtProvider).generateTokenHash(VALID_REFRESH_TOKEN);
-        verify(refreshTokenStore).findByTokenHash(TOKEN_HASH);
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 Refresh Token 조회 시 예외가 발생해야 한다")
-    void getStoredRefreshToken_WithNonExistentToken_ShouldThrowException() {
-        // given
-        when(jwtProvider.generateTokenHash(anyString())).thenReturn("nonexistent-hash");
-        when(refreshTokenStore.findByTokenHash(anyString())).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> tokenService.getStoredRefreshToken("nonexistent-token"))
-                .isInstanceOf(InvalidRefreshTokenException.class);
-
-        verify(refreshTokenStore).findByTokenHash("nonexistent-hash");
-    }
-
-    @Test
-    @DisplayName("Refresh Token 저장이 성공해야 한다")
-    void storeRefreshToken_ShouldSucceed() {
-        // given
-        Long familyId = 1L;
-        when(jwtProvider.generateTokenHash(VALID_REFRESH_TOKEN)).thenReturn(TOKEN_HASH);
-        when(jwtProvider.refreshTokenDuration()).thenReturn(Duration.ofDays(14));
-
-        // when
-        tokenService.storeRefreshToken(familyId, VALID_REFRESH_TOKEN);
-
-        // then
-        verify(jwtProvider).generateTokenHash(VALID_REFRESH_TOKEN);
-        verify(refreshTokenStore).save(eq(familyId), eq(TOKEN_HASH), any(LocalDateTime.class));
     }
 
     @Test


### PR DESCRIPTION
## 개요
Refresh Token 처리 경로를 Redis 기반으로 고도화 진행
- 초기 Cache-Aside 적용에서 한 단계 더 나아가, 최종적으로 `TokenFamily` 중심의 Redis state store + 원자적 rotate(CAS) 구조로 정리

## 배경
기존 Refresh Token 갱신 경로는 DB read/write 의존도가 높고 RTR(Reuse Token Rotation) 처리 분산으로 인해 관리 포인트가 많았습니다.
이번 변경으로 다음을 목표로 했습니다.

- refresh 경로의 Redis fast-path 확보
- 재사용 탐지/회전 로직 원자화
- 서비스 계층 책임 정리 (`RefreshTokenStore` 중심 -> `TokenFamilyStore` 중심)

## 주요 변경 사항
- `TokenFamilyStore` 인터페이스 확장
  - `initFamilyState`
  - `rotateFamilyToken`
  - `revokeFamilyState`
  - `revokeAllFamilyStates`
- `RedisTokenFamilyStore` 도입/강화
  - Redis HASH 기반 family state 관리
  - Lua 기반 rotate CAS 처리
  - 재사용 탐지 시 revoke 연계
- `OAuthApplicationServiceImpl` 리팩터링
  - refreshTokens 흐름을 `TokenFamilyStore` 중심으로 단순화
  - rotate 결과 코드 기반 예외 처리
- `RTRService`/`RTRServiceImpl` 책임 축소
  - Family 생성 책임 위주로 정리
- `TokenService`/`TokenServiceImpl` 정리
  - 불필요한 RefreshToken 저장/조회 의존 제거
- 테스트 정리
  - `JpaTokenFamilyStoreTest` 추가
  - 기존 테스트(`OAuthApplicationServiceTest`) 시나리오 보강
  - 구조 변경에 맞춰 일부 테스트 제거/정리

## 기대 효과
- 보안 강화
  - RTR 회전 로직을 Redis CAS로 단일화해 재사용 토큰 탐지 신뢰도를 높임
  - family 단위 revoke 전파가 명확해져 세션 탈취 대응력이 향상됨

- 성능 개선
  - refresh 경로에서 Redis fast-path를 사용해 DB 접근 빈도를 낮춤
  - 토큰 갱신 트래픽 구간에서 인증 지연 및 DB 부하 완화 기대

- 정합성/운영성 향상
  - 인증 상태 관리를 `TokenFamilyStore` 중심으로 일원화해 로직 파편화 감소
  - 서비스 책임 경계가 명확해져 장애 분석 및 유지보수 비용 절감

- 테스트 가능성 개선
  - family 상태 전이(초기화/회전/폐기) 단위 테스트가 가능해져 회귀 방지력 강화

## 영향 범위
- 인증/토큰 갱신 API
  - `POST /api/auth/tokens`
  - `POST /api/auth/logout`
  - `POST /api/auth/logout/all`
- Redis profile 활성 환경의 인증 상태 관리
- Token family revoke/reuse 탐지 동작

## 관련 Issue
 - closes #178 