### PR TITLE
fix:[#236] refresh fail-close 강화 및 Redis revoke TTL 오염 방지

### DIFF
--- a/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/auth/service/impl/OAuthApplicationServiceImpl.java
@@ -151,6 +151,11 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
     public TokenRefreshResult refreshTokens(String refreshToken) {
         RefreshTokenClaims claims = tokenService.validateRefreshToken(refreshToken);
 
+        // Redis TTL이 남아있어도 만료/폐기된 family는 차단
+        tokenFamilyStore.findByUuid(claims.familyUuid())
+                .filter(TokenFamilyInfo::active)
+                .orElseThrow(() -> new InvalidRefreshTokenException(claims.familyUuid()));
+
         String oldHash = tokenService.generateTokenHash(refreshToken);
         String newRefreshToken = tokenService.issueRefreshToken(
                 claims.userId(),
@@ -166,9 +171,11 @@ public class OAuthApplicationServiceImpl implements OAuthApplicationService {
 
         switch (result) {
             case 1 -> { }
-            case -1 -> throw new InvalidRefreshTokenException();
+            case -1 -> throw new InvalidRefreshTokenException(claims.familyUuid());
             case -2 -> throw new FamilyRevokedException();
             case -3 -> throw new TokenReuseDetectedException(claims.familyUuid());
+            default -> throw new InvalidRefreshTokenException(
+                    "unexpected rotate result: " + result + ", familyUuid: " + claims.familyUuid());
         }
 
         String newAccessToken = tokenService.issueAccessToken(

--- a/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
@@ -17,6 +17,11 @@ import org.springframework.stereotype.Service;
 /**
  * Redis 기반 Token Family State Store
  * <p>
+ * 전략: DB SoT(TokenFamily 유효성) + Redis fast path(hash CAS)
+ * - initFamilyState: DB RefreshToken write + Redis HASH write
+ * - rotateFamilyToken: Redis Lua CAS only; 재사용 시 DB revoke
+ * - revoke*: Redis HASH(존재 시만) + DB revoke
+ * <p>
  * Key: auth:family:{familyUuid}  (HASH)
  * Fields:
  *   currentHash  → SHA256(현재 유효한 refresh token)
@@ -53,6 +58,18 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
         + "redis.call('HSET', KEYS[1], 'currentHash', ARGV[2])\n"
         + "redis.call('PEXPIRE', KEYS[1], ARGV[3])\n"
         + "return 1",
+        Long.class
+    );
+
+    /**
+     * key가 존재할 때만 revoked=1 설정 — 없으면 새 key를 생성하지 않음 (TTL 오염 방지)
+     */
+    private static final RedisScript<Long> REVOKE_IF_EXISTS_SCRIPT = RedisScript.of(
+        "if redis.call('EXISTS', KEYS[1]) == 1 then\n"
+        + "  redis.call('HSET', KEYS[1], 'revoked', '1')\n"
+        + "  return 1\n"
+        + "end\n"
+        + "return 0",
         Long.class
     );
 
@@ -93,7 +110,7 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
 
     @Override
     public void revokeFamilyState(String familyUuid, RevokeReason reason) {
-        redisTemplate.opsForHash().put(familyKey(familyUuid), FIELD_REVOKED, REVOKED_TRUE);
+        redisTemplate.execute(REVOKE_IF_EXISTS_SCRIPT, List.of(familyKey(familyUuid)));
         jpaStore.revokeFamilyState(familyUuid, reason);
         log.debug("Family 폐기: familyUuid={}, reason={}", familyUuid, reason);
     }
@@ -102,7 +119,7 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
     public int revokeAllFamilyStates(Long accountId, RevokeReason reason) {
         List<String> activeUuids = jpaStore.findActiveUuids(accountId);
         activeUuids.forEach(uuid ->
-            redisTemplate.opsForHash().put(familyKey(uuid), FIELD_REVOKED, REVOKED_TRUE)
+            redisTemplate.execute(REVOKE_IF_EXISTS_SCRIPT, List.of(familyKey(uuid)))
         );
         return jpaStore.revokeAllFamilyStates(accountId, reason);
     }

--- a/src/test/java/com/ktb/auth/service/OAuthApplicationServiceTest.java
+++ b/src/test/java/com/ktb/auth/service/OAuthApplicationServiceTest.java
@@ -25,6 +25,7 @@ import com.ktb.auth.exception.token.TokenReuseDetectedException;
 import com.ktb.auth.service.impl.OAuthApplicationServiceImpl;
 import com.ktb.common.domain.ErrorCode;
 import com.ktb.common.exception.BusinessException;
+import com.ktb.fixture.TokenFamilyFixture;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -260,6 +261,7 @@ class OAuthApplicationServiceTest {
         String newAccessToken = "new.access.token";
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
+        when(tokenFamilyStore.findByUuid(FAMILY_UUID)).thenReturn(TokenFamilyFixture.activeFamilyOptional());
         when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn("old-hash");
         when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn(newRefreshToken);
         when(tokenService.generateTokenHash(newRefreshToken)).thenReturn("new-hash");
@@ -286,6 +288,7 @@ class OAuthApplicationServiceTest {
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
+        when(tokenFamilyStore.findByUuid(FAMILY_UUID)).thenReturn(TokenFamilyFixture.activeFamilyOptional());
         when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn("stale-hash");
         when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
         when(tokenService.generateTokenHash("new.refresh.token")).thenReturn("new-hash");
@@ -351,6 +354,7 @@ class OAuthApplicationServiceTest {
         RefreshTokenClaims claims = new RefreshTokenClaims(USER_ID, USER_NICKNAME, FAMILY_UUID);
 
         when(tokenService.validateRefreshToken(REFRESH_TOKEN)).thenReturn(claims);
+        when(tokenFamilyStore.findByUuid(FAMILY_UUID)).thenReturn(TokenFamilyFixture.activeFamilyOptional());
         when(tokenService.generateTokenHash(REFRESH_TOKEN)).thenReturn("stale-hash");
         when(tokenService.issueRefreshToken(USER_ID, FAMILY_UUID, USER_NICKNAME)).thenReturn("new.refresh.token");
         when(tokenService.generateTokenHash("new.refresh.token")).thenReturn("new-hash");

--- a/src/test/java/com/ktb/fixture/TokenFamilyFixture.java
+++ b/src/test/java/com/ktb/fixture/TokenFamilyFixture.java
@@ -1,0 +1,26 @@
+package com.ktb.fixture;
+
+import com.ktb.auth.dto.TokenFamilyInfo;
+import java.util.Optional;
+
+public class TokenFamilyFixture {
+
+    public static final Long DEFAULT_FAMILY_ID = 10L;
+    public static final String DEFAULT_FAMILY_UUID = "family-uuid-123";
+
+    public static TokenFamilyInfo activeFamily() {
+        return new TokenFamilyInfo(DEFAULT_FAMILY_ID, DEFAULT_FAMILY_UUID, true);
+    }
+
+    public static TokenFamilyInfo revokedFamily() {
+        return new TokenFamilyInfo(DEFAULT_FAMILY_ID, DEFAULT_FAMILY_UUID, false);
+    }
+
+    public static Optional<TokenFamilyInfo> activeFamilyOptional() {
+        return Optional.of(activeFamily());
+    }
+
+    public static Optional<TokenFamilyInfo> revokedFamilyOptional() {
+        return Optional.of(revokedFamily());
+    }
+}


### PR DESCRIPTION
## 배경
- Redis state store 기반 RTR에서 refresh 경로 보안/정합성 보강 필요
- family 만료/폐기 검증 누락, rotate 결과 기본 분기 누락, revoke 시 TTL 없는 key 생성 가능성 확인

## 변경 사항
- OAuthApplicationServiceImpl.refreshTokens()
  - refresh 처리 시작 시 DB TokenFamily 유효성(active) 선검증 추가
  - rotateFamilyToken() 결과값 switch에 default 분기 추가 (알 수 없는 코드 즉시 차단)
  - `-1` 경로 예외 메시지/식별자(familyUuid) 포함으로 추적성 강화

- RedisTokenFamilyStore
  - key 존재 시에만 revoked=1로 마킹하는 Lua 스크립트(REVOKE_IF_EXISTS_SCRIPT) 추가
  - revokeFamilyState(), revokeAllFamilyStates()에서 HSET 직접 호출 제거
  - 만료된 key에 대해 신규 key 생성하지 않도록 변경(TTL 오염 방지)
  - 클래스 주석에 운영 전략 명시: DB SoT(TokenFamily) + Redis fast-path(CAS)
- 테스트 보강
  - `OAuthApplicationServiceIntegrationTest`에 만료/폐기 family refresh 차단 시나리오 추가

## 기대 효과
- 보안 강화
  - DB 만료/폐기 기준을 refresh 시 강제해 세션 hard cap(30일) 우회 차단
  - rotate unknown code fail-close로 비정상 분기 허용 제거
  - revoke 처리에서 TTL 없는 영구 key 생성 방지

- 성능/운영 안정성 개선
  - Redis fast-path(CAS)는 유지하면서, 불필요한 revoke 대상 축소(만료 family 제외)
  - key 수명 오염 제거로 Redis 상태 관리 예측 가능성 향상

- 정합성 향상
  - DB와 Redis의 책임 경계 분리

## 영향 범위
- 인증/토큰 갱신 API
  - `POST /api/auth/tokens`
  - `POST /api/auth/logout`
  - `POST /api/auth/logout/all`
- Redis profile 활성 환경의 인증 상태 관리
- TokenFamily revoke/reuse 탐지 동작

## 관련 Issue
 - closes #236 