### PR TITLE
fix:[#241] 포트폴리오 PK 컬럼 매핑 불일치 수정

### DIFF
--- a/src/main/java/com/ktb/portfolio/domain/Portfolio.java
+++ b/src/main/java/com/ktb/portfolio/domain/Portfolio.java
@@ -22,6 +22,7 @@ public class Portfolio extends BaseSoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "portfolio_id")
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ktb/portfolio/domain/Project.java
+++ b/src/main/java/com/ktb/portfolio/domain/Project.java
@@ -21,6 +21,7 @@ public class Project extends BaseSoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "project_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION

### 내용
----
Portfolio, Project 테이블 PK 컬럼 이름을 명시적으로 설정하지 않아서 하이버네이트가 임의의 컬럼 이름을 사용하면서
엔티티와 컬럼명 불일치 발생
<img width="717" height="28" alt="image" src="https://github.com/user-attachments/assets/f07532c6-f018-493a-8060-ed53ea5cdebd" />


- Portfolio 엔티티 id를 portfolio_id 컬럼에 명시적으로 매핑
- Project 엔티티 id를 project_id 컬럼에 명시적으로 매핑

### 관련 커밋
----
 - #241 