### PR TITLE
feat: enable Tomcat MBean registry for thread pool metrics

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -93,6 +93,11 @@ ai:
     endpoint: /ai/tts
     timeout: 60000  # 60초
 
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
 management:
   server:
     port: 8081


### PR DESCRIPTION
## Summary
- Tomcat MBean registry를 활성화하여 스레드 풀 메트릭(`tomcat_threads_busy_threads`, `tomcat_threads_config_max_threads` 등)이 `/actuator/prometheus`에 노출되도록 합니다.
- 설정 한 줄 추가: `server.tomcat.mbeanregistry.enabled: true`

## Why
- 현재 Grafana 대시보드에서 JVM 전체 스레드 수(`jvm_threads_live_threads`)는 보이지만, **Tomcat 스레드 풀 포화도(Saturation)** 를 측정할 수 없습니다.
- 과거 스레드 6000개 부하 사건에서 모니터링 감지 실패 → 이를 방지하기 위해 Tomcat 스레드 풀 메트릭이 필요합니다.
- `tomcat_threads_busy_threads / tomcat_threads_config_max_threads`로 스레드 풀 포화도를 측정하고 알림을 설정할 수 있게 됩니다.

## Test plan
- [ ] 배포 후 Grafana Explore에서 `tomcat_threads_busy_threads` 메트릭 존재 확인
- [ ] `tomcat_threads_config_max_threads` 값이 Tomcat 설정과 일치하는지 확인