### PR TITLE
feat:[#242] 알림 내역 조회 off-set에서 cursor 페이지네이션으로 변경

### DIFF
--- a/src/main/java/com/ktb/notification/controller/UserNotificationController.java
+++ b/src/main/java/com/ktb/notification/controller/UserNotificationController.java
@@ -2,6 +2,7 @@ package com.ktb.notification.controller;
 
 import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.common.dto.ApiResponse;
+import com.ktb.notification.dto.response.UserNotificationListResponse;
 import com.ktb.notification.dto.response.UserNotificationResponse;
 import com.ktb.notification.service.UserNotificationService;
 import com.ktb.notification.sse.SseEmitterRegistry;
@@ -13,10 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +21,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -37,19 +35,21 @@ public class UserNotificationController {
     private final SseEmitterRegistry sseEmitterRegistry;
 
     @GetMapping
-    @Operation(summary = "알림 목록 조회", description = "내 알림 목록을 조회합니다.")
+    @Operation(summary = "알림 목록 조회", description = "내 알림 목록을 커서 기반으로 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요",
                     content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
     })
-    public ResponseEntity<ApiResponse<Page<UserNotificationResponse>>> getNotifications(
+    public ResponseEntity<ApiResponse<UserNotificationListResponse>> getNotifications(
             @AuthenticationPrincipal SecurityUserAccount principal,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @Parameter(description = "커서 (마지막 알림 ID)", example = "10")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size
     ) {
-        Page<UserNotificationResponse> result = userNotificationService.getNotifications(
-                principal.getAccount().getId(),
-                pageable
+        UserNotificationListResponse result = userNotificationService.getNotifications(
+                principal.getAccount().getId(), cursor, size
         );
         return ResponseEntity.ok(new ApiResponse<>("notifications_retrieval_success", result));
     }

--- a/src/main/java/com/ktb/notification/dto/response/UserNotificationListResponse.java
+++ b/src/main/java/com/ktb/notification/dto/response/UserNotificationListResponse.java
@@ -1,0 +1,9 @@
+package com.ktb.notification.dto.response;
+
+import java.util.List;
+
+public record UserNotificationListResponse(
+        List<UserNotificationResponse> notifications,
+        UserNotificationPaginationResponse pagination
+) {
+}

--- a/src/main/java/com/ktb/notification/dto/response/UserNotificationPaginationResponse.java
+++ b/src/main/java/com/ktb/notification/dto/response/UserNotificationPaginationResponse.java
@@ -1,0 +1,8 @@
+package com.ktb.notification.dto.response;
+
+public record UserNotificationPaginationResponse(
+        Long nextCursor,
+        boolean hasNext,
+        int size
+) {
+}

--- a/src/main/java/com/ktb/notification/repository/UserNotificationRepository.java
+++ b/src/main/java/com/ktb/notification/repository/UserNotificationRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -45,4 +46,14 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
             NotificationTypeCd notificationType,
             Long referenceId
     );
+
+    @Query("SELECT n FROM UserNotification n WHERE n.account.id = :accountId ORDER BY n.id DESC")
+    Slice<UserNotification> findByAccountIdOrderByIdDesc(
+            @Param("accountId") Long accountId, Pageable pageable);
+
+    @Query("SELECT n FROM UserNotification n WHERE n.account.id = :accountId AND n.id < :cursor ORDER BY n.id DESC")
+    Slice<UserNotification> findByAccountIdAndIdLessThanOrderByIdDesc(
+            @Param("accountId") Long accountId,
+            @Param("cursor") Long cursor,
+            Pageable pageable);
 }

--- a/src/main/java/com/ktb/notification/service/UserNotificationService.java
+++ b/src/main/java/com/ktb/notification/service/UserNotificationService.java
@@ -1,13 +1,12 @@
 package com.ktb.notification.service;
 
 import com.ktb.notification.domain.enums.NotificationTypeCd;
+import com.ktb.notification.dto.response.UserNotificationListResponse;
 import com.ktb.notification.dto.response.UserNotificationResponse;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 public interface UserNotificationService {
 
-    Page<UserNotificationResponse> getNotifications(Long accountId, Pageable pageable);
+    UserNotificationListResponse getNotifications(Long accountId, Long cursor, int size);
 
     boolean hasUnread(Long accountId);
 

--- a/src/main/java/com/ktb/notification/service/impl/UserNotificationServiceImpl.java
+++ b/src/main/java/com/ktb/notification/service/impl/UserNotificationServiceImpl.java
@@ -5,6 +5,8 @@ import com.ktb.auth.service.UserAccountService;
 import com.ktb.notification.domain.Notice;
 import com.ktb.notification.domain.UserNotification;
 import com.ktb.notification.domain.enums.NotificationTypeCd;
+import com.ktb.notification.dto.response.UserNotificationListResponse;
+import com.ktb.notification.dto.response.UserNotificationPaginationResponse;
 import com.ktb.notification.dto.response.UserNotificationResponse;
 import com.ktb.notification.exception.NoticeNotFoundException;
 import com.ktb.notification.exception.UserNotificationNotFoundException;
@@ -12,9 +14,10 @@ import com.ktb.notification.repository.NoticeRepository;
 import com.ktb.notification.repository.UserNotificationRepository;
 import com.ktb.notification.service.UserNotificationService;
 import com.ktb.notification.sse.UnreadEventPublisher;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,15 +26,35 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserNotificationServiceImpl implements UserNotificationService {
 
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+
     private final UserNotificationRepository userNotificationRepository;
     private final UserAccountService userAccountService;
     private final NoticeRepository noticeRepository;
     private final UnreadEventPublisher unreadEventPublisher;
 
     @Override
-    public Page<UserNotificationResponse> getNotifications(Long accountId, Pageable pageable) {
-        return userNotificationRepository.findByAccountId(accountId, pageable)
-                .map(UserNotificationResponse::from);
+    public UserNotificationListResponse getNotifications(Long accountId, Long cursor, int size) {
+        int validatedSize = Math.max(MIN_SIZE, Math.min(MAX_SIZE, size));
+        PageRequest pageRequest = PageRequest.of(0, validatedSize);
+
+        Slice<UserNotification> slice = (cursor == null)
+                ? userNotificationRepository.findByAccountIdOrderByIdDesc(accountId, pageRequest)
+                : userNotificationRepository.findByAccountIdAndIdLessThanOrderByIdDesc(accountId, cursor, pageRequest);
+
+        List<UserNotificationResponse> notifications = slice.getContent().stream()
+                .map(UserNotificationResponse::from)
+                .toList();
+
+        Long nextCursor = slice.hasNext()
+                ? slice.getContent().get(slice.getContent().size() - 1).getId()
+                : null;
+
+        return new UserNotificationListResponse(
+                notifications,
+                new UserNotificationPaginationResponse(nextCursor, slice.hasNext(), validatedSize)
+        );
     }
 
     @Override


### PR DESCRIPTION
## 요약
`/api/notifications` 조회 방식을 offset(Pageable) 기반에서 id cursor 기반으로 전환했습니다.  
첫 조회는 `cursor=null` 이후 조회는 `id < cursor` 조건으로 이어받아 최신순 목록을 조회합니다.

## 변경사항

### 1. Controller 응답/요청 계약 변경
- `UserNotificationController#getNotifications`
  - `Pageable` 제거
  - `cursor`, `size` 쿼리 파라미터로 변경
  - 응답 타입: `ApiResponse<Page<UserNotificationResponse>>`
    -> `ApiResponse<UserNotificationListResponse>`

### 2. 커서 응답 DTO 추가
- `UserNotificationListResponse` 추가
  - `notifications`
  - `pagination`
- `UserNotificationPaginationResponse` 추가
  - `nextCursor`, `hasNext`, `size`

### 3. Service 로직 커서 기반으로 전환
- `UserNotificationService#getNotifications(Long accountId, Long cursor, int size)`로 시그니처 변경
- `Slice` 기반 조회 및 `nextCursor` 계산 로직 추가
- `size` 방어 로직 추가 (min=1, max=100)

### 4. Repository 커서 조회 메서드 추가
- `findByAccountIdOrderByIdDesc`
- `findByAccountIdAndIdLessThanOrderByIdDesc`

### 5. 정렬 기준 고정
- 목록 정렬을 `id DESC`로 통일하여 최신 알림 우선 노출 보장

## API 변경

### Request
- `GET /api/notifications?cursor={lastId?}&size={size?}`

### Response (data)
- `notifications: UserNotificationResponse[]`
- `pagination.nextCursor: Long | null`
- `pagination.ha