### PR TITLE
feat:[#247] 답변 Abuse의 인메모리 내역 Redis로 전환

### DIFF
--- a/src/main/java/com/ktb/abuse/store/redis/RedisContentHashStore.java
+++ b/src/main/java/com/ktb/abuse/store/redis/RedisContentHashStore.java
@@ -1,0 +1,58 @@
+package com.ktb.abuse.store.redis;
+
+import com.ktb.abuse.store.ContentHashStore;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Primary
+@Profile("redis")
+public class RedisContentHashStore implements ContentHashStore {
+
+    private static final String EXACT_KEY_PREFIX = "abuse:hash:exact:";
+    private static final String SIM_KEY_PREFIX = "abuse:hash:sim:";
+    private static final long HASH_TTL_SECONDS = 7L * 24 * 60 * 60;
+    private static final long SIM_HASH_MAX_SIZE = 100L;
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void storeHash(Long accountId, Long questionId, String hash, String simHash) {
+        String exactKey = exactKey(accountId, questionId);
+        String simKey = simKey(accountId, questionId);
+
+        redisTemplate.opsForSet().add(exactKey, hash);
+        redisTemplate.expire(exactKey, HASH_TTL_SECONDS, TimeUnit.SECONDS);
+
+        redisTemplate.opsForList().leftPush(simKey, simHash);
+        redisTemplate.opsForList().trim(simKey, 0, SIM_HASH_MAX_SIZE - 1);
+        redisTemplate.expire(simKey, HASH_TTL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public boolean existsHash(Long accountId, Long questionId, String hash) {
+        Boolean result = redisTemplate.opsForSet().isMember(exactKey(accountId, questionId), hash);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @Override
+    public List<String> getRecentSimHashes(Long accountId, Long questionId, int limit) {
+        List<String> result = redisTemplate.opsForList().range(simKey(accountId, questionId), 0, limit - 1);
+        return result != null ? result : Collections.emptyList();
+    }
+
+    private String exactKey(Long accountId, Long questionId) {
+        return EXACT_KEY_PREFIX + accountId + ":" + questionId;
+    }
+
+    private String simKey(Long accountId, Long questionId) {
+        return SIM_KEY_PREFIX + accountId + ":" + questionId;
+    }
+}

--- a/src/main/java/com/ktb/abuse/store/redis/RedisContentHashStore.java
+++ b/src/main/java/com/ktb/abuse/store/redis/RedisContentHashStore.java
@@ -44,6 +44,9 @@ public class RedisContentHashStore implements ContentHashStore {
 
     @Override
     public List<String> getRecentSimHashes(Long accountId, Long questionId, int limit) {
+        if (limit <= 0) {
+            return Collections.emptyList();
+        }
         List<String> result = redisTemplate.opsForList().range(simKey(accountId, questionId), 0, limit - 1);
         return result != null ? result : Collections.emptyList();
     }

--- a/src/main/java/com/ktb/abuse/store/redis/RedisCooldownStore.java
+++ b/src/main/java/com/ktb/abuse/store/redis/RedisCooldownStore.java
@@ -1,0 +1,76 @@
+package com.ktb.abuse.store.redis;
+
+import com.ktb.abuse.store.CooldownStore;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Primary
+@Profile("redis")
+public class RedisCooldownStore implements CooldownStore {
+
+    private static final String LAST_KEY_PREFIX = "abuse:cooldown:last:";
+    private static final String CONSEC_KEY_PREFIX = "abuse:cooldown:consec:";
+    private static final long COOLDOWN_TTL_SECONDS = 86400L;
+
+    private static final RedisScript<Long> INCR_WITH_EXPIRE = RedisScript.of(
+        "local v = redis.call('INCR', KEYS[1])\n"
+        + "if v == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n"
+        + "return v",
+        Long.class
+    );
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void setLastSubmitTime(Long accountId, Long questionId, long timestamp) {
+        redisTemplate.opsForValue().set(
+            lastKey(accountId, questionId),
+            String.valueOf(timestamp),
+            COOLDOWN_TTL_SECONDS,
+            TimeUnit.SECONDS
+        );
+    }
+
+    @Override
+    public Optional<Long> getLastSubmitTime(Long accountId, Long questionId) {
+        String value = redisTemplate.opsForValue().get(lastKey(accountId, questionId));
+        return Optional.ofNullable(value).map(Long::parseLong);
+    }
+
+    @Override
+    public void incrementConsecutiveCount(Long accountId, Long questionId) {
+        redisTemplate.execute(
+            INCR_WITH_EXPIRE,
+            List.of(consecKey(accountId, questionId)),
+            String.valueOf(COOLDOWN_TTL_SECONDS)
+        );
+    }
+
+    @Override
+    public int getConsecutiveCount(Long accountId, Long questionId) {
+        String value = redisTemplate.opsForValue().get(consecKey(accountId, questionId));
+        return value != null ? Integer.parseInt(value) : 0;
+    }
+
+    @Override
+    public void resetConsecutiveCount(Long accountId, Long questionId) {
+        redisTemplate.delete(consecKey(accountId, questionId));
+    }
+
+    private String lastKey(Long accountId, Long questionId) {
+        return LAST_KEY_PREFIX + accountId + ":" + questionId;
+    }
+
+    private String consecKey(Long accountId, Long questionId) {
+        return CONSEC_KEY_PREFIX + accountId + ":" + questionId;
+    }
+}

--- a/src/main/java/com/ktb/abuse/store/redis/RedisQuotaStore.java
+++ b/src/main/java/com/ktb/abuse/store/redis/RedisQuotaStore.java
@@ -2,6 +2,7 @@ package com.ktb.abuse.store.redis;
 
 import com.ktb.abuse.store.QuotaStore;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class RedisQuotaStore implements QuotaStore {
 
     private static final String KEY_PREFIX = "abuse:quota:";
+    private static final ZoneId FIXED_ZONE = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
     private static final long QUOTA_TTL_SECONDS = 48L * 60 * 60;
 
@@ -48,6 +50,6 @@ public class RedisQuotaStore implements QuotaStore {
     }
 
     private String dailyKey(Long accountId) {
-        return KEY_PREFIX + accountId + ":" + LocalDate.now().format(DATE_FORMAT);
+        return KEY_PREFIX + accountId + ":" + LocalDate.now(FIXED_ZONE).format(DATE_FORMAT);
     }
 }

--- a/src/main/java/com/ktb/abuse/store/redis/RedisQuotaStore.java
+++ b/src/main/java/com/ktb/abuse/store/redis/RedisQuotaStore.java
@@ -1,0 +1,53 @@
+package com.ktb.abuse.store.redis;
+
+import com.ktb.abuse.store.QuotaStore;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Primary
+@Profile("redis")
+public class RedisQuotaStore implements QuotaStore {
+
+    private static final String KEY_PREFIX = "abuse:quota:";
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long QUOTA_TTL_SECONDS = 48L * 60 * 60;
+
+    private static final RedisScript<Long> INCR_WITH_EXPIRE = RedisScript.of(
+        "local v = redis.call('INCR', KEYS[1])\n"
+        + "if v == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n"
+        + "return v",
+        Long.class
+    );
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public int incrementDailyQuota(Long accountId) {
+        String key = dailyKey(accountId);
+        Long count = redisTemplate.execute(
+            INCR_WITH_EXPIRE,
+            List.of(key),
+            String.valueOf(QUOTA_TTL_SECONDS)
+        );
+        return count != null ? count.intValue() : 1;
+    }
+
+    @Override
+    public int getDailyQuota(Long accountId) {
+        String value = redisTemplate.opsForValue().get(dailyKey(accountId));
+        return value != null ? Integer.parseInt(value) : 0;
+    }
+
+    private String dailyKey(Long accountId) {
+        return KEY_PREFIX + accountId + ":" + LocalDate.now().format(DATE_FORMAT);
+    }
+}

--- a/src/main/java/com/ktb/abuse/store/redis/RedisRateLimitStore.java
+++ b/src/main/java/com/ktb/abuse/store/redis/RedisRateLimitStore.java
@@ -1,0 +1,47 @@
+package com.ktb.abuse.store.redis;
+
+import com.ktb.abuse.store.RateLimitStore;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Primary
+@Profile("redis")
+public class RedisRateLimitStore implements RateLimitStore {
+
+    private static final String KEY_PREFIX = "abuse:rate:";
+
+    private static final RedisScript<Long> INCREMENT_WITH_EXPIRE = RedisScript.of(
+        "local v = redis.call('INCR', KEYS[1])\n"
+        + "if v == 1 then redis.call('PEXPIRE', KEYS[1], ARGV[1]) end\n"
+        + "return v",
+        Long.class
+    );
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public long incrementAndGet(String key, Duration window) {
+        String redisKey = KEY_PREFIX + key;
+        Long count = redisTemplate.execute(
+            INCREMENT_WITH_EXPIRE,
+            List.of(redisKey),
+            String.valueOf(window.toMillis())
+        );
+        return count != null ? count : 1L;
+    }
+
+    @Override
+    public Optional<Long> get(String key) {
+        String value = redisTemplate.opsForValue().get(KEY_PREFIX + key);
+        return Optional.ofNullable(value).map(Long::parseLong);
+    }
+}

--- a/src/test/java/com/ktb/abuse/store/redis/RedisContentHashStoreTest.java
+++ b/src/test/java/com/ktb/abuse/store/redis/RedisContentHashStoreTest.java
@@ -1,0 +1,91 @@
+package com.ktb.abuse.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisContentHashStore 단위 테스트")
+class RedisContentHashStoreTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ListOperations<String, String> listOperations;
+
+    @InjectMocks
+    private RedisContentHashStore store;
+
+    @Nested
+    @DisplayName("getRecentSimHashes — limit 경계값 테스트")
+    class GetRecentSimHashesLimitTest {
+
+        @Test
+        @DisplayName("limit = 0이면 emptyList 반환, range() 호출 없음")
+        void getRecentSimHashes_WhenLimitIsZero_ShouldReturnEmptyListWithoutRedisCall() {
+            // When
+            List<String> result = store.getRecentSimHashes(1L, 100L, 0);
+
+            // Then
+            assertThat(result).isEmpty();
+            verifyNoInteractions(redisTemplate);
+        }
+
+        @Test
+        @DisplayName("limit = -1이면 emptyList 반환, range() 호출 없음")
+        void getRecentSimHashes_WhenLimitIsNegative_ShouldReturnEmptyListWithoutRedisCall() {
+            // When
+            List<String> result = store.getRecentSimHashes(1L, 100L, -1);
+
+            // Then
+            assertThat(result).isEmpty();
+            verifyNoInteractions(redisTemplate);
+        }
+
+        @Test
+        @DisplayName("limit = 3이면 range(key, 0, 2) 호출하고 결과 반환")
+        void getRecentSimHashes_WhenLimitIsThree_ShouldCallRangeWithCorrectArgs() {
+            // Given
+            String expectedKey = "abuse:hash:sim:1:100";
+            List<String> redisResult = List.of("sim1", "sim2", "sim3");
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.range(expectedKey, 0, 2)).thenReturn(redisResult);
+
+            // When
+            List<String> result = store.getRecentSimHashes(1L, 100L, 3);
+
+            // Then
+            assertThat(result).containsExactly("sim1", "sim2", "sim3");
+            verify(listOperations).range(expectedKey, 0, 2);
+        }
+
+        @Test
+        @DisplayName("range() 가 null 반환 시 emptyList 반환")
+        void getRecentSimHashes_WhenRangeReturnsNull_ShouldReturnEmptyList() {
+            // Given
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.range(anyString(), anyLong(), anyLong())).thenReturn(null);
+
+            // When
+            List<String> result = store.getRecentSimHashes(1L, 100L, 5);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/ktb/abuse/store/redis/RedisContentHashStoreTest.java
+++ b/src/test/java/com/ktb/abuse/store/redis/RedisContentHashStoreTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,14 +17,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RedisContentHashStore 단위 테스트")
 class RedisContentHashStoreTest {
 
+    private static final String EXACT_KEY_PREFIX = "abuse:hash:exact:";
+    private static final String SIM_KEY_PREFIX = "abuse:hash:sim:";
+    private static final long HASH_TTL_SECONDS = 7L * 24 * 60 * 60; // 604800
+    private static final long SIM_HASH_MAX_SIZE = 100L;
+
     @Mock
     private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private SetOperations<String, String> setOperations;
 
     @Mock
     private ListOperations<String, String> listOperations;
@@ -32,36 +42,151 @@ class RedisContentHashStoreTest {
     private RedisContentHashStore store;
 
     @Nested
+    @DisplayName("storeHash 테스트")
+    class StoreHashTest {
+
+        @Test
+        @DisplayName("exactKey(Set)에 hash를 추가하고 TTL을 설정함")
+        void storeHash_ShouldAddHashToExactSetWithTtl() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+
+            // When
+            store.storeHash(1L, 100L, "abc123", "sim123");
+
+            // Then
+            verify(setOperations).add(EXACT_KEY_PREFIX + "1:100", "abc123");
+            verify(redisTemplate).expire(EXACT_KEY_PREFIX + "1:100", HASH_TTL_SECONDS, TimeUnit.SECONDS);
+        }
+
+        @Test
+        @DisplayName("simKey(List)에 simHash를 leftPush하고 최대 100개로 trim 후 TTL 설정")
+        void storeHash_ShouldLeftPushSimHashWithTrimAndTtl() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+
+            // When
+            store.storeHash(1L, 100L, "abc123", "sim123");
+
+            // Then
+            verify(listOperations).leftPush(SIM_KEY_PREFIX + "1:100", "sim123");
+            verify(listOperations).trim(SIM_KEY_PREFIX + "1:100", 0, SIM_HASH_MAX_SIZE - 1);
+            verify(redisTemplate).expire(SIM_KEY_PREFIX + "1:100", HASH_TTL_SECONDS, TimeUnit.SECONDS);
+        }
+
+        @Test
+        @DisplayName("accountId·questionId가 다르면 서로 다른 key에 저장됨")
+        void storeHash_DifferentAccountAndQuestion_ShouldUseDifferentKeys() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+
+            // When
+            store.storeHash(2L, 200L, "hashX", "simX");
+
+            // Then — key가 계정·질문 조합으로 격리됨
+            verify(setOperations).add(EXACT_KEY_PREFIX + "2:200", "hashX");
+            verify(listOperations).leftPush(SIM_KEY_PREFIX + "2:200", "simX");
+        }
+    }
+
+    @Nested
+    @DisplayName("existsHash 테스트")
+    class ExistsHashTest {
+
+        @Test
+        @DisplayName("isMember 가 TRUE 반환 → true")
+        void existsHash_WhenIsMemberReturnsTrue_ShouldReturnTrue() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(setOperations.isMember(EXACT_KEY_PREFIX + "1:100", "abc123")).thenReturn(Boolean.TRUE);
+
+            // When & Then
+            assertThat(store.existsHash(1L, 100L, "abc123")).isTrue();
+        }
+
+        @Test
+        @DisplayName("isMember 가 FALSE 반환 → false")
+        void existsHash_WhenIsMemberReturnsFalse_ShouldReturnFalse() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(setOperations.isMember(EXACT_KEY_PREFIX + "1:100", "abc123")).thenReturn(Boolean.FALSE);
+
+            // When & Then
+            assertThat(store.existsHash(1L, 100L, "abc123")).isFalse();
+        }
+
+        @Test
+        @DisplayName("isMember 가 null 반환 → false (Boolean.TRUE.equals(null) 안전)")
+        void existsHash_WhenIsMemberReturnsNull_ShouldReturnFalse() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(setOperations.isMember(EXACT_KEY_PREFIX + "1:100", "abc123")).thenReturn(null);
+
+            // When & Then
+            assertThat(store.existsHash(1L, 100L, "abc123")).isFalse();
+        }
+
+        @Test
+        @DisplayName("exactKey 형식은 'abuse:hash:exact:{accountId}:{questionId}'")
+        void existsHash_ShouldUseCorrectExactKeyFormat() {
+            // Given
+            when(redisTemplate.opsForSet()).thenReturn(setOperations);
+            when(setOperations.isMember(EXACT_KEY_PREFIX + "42:999", "h")).thenReturn(Boolean.TRUE);
+
+            // When
+            boolean result = store.existsHash(42L, 999L, "h");
+
+            // Then
+            assertThat(result).isTrue();
+            verify(setOperations).isMember(EXACT_KEY_PREFIX + "42:999", "h");
+        }
+    }
+
+    @Nested
     @DisplayName("getRecentSimHashes — limit 경계값 테스트")
     class GetRecentSimHashesLimitTest {
 
         @Test
-        @DisplayName("limit = 0이면 emptyList 반환, range() 호출 없음")
+        @DisplayName("limit = 0이면 emptyList 반환, Redis 호출 없음")
         void getRecentSimHashes_WhenLimitIsZero_ShouldReturnEmptyListWithoutRedisCall() {
-            // When
             List<String> result = store.getRecentSimHashes(1L, 100L, 0);
 
-            // Then
             assertThat(result).isEmpty();
             verifyNoInteractions(redisTemplate);
         }
 
         @Test
-        @DisplayName("limit = -1이면 emptyList 반환, range() 호출 없음")
+        @DisplayName("limit = -1이면 emptyList 반환, Redis 호출 없음")
         void getRecentSimHashes_WhenLimitIsNegative_ShouldReturnEmptyListWithoutRedisCall() {
-            // When
             List<String> result = store.getRecentSimHashes(1L, 100L, -1);
 
-            // Then
             assertThat(result).isEmpty();
             verifyNoInteractions(redisTemplate);
         }
 
         @Test
-        @DisplayName("limit = 3이면 range(key, 0, 2) 호출하고 결과 반환")
-        void getRecentSimHashes_WhenLimitIsThree_ShouldCallRangeWithCorrectArgs() {
+        @DisplayName("limit = 1이면 range(key, 0, 0) 호출")
+        void getRecentSimHashes_WhenLimitIsOne_ShouldCallRangeZeroToZero() {
             // Given
-            String expectedKey = "abuse:hash:sim:1:100";
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.range(SIM_KEY_PREFIX + "1:100", 0, 0)).thenReturn(List.of("sim1"));
+
+            // When
+            List<String> result = store.getRecentSimHashes(1L, 100L, 1);
+
+            // Then
+            assertThat(result).containsExactly("sim1");
+            verify(listOperations).range(SIM_KEY_PREFIX + "1:100", 0, 0);
+        }
+
+        @Test
+        @DisplayName("limit = 3이면 range(key, 0, 2) 호출하고 결과 그대로 반환")
+        void getRecentSimHashes_WhenLimitIsThree_ShouldCallRangeWithCorrectEndIndex() {
+            // Given
+            String expectedKey = SIM_KEY_PREFIX + "1:100";
             List<String> redisResult = List.of("sim1", "sim2", "sim3");
             when(redisTemplate.opsForList()).thenReturn(listOperations);
             when(listOperations.range(expectedKey, 0, 2)).thenReturn(redisResult);
@@ -75,7 +200,7 @@ class RedisContentHashStoreTest {
         }
 
         @Test
-        @DisplayName("range() 가 null 반환 시 emptyList 반환")
+        @DisplayName("range() 가 null 반환 시 emptyList 반환 (null 방어)")
         void getRecentSimHashes_WhenRangeReturnsNull_ShouldReturnEmptyList() {
             // Given
             when(redisTemplate.opsForList()).thenReturn(listOperations);
@@ -86,6 +211,35 @@ class RedisContentHashStoreTest {
 
             // Then
             assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("range() 가 빈 리스트 반환 시 빈 리스트 그대로 반환")
+        void getRecentSimHashes_WhenRangeReturnsEmptyList_ShouldReturnEmptyList() {
+            // Given
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.range(anyString(), anyLong(), anyLong())).thenReturn(List.of());
+
+            // When
+            List<String> result = store.getRecentSimHashes(1L, 100L, 5);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("simKey 형식은 'abuse:hash:sim:{accountId}:{questionId}'")
+        void getRecentSimHashes_ShouldUseCorrectSimKeyFormat() {
+            // Given
+            String expectedKey = SIM_KEY_PREFIX + "7:300";
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.range(expectedKey, 0, 4)).thenReturn(List.of());
+
+            // When
+            store.getRecentSimHashes(7L, 300L, 5);
+
+            // Then
+            verify(listOperations).range(expectedKey, 0, 4);
         }
     }
 }

--- a/src/test/java/com/ktb/abuse/store/redis/RedisCooldownStoreTest.java
+++ b/src/test/java/com/ktb/abuse/store/redis/RedisCooldownStoreTest.java
@@ -1,0 +1,163 @@
+package com.ktb.abuse.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisCooldownStore 단위 테스트")
+class RedisCooldownStoreTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private RedisCooldownStore store;
+
+    @Nested
+    @DisplayName("setLastSubmitTime / getLastSubmitTime 테스트")
+    class LastSubmitTimeTest {
+
+        @Test
+        @DisplayName("setLastSubmitTime — TTL과 함께 올바른 key로 저장됨")
+        void setLastSubmitTime_ShouldStoreWithTtl() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            long timestamp = 1700000000L;
+
+            // When
+            store.setLastSubmitTime(1L, 100L, timestamp);
+
+            // Then
+            verify(valueOperations).set(
+                eq("abuse:cooldown:last:1:100"),
+                eq("1700000000"),
+                eq(86400L),
+                eq(TimeUnit.SECONDS)
+            );
+        }
+
+        @Test
+        @DisplayName("getLastSubmitTime — 값이 있으면 Optional.of(Long) 반환")
+        void getLastSubmitTime_WhenValueExists_ShouldReturnOptionalLong() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:cooldown:last:1:100")).thenReturn("1700000000");
+
+            // When
+            Optional<Long> result = store.getLastSubmitTime(1L, 100L);
+
+            // Then
+            assertThat(result).isPresent().contains(1700000000L);
+        }
+
+        @Test
+        @DisplayName("getLastSubmitTime — 값이 없으면 Optional.empty() 반환")
+        void getLastSubmitTime_WhenNoValue_ShouldReturnEmpty() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:cooldown:last:1:100")).thenReturn(null);
+
+            // When
+            Optional<Long> result = store.getLastSubmitTime(1L, 100L);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementConsecutiveCount 테스트")
+    class IncrementConsecutiveCountTest {
+
+        @Test
+        @DisplayName("Lua 스크립트로 consecKey에 INCR+EXPIRE 실행됨")
+        void incrementConsecutiveCount_ShouldExecuteLuaScript() {
+            // Given
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(1L);
+
+            // When
+            store.incrementConsecutiveCount(1L, 100L);
+
+            // Then
+            verify(redisTemplate).execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                eq(java.util.List.of("abuse:cooldown:consec:1:100")),
+                eq("86400")
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("getConsecutiveCount 테스트")
+    class GetConsecutiveCountTest {
+
+        @Test
+        @DisplayName("값이 있으면 정수로 반환")
+        void getConsecutiveCount_WhenValueExists_ShouldReturnInt() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:cooldown:consec:1:100")).thenReturn("4");
+
+            // When
+            int result = store.getConsecutiveCount(1L, 100L);
+
+            // Then
+            assertThat(result).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("값이 없으면 0 반환")
+        void getConsecutiveCount_WhenNoValue_ShouldReturnZero() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:cooldown:consec:1:100")).thenReturn(null);
+
+            // When
+            int result = store.getConsecutiveCount(1L, 100L);
+
+            // Then
+            assertThat(result).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("resetConsecutiveCount 테스트")
+    class ResetConsecutiveCountTest {
+
+        @Test
+        @DisplayName("consecKey를 삭제함")
+        void resetConsecutiveCount_ShouldDeleteConsecKey() {
+            // When
+            store.resetConsecutiveCount(1L, 100L);
+
+            // Then
+            verify(redisTemplate).delete("abuse:cooldown:consec:1:100");
+        }
+    }
+}

--- a/src/test/java/com/ktb/abuse/store/redis/RedisQuotaStoreTest.java
+++ b/src/test/java/com/ktb/abuse/store/redis/RedisQuotaStoreTest.java
@@ -3,11 +3,13 @@ package com.ktb.abuse.store.redis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,8 @@ class RedisQuotaStoreTest {
 
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final String KEY_PREFIX = "abuse:quota:";
+    private static final long QUOTA_TTL_SECONDS = 48L * 60 * 60; // 172800
 
     @Mock
     private StringRedisTemplate redisTemplate;
@@ -37,69 +41,85 @@ class RedisQuotaStoreTest {
     private RedisQuotaStore store;
 
     @Nested
-    @DisplayName("dailyKey — 고정 ZoneId 검증")
-    class DailyKeyZoneTest {
+    @DisplayName("dailyKey — ZoneId 및 key 형식 검증")
+    class DailyKeyTest {
+
+        @Test
+        @DisplayName("key 형식은 'abuse:quota:{accountId}:{yyyyMMdd(Seoul)}'")
+        void dailyKey_ShouldUseCorrectKeyFormat() {
+            // Given
+            String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+            String expectedKey = KEY_PREFIX + "42:" + seoulDate;
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(expectedKey)).thenReturn("5");
+
+            // When
+            int result = store.getDailyQuota(42L);
+
+            // Then
+            assertThat(result).isEqualTo(5);
+            verify(valueOperations).get(expectedKey);
+        }
 
         @Test
         @DisplayName("JVM 기본 타임존이 UTC여도 Asia/Seoul 기준 날짜가 key에 사용됨")
-        void getDailyQuota_WithUtcDefaultZone_ShouldUseSeoulDate() {
-            // Given — JVM 기본 타임존을 UTC로 변경
+        void dailyKey_WithJvmTimezoneUtc_ShouldStillUseSeoulDate() {
+            // Given — JVM 기본 타임존을 UTC로 교체
             java.util.TimeZone originalDefault = java.util.TimeZone.getDefault();
             try {
                 java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"));
 
                 String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
-                String expectedKey = "abuse:quota:1:" + seoulDate;
-
+                String expectedKey = KEY_PREFIX + "1:" + seoulDate;
                 when(redisTemplate.opsForValue()).thenReturn(valueOperations);
                 when(valueOperations.get(expectedKey)).thenReturn("3");
 
                 // When
                 int quota = store.getDailyQuota(1L);
 
-                // Then — Seoul 기준 날짜 key로 조회됨
+                // Then — Seoul 날짜 기준으로 조회됨
                 assertThat(quota).isEqualTo(3);
+                verify(valueOperations).get(expectedKey);
             } finally {
                 java.util.TimeZone.setDefault(originalDefault);
             }
         }
 
         @Test
-        @DisplayName("getDailyQuota key는 'abuse:quota:{accountId}:{yyyyMMdd(Seoul)}' 형식")
-        void getDailyQuota_ShouldUseCorrectKeyFormat() {
+        @DisplayName("accountId가 다르면 서로 다른 dailyKey가 사용됨 (key 격리)")
+        void dailyKey_DifferentAccountIds_ShouldUseDifferentKeys() {
             // Given
-            Long accountId = 42L;
             String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
-            String expectedKey = "abuse:quota:" + accountId + ":" + seoulDate;
-
+            String keyFor1 = KEY_PREFIX + "1:" + seoulDate;
+            String keyFor2 = KEY_PREFIX + "2:" + seoulDate;
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.get(expectedKey)).thenReturn("5");
+            when(valueOperations.get(keyFor1)).thenReturn("3");
+            when(valueOperations.get(keyFor2)).thenReturn("7");
 
             // When
-            int result = store.getDailyQuota(accountId);
+            int quotaFor1 = store.getDailyQuota(1L);
+            int quotaFor2 = store.getDailyQuota(2L);
 
             // Then
-            assertThat(result).isEqualTo(5);
+            assertThat(quotaFor1).isEqualTo(3);
+            assertThat(quotaFor2).isEqualTo(7);
         }
     }
 
     @Nested
-    @DisplayName("getDailyQuota 회귀 테스트")
+    @DisplayName("getDailyQuota 테스트")
     class GetDailyQuotaTest {
 
         @Test
-        @DisplayName("Redis에 값이 있으면 해당 정수 반환")
+        @DisplayName("Redis에 값이 있으면 정수로 파싱하여 반환")
         void getDailyQuota_WhenValueExists_ShouldReturnParsedInt() {
             // Given
             String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.get("abuse:quota:1:" + seoulDate)).thenReturn("7");
+            when(valueOperations.get(KEY_PREFIX + "1:" + seoulDate)).thenReturn("7");
 
-            // When
-            int result = store.getDailyQuota(1L);
-
-            // Then
-            assertThat(result).isEqualTo(7);
+            // When & Then
+            assertThat(store.getDailyQuota(1L)).isEqualTo(7);
         }
 
         @Test
@@ -108,22 +128,75 @@ class RedisQuotaStoreTest {
             // Given
             String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.get("abuse:quota:1:" + seoulDate)).thenReturn(null);
+            when(valueOperations.get(KEY_PREFIX + "1:" + seoulDate)).thenReturn(null);
 
-            // When
-            int result = store.getDailyQuota(1L);
+            // When & Then
+            assertThat(store.getDailyQuota(1L)).isEqualTo(0);
+        }
 
-            // Then
-            assertThat(result).isEqualTo(0);
+        @Test
+        @DisplayName("quota 값이 1이면 1 반환 (최솟값 경계)")
+        void getDailyQuota_WhenValueIsOne_ShouldReturnOne() {
+            // Given
+            String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(KEY_PREFIX + "1:" + seoulDate)).thenReturn("1");
+
+            // When & Then
+            assertThat(store.getDailyQuota(1L)).isEqualTo(1);
         }
     }
 
     @Nested
-    @DisplayName("incrementDailyQuota 회귀 테스트")
+    @DisplayName("incrementDailyQuota 테스트")
     class IncrementDailyQuotaTest {
 
         @Test
-        @DisplayName("Lua 스크립트 실행 결과가 null이면 1 반환")
+        @DisplayName("Lua 스크립트 호출 시 올바른 dailyKey가 전달됨")
+        void incrementDailyQuota_ShouldPassCorrectKeyToScript() {
+            // Given
+            String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+            String expectedKey = KEY_PREFIX + "1:" + seoulDate;
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(1L);
+
+            // When
+            store.incrementDailyQuota(1L);
+
+            // Then — key 리스트로 정확한 dailyKey 전달
+            verify(redisTemplate).execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                org.mockito.ArgumentMatchers.eq(List.of(expectedKey)),
+                anyString()
+            );
+        }
+
+        @Test
+        @DisplayName("Lua 스크립트 호출 시 TTL 값 '172800'이 전달됨")
+        void incrementDailyQuota_ShouldPassCorrectTtlToScript() {
+            // Given
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(1L);
+
+            // When
+            store.incrementDailyQuota(1L);
+
+            // Then — QUOTA_TTL_SECONDS = 48 * 3600 = 172800
+            verify(redisTemplate).execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                org.mockito.ArgumentMatchers.eq(String.valueOf(QUOTA_TTL_SECONDS))
+            );
+        }
+
+        @Test
+        @DisplayName("스크립트 결과가 null이면 1 반환")
         void incrementDailyQuota_WhenScriptReturnsNull_ShouldReturnOne() {
             // Given
             when(redisTemplate.execute(
@@ -132,15 +205,12 @@ class RedisQuotaStoreTest {
                 anyString()
             )).thenReturn(null);
 
-            // When
-            int result = store.incrementDailyQuota(1L);
-
-            // Then
-            assertThat(result).isEqualTo(1);
+            // When & Then
+            assertThat(store.incrementDailyQuota(1L)).isEqualTo(1);
         }
 
         @Test
-        @DisplayName("Lua 스크립트 실행 결과가 3이면 3 반환")
+        @DisplayName("스크립트 결과가 3이면 3 반환")
         void incrementDailyQuota_WhenScriptReturnsThree_ShouldReturnThree() {
             // Given
             when(redisTemplate.execute(
@@ -149,11 +219,22 @@ class RedisQuotaStoreTest {
                 anyString()
             )).thenReturn(3L);
 
-            // When
-            int result = store.incrementDailyQuota(1L);
+            // When & Then
+            assertThat(store.incrementDailyQuota(1L)).isEqualTo(3);
+        }
 
-            // Then
-            assertThat(result).isEqualTo(3);
+        @Test
+        @DisplayName("첫 번째 호출(v==1)이면 1 반환 (일별 첫 사용)")
+        void incrementDailyQuota_FirstCallOfDay_ShouldReturnOne() {
+            // Given
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(1L);
+
+            // When & Then
+            assertThat(store.incrementDailyQuota(1L)).isEqualTo(1);
         }
     }
 }

--- a/src/test/java/com/ktb/abuse/store/redis/RedisQuotaStoreTest.java
+++ b/src/test/java/com/ktb/abuse/store/redis/RedisQuotaStoreTest.java
@@ -1,0 +1,159 @@
+package com.ktb.abuse.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisQuotaStore 단위 테스트")
+class RedisQuotaStoreTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private RedisQuotaStore store;
+
+    @Nested
+    @DisplayName("dailyKey — 고정 ZoneId 검증")
+    class DailyKeyZoneTest {
+
+        @Test
+        @DisplayName("JVM 기본 타임존이 UTC여도 Asia/Seoul 기준 날짜가 key에 사용됨")
+        void getDailyQuota_WithUtcDefaultZone_ShouldUseSeoulDate() {
+            // Given — JVM 기본 타임존을 UTC로 변경
+            java.util.TimeZone originalDefault = java.util.TimeZone.getDefault();
+            try {
+                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"));
+
+                String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+                String expectedKey = "abuse:quota:1:" + seoulDate;
+
+                when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+                when(valueOperations.get(expectedKey)).thenReturn("3");
+
+                // When
+                int quota = store.getDailyQuota(1L);
+
+                // Then — Seoul 기준 날짜 key로 조회됨
+                assertThat(quota).isEqualTo(3);
+            } finally {
+                java.util.TimeZone.setDefault(originalDefault);
+            }
+        }
+
+        @Test
+        @DisplayName("getDailyQuota key는 'abuse:quota:{accountId}:{yyyyMMdd(Seoul)}' 형식")
+        void getDailyQuota_ShouldUseCorrectKeyFormat() {
+            // Given
+            Long accountId = 42L;
+            String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+            String expectedKey = "abuse:quota:" + accountId + ":" + seoulDate;
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get(expectedKey)).thenReturn("5");
+
+            // When
+            int result = store.getDailyQuota(accountId);
+
+            // Then
+            assertThat(result).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("getDailyQuota 회귀 테스트")
+    class GetDailyQuotaTest {
+
+        @Test
+        @DisplayName("Redis에 값이 있으면 해당 정수 반환")
+        void getDailyQuota_WhenValueExists_ShouldReturnParsedInt() {
+            // Given
+            String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:quota:1:" + seoulDate)).thenReturn("7");
+
+            // When
+            int result = store.getDailyQuota(1L);
+
+            // Then
+            assertThat(result).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("Redis에 값이 없으면 0 반환")
+        void getDailyQuota_WhenNoValue_ShouldReturnZero() {
+            // Given
+            String seoulDate = LocalDate.now(SEOUL_ZONE).format(DATE_FORMAT);
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:quota:1:" + seoulDate)).thenReturn(null);
+
+            // When
+            int result = store.getDailyQuota(1L);
+
+            // Then
+            assertThat(result).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementDailyQuota 회귀 테스트")
+    class IncrementDailyQuotaTest {
+
+        @Test
+        @DisplayName("Lua 스크립트 실행 결과가 null이면 1 반환")
+        void incrementDailyQuota_WhenScriptReturnsNull_ShouldReturnOne() {
+            // Given
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(null);
+
+            // When
+            int result = store.incrementDailyQuota(1L);
+
+            // Then
+            assertThat(result).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Lua 스크립트 실행 결과가 3이면 3 반환")
+        void incrementDailyQuota_WhenScriptReturnsThree_ShouldReturnThree() {
+            // Given
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(3L);
+
+            // When
+            int result = store.incrementDailyQuota(1L);
+
+            // Then
+            assertThat(result).isEqualTo(3);
+        }
+    }
+}

--- a/src/test/java/com/ktb/abuse/store/redis/RedisRateLimitStoreTest.java
+++ b/src/test/java/com/ktb/abuse/store/redis/RedisRateLimitStoreTest.java
@@ -1,0 +1,136 @@
+package com.ktb.abuse.store.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisRateLimitStore 단위 테스트")
+class RedisRateLimitStoreTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private RedisRateLimitStore store;
+
+    @Nested
+    @DisplayName("incrementAndGet 테스트")
+    class IncrementAndGetTest {
+
+        @Test
+        @DisplayName("Lua 스크립트로 'abuse:rate:{key}'에 INCR+PEXPIRE 실행되고 결과 반환")
+        void incrementAndGet_ShouldExecuteLuaScriptWithPrefixedKey() {
+            // Given
+            Duration window = Duration.ofSeconds(60);
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(3L);
+
+            // When
+            long result = store.incrementAndGet("account:1", window);
+
+            // Then
+            assertThat(result).isEqualTo(3L);
+            verify(redisTemplate).execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                eq(java.util.List.of("abuse:rate:account:1")),
+                eq("60000")
+            );
+        }
+
+        @Test
+        @DisplayName("Lua 스크립트가 null 반환 시 1L 반환")
+        void incrementAndGet_WhenScriptReturnsNull_ShouldReturnOne() {
+            // Given
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(null);
+
+            // When
+            long result = store.incrementAndGet("account:1", Duration.ofSeconds(10));
+
+            // Then
+            assertThat(result).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("window 크기가 밀리초로 변환되어 전달됨")
+        void incrementAndGet_ShouldConvertWindowToMillis() {
+            // Given
+            Duration window = Duration.ofMinutes(1);
+            when(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                anyString()
+            )).thenReturn(1L);
+
+            // When
+            store.incrementAndGet("some:key", window);
+
+            // Then — 60초 = 60000ms
+            verify(redisTemplate).execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                anyList(),
+                eq("60000")
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("get 테스트")
+    class GetTest {
+
+        @Test
+        @DisplayName("값이 있으면 Optional.of(Long) 반환")
+        void get_WhenValueExists_ShouldReturnOptionalLong() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:rate:account:1")).thenReturn("5");
+
+            // When
+            Optional<Long> result = store.get("account:1");
+
+            // Then
+            assertThat(result).isPresent().contains(5L);
+        }
+
+        @Test
+        @DisplayName("값이 없으면 Optional.empty() 반환")
+        void get_WhenNoValue_ShouldReturnEmpty() {
+            // Given
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("abuse:rate:account:1")).thenReturn(null);
+
+            // When
+            Optional<Long> result = store.get("account:1");
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
abuse guard에서 사용하던 InMemory 저장소를 Redis 기반 저장소로 전환했습니다.
redis profile 활성화 시 RateLimit/Cooldown/Quota/ContentHash 데이터가 Redis에 저장됩니다.

## 변경사항
- Redis Store 4종 추가
  - `RedisRateLimitStore`
  - `RedisCooldownStore`
  - `RedisQuotaStore`
  - `RedisContentHashStore`
- 공통 사항
  - `@Profile("redis")`, `@Primary` 적용
  - `StringRedisTemplate` 기반 구현
- 원자성/만료 처리
  - RateLimit/Quota/Cooldown 카운터: Lua(`INCR + EXPIRE/PEXPIRE`)로 초기 만료 원자 처리
  - ContentHash: exact hash(set), sim hash(list + trim) + TTL 적용

### 1) `getRecentSimHashes` limit 경계값 보정
- 파일: `RedisContentHashStore`
- 변경: `limit <= 0`이면 Redis range 호출 없이 `emptyList` 반환
- 효과: `range(0, -1)`로 전체 리스트가 반환되는 비정상 동작 방지
- 정합성: InMemory 구현과 동작 일치

### 2) 일일 quota key 날짜 기준 타임존 고정
- 파일: `RedisQuotaStore`
- 변경: `LocalDate.now()` -> `LocalDate.now(ZoneId.of("Asia/Seoul"))`
- 효과: 멀티 인스턴스/기본 타임존 차이로 인한 날짜 경계 불일치 방지
- 키 포맷(`yyyyMMdd`)은 기존 유지

## 기대효과
- 인스턴스 재시작/스케일아웃 환경에서 abuse 상태 공유
- InMemory 한계를 제거해 guard 일관성 향상
- 트래픽 증가 시 guard 상태 저장 안정성 개선
- 중복 검사(sim hash) 조회의 예측 가능성 향상
- 일일 quota 집계의 환경 독립성 강화
- redis/inmemory 간 행위 일관성 확보

## 영향 범위
- redis profile 활성 환경의 abuse guard 저장소 동작
- rate-limit / cooldown / quota / duplicate guard

## 관련 Issue
- Closes #247