### PR TITLE
feat:[#239] AI 피드백 완료 시 알림 발송 연동

### DIFF
--- a/src/main/java/com/ktb/interview/session/persistence/InterviewFinalFeedbackPersistenceServiceImpl.java
+++ b/src/main/java/com/ktb/interview/session/persistence/InterviewFinalFeedbackPersistenceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ktb.interview.session.persistence;
 
+import com.ktb.async.contract.FeedbackCompletedEvent;
 import com.ktb.answer.domain.Answer;
 import com.ktb.answer.repository.AnswerRepository;
 import com.ktb.hashtag.domain.AnswerHashtag;
@@ -21,8 +22,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +41,7 @@ public class InterviewFinalFeedbackPersistenceServiceImpl implements InterviewFi
     private final MetricRepository metricRepository;
     private final AnswerMetricRepository answerMetricRepository;
     private final AnswerHashtagRepository answerHashtagRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * AI 피드백 응답을 Answer/Metric/Hashtag 저장 구조로 분해해 영속화합니다.
@@ -66,6 +70,16 @@ public class InterviewFinalFeedbackPersistenceServiceImpl implements InterviewFi
         answerRepository.save(answer);
 
         saveKeywordResult(answer, questionHashtags, feedback.keywordResult());
+
+        Map<String, Integer> metricsMap = metrics.stream()
+                .collect(Collectors.toMap(
+                        InterviewFeedbackMetricResponse::name,
+                        m -> m.score() == null ? 1 : m.score()
+                ));
+        String strengths = overall != null ? overall.strengths() : null;
+        String improvements = overall != null ? overall.improvements() : null;
+        eventPublisher.publishEvent(FeedbackCompletedEvent.create(
+                answer, metricsMap, null, strengths, improvements, null, null));
         log.info("persistAnswerFeedback success - answerId={}, sessionId={}", answer.getId(), answer.getSessionId());
     }
 


### PR DESCRIPTION
## 개요
AI 최종 피드백 저장 완료 시점에 `FeedbackCompletedEvent`를 발행하도록 연동했습니다.
이번 변경은 알림 발송 자체 구현보다, 알림 파이프라인의 트리거를 연결하는 목적입니다.

## 배경
기존에는 최종 피드백 저장과 알림 흐름이 분리되어 있어, 후속 알림 처리 연동 지점이 명확하지 않았습니다.
피드백 저장 성공 시 이벤트를 발행해 비동기 알림 흐름으로 자연스럽게 연결되도록 개선했습니다.

## 주요 변경 사항
- `InterviewFinalFeedbackPersistenceServiceImpl`에 `ApplicationEventPublisher` 주입
- 피드백 저장 성공 직후 `FeedbackCompletedEvent.create(...)` 호출
- metric 정보를 `Map<String, Integer>`로 변환해 이벤트 payload에 포함
- overall의 `strengths` / `improvements`를 이벤트 payload에 포함

## 기대 효과
- 피드백 완료 시점의 이벤트 트리거 일관성 확보
- 알림/후처리 워커와의 결합도 감소 (이벤트 기반 연결)
- 이후 Notification Worker 확장 시 진입점 명확화

## 영향 범위
- 인터뷰 최종 피드백 영속화 경로
- `FeedbackCompletedEvent` 구독 컴포넌트(알림/후처리) 연계 지점

## 관련 이슈
- closes #239