### PR TITLE
refactor:[#254] Answer 도메인 SOLID 개선 및 AI 피드백 트랜잭션 경계 분리 

### DIFF
--- a/src/main/java/com/ktb/ai/feedback/classifier/AiFeedbackOutcomeClassifier.java
+++ b/src/main/java/com/ktb/ai/feedback/classifier/AiFeedbackOutcomeClassifier.java
@@ -1,0 +1,8 @@
+package com.ktb.ai.feedback.classifier;
+
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+
+public interface AiFeedbackOutcomeClassifier {
+
+    FeedbackOutcome classify(AiFeedbackResponse response);
+}

--- a/src/main/java/com/ktb/ai/feedback/classifier/DefaultAiFeedbackOutcomeClassifier.java
+++ b/src/main/java/com/ktb/ai/feedback/classifier/DefaultAiFeedbackOutcomeClassifier.java
@@ -1,0 +1,13 @@
+package com.ktb.ai.feedback.classifier;
+
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultAiFeedbackOutcomeClassifier implements AiFeedbackOutcomeClassifier {
+
+    @Override
+    public FeedbackOutcome classify(AiFeedbackResponse response) {
+        return response.badCaseFeedback() != null ? FeedbackOutcome.BAD_CASE : FeedbackOutcome.NORMAL;
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/classifier/FeedbackOutcome.java
+++ b/src/main/java/com/ktb/ai/feedback/classifier/FeedbackOutcome.java
@@ -1,0 +1,6 @@
+package com.ktb.ai.feedback.classifier;
+
+public enum FeedbackOutcome {
+    NORMAL,
+    BAD_CASE
+}

--- a/src/main/java/com/ktb/ai/feedback/client/AiFeedbackClient.java
+++ b/src/main/java/com/ktb/ai/feedback/client/AiFeedbackClient.java
@@ -1,0 +1,148 @@
+package com.ktb.ai.feedback.client;
+
+import static com.ktb.common.domain.ErrorCode.AI_FEEDBACK_SERVICE_ERROR;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.ktb.ai.feedback.dto.request.AiFeedbackRequest;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.common.dto.ApiResponse;
+import org.springframework.core.ParameterizedTypeReference;
+import com.ktb.ai.feedback.exception.AiFeedbackAlreadyInProgressException;
+import com.ktb.ai.feedback.exception.AiFeedbackAnswerTooLongException;
+import com.ktb.ai.feedback.exception.AiFeedbackAnswerTooShortException;
+import com.ktb.ai.feedback.exception.AiFeedbackEmptyAnswerException;
+import com.ktb.ai.feedback.exception.AiFeedbackEmptyQuestionException;
+import com.ktb.ai.feedback.exception.AiFeedbackInternalServerException;
+import com.ktb.ai.feedback.exception.AiFeedbackLlmServiceUnavailableException;
+import com.ktb.ai.feedback.exception.AiFeedbackRateLimitException;
+import com.ktb.ai.feedback.exception.AiFeedbackServiceException;
+import com.ktb.ai.feedback.exception.AiFeedbackServiceTemporarilyUnavailableException;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiFeedbackClient {
+
+    private static final String MESSAGE_EMPTY_QUESTION = "EMPTY_QUESTION";
+    private static final String MESSAGE_EMPTY_ANSWER = "EMPTY_ANSWER";
+    private static final String MESSAGE_ANSWER_TOO_SHORT = "ANSWER_TOO_SHORT";
+    private static final String MESSAGE_ANSWER_TOO_LONG = "ANSWER_TOO_LONG";
+
+    private final RestClient aiRestClient;
+
+    @Value("${ai.feedback.base-url}")
+    private String baseUrl;
+
+    @Value("${ai.feedback.endpoint}")
+    private String endpoint;
+
+    public ApiResponse<AiFeedbackResponse> evaluate(AiFeedbackRequest request) {
+        String url = baseUrl + endpoint;
+
+        log.info("Requesting AI feedback - URL: {}, userId: {}, questionId: {}",
+                url, request.userId(), request.questionId());
+
+        try {
+            // AI 서버가 정의한 요청 형태 그대로 전달합니다.
+            ApiResponse<AiFeedbackResponse> response = aiRestClient.post()
+                    .uri(url)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        int statusCode = res.getStatusCode().value();
+                        String responseBody = new String(res.getBody().readAllBytes());
+
+                        log.error("AI Feedback 4xx error - status: {}, body: {}", statusCode, responseBody);
+
+                        if (statusCode == 400) {
+                            handle400Error(responseBody);
+                        } else if (statusCode == 409) {
+                            throw new AiFeedbackAlreadyInProgressException();
+                        } else if (statusCode == 429) {
+                            throw new AiFeedbackRateLimitException();
+                        } else {
+                            throw new AiFeedbackServiceException(
+                                String.format("%s - status: %s", AI_FEEDBACK_SERVICE_ERROR.getMessage(), statusCode)
+                            );
+                        }
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+                        int statusCode = res.getStatusCode().value();
+                        String responseBody = new String(res.getBody().readAllBytes());
+
+                        log.error("AI Feedback 5xx error - status: {}, body: {}", statusCode, responseBody);
+
+                        if (statusCode == 500) {
+                            throw new AiFeedbackInternalServerException();
+                        } else if (statusCode == 502) {
+                            throw new AiFeedbackLlmServiceUnavailableException();
+                        } else if (statusCode == 503) {
+                            throw new AiFeedbackServiceTemporarilyUnavailableException(
+                                String.format("status: %s", statusCode));
+                        } else {
+                            throw new AiFeedbackServiceException(
+                                String.format("%s - status: %s", AI_FEEDBACK_SERVICE_ERROR.getMessage(), statusCode)
+                            );
+                        }
+                    })
+                    .body(new ParameterizedTypeReference<>() {
+                    });
+
+            if (response == null) {
+                throw new AiFeedbackServiceException("AI 피드백 응답이 null입니다");
+            }
+
+            if (!"generate_feedback_success".equals(response.message()) && !"bad_case_detected".equals(response.message())) {
+                log.error("AI feedback request failed - unknown message: {}", response.message());
+                throw new AiFeedbackServiceException(
+                        "AI 피드백 생성 실패: 알 수 없는 응답 - " + response.message()
+                );
+            }
+
+            log.info("AI feedback request successful - userId: {}, questionId: {}, message: {}",
+                    request.userId(), request.questionId(), response.message());
+
+            return response;
+
+        } catch (RestClientException e) {
+            log.error("AI feedback API call failed - URL: {}, error: {}", url, e.getMessage(), e);
+            throw new AiFeedbackServiceException("AI 피드백 서버 호출 실패", e);
+        }
+    }
+
+    private void handle400Error(String responseBody) {
+        try {
+            JsonNode jsonNode = JsonMapper.builder().build().readTree(responseBody);
+            String message = jsonNode.has("message") ? jsonNode.get("message").asText() : "";
+
+            switch (message) {
+                case MESSAGE_EMPTY_QUESTION:
+                    throw new AiFeedbackEmptyQuestionException();
+                case MESSAGE_EMPTY_ANSWER:
+                    throw new AiFeedbackEmptyAnswerException();
+                case MESSAGE_ANSWER_TOO_SHORT:
+                    throw new AiFeedbackAnswerTooShortException();
+                case MESSAGE_ANSWER_TOO_LONG:
+                    throw new AiFeedbackAnswerTooLongException();
+                default:
+                    throw new AiFeedbackServiceException(
+                        String.format("%s - message: %s",AI_FEEDBACK_SERVICE_ERROR.getMessage() , message)
+                    );
+            }
+        } catch (IOException e) {
+            log.error("Failed to parse error response body: {}", responseBody, e);
+            throw new AiFeedbackServiceException("AI 피드백 에러 응답 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/request/AiFeedbackRequest.java
@@ -1,0 +1,50 @@
+package com.ktb.ai.feedback.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AI 피드백 생성 요청")
+public record AiFeedbackRequest(
+
+        @JsonProperty("user_id")
+        @Schema(description = "사용자 ID", example = "101", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+
+        @JsonProperty("question_id")
+        @Schema(description = "질문 ID", example = "505", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "질문 ID는 필수입니다")
+        Long questionId,
+
+        @JsonProperty("question_type")
+        @Schema(description = "질문 타입", example = "PRACTICE_INTERVIEW", requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"CS", "SYSTEM_DESIGN", "PORTFOLIO"})
+        @NotBlank(message = "질문 타입은 필수입니다")
+        String type,
+
+        @JsonProperty("category")
+        // AI 서버가 허용하는 카테고리 값 목록입니다.
+        @Schema(description = "질문 카테고리", example = "DB", requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "ALGORITHM", "DATA_STRUCTURE"})
+        String category,
+
+        @JsonProperty("interview_type")
+        @Schema(description = "인터뷰 카테고리", example = "PRACTICE_INTERVIEW", requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"PRACTICE_INTERVIEW", "REAL_INTERVIEW"})
+        @NotBlank(message = "인터뷰 카테고리는 필수입니다")
+        String interviewType,
+
+        @JsonProperty("question")
+        @Schema(description = "질문 내용", example = "RDBMS와 NoSQL의 차이점에 대해 설명해주세요.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "질문 내용은 필수입니다")
+        String question,
+
+        @JsonProperty("answer_text")
+        @Schema(description = "답변 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "답변 내용은 필수입니다")
+        String answerText
+) {
+}

--- a/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackBadCaseFeedback.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackBadCaseFeedback.java
@@ -1,0 +1,25 @@
+package com.ktb.ai.feedback.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Bad case 피드백")
+public record AiFeedbackBadCaseFeedback(
+
+        @JsonProperty("type")
+        @Schema(description = "Bad case 타입", example = "REFUSE_TO_ANSWER",
+                allowableValues = {"REFUSE_TO_ANSWER", "TOO_SHORT", "INAPPROPRIATE"})
+        String type,
+
+        @JsonProperty("message")
+        @Schema(description = "메시지", example = "답변이 감지되지 않았습니다.")
+        String message,
+
+        @JsonProperty("guidance")
+        @Schema(description = "가이드", example = "질문에 대한 답변을 입력해주세요...")
+        String guidance
+) {
+    public BadCaseType getTypeEnum() {
+        return BadCaseType.valueOf(type);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackFeedback.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackFeedback.java
@@ -1,0 +1,17 @@
+package com.ktb.ai.feedback.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "종합 피드백")
+public record AiFeedbackFeedback(
+
+        @JsonProperty("strengths")
+        @Schema(description = "강점", example = "• RDBMS와 NoSQL의 핵심적인 차이점을 정확하게 이해하고 설명했습니다...")
+        String strengths,
+
+        @JsonProperty("improvements")
+        @Schema(description = "개선사항", example = "• 각 데이터베이스의 특징을 나열하는 것을 넘어, 인과관계를 함께 설명하면...")
+        String improvements
+) {
+}

--- a/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackMetric.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackMetric.java
@@ -1,0 +1,21 @@
+package com.ktb.ai.feedback.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "평가 지표")
+public record AiFeedbackMetric(
+
+        @JsonProperty("name")
+        @Schema(description = "지표명", example = "정확도")
+        String name,
+
+        @JsonProperty("score")
+        @Schema(description = "점수 (1~5)", example = "4", minimum = "1", maximum = "5")
+        Integer score,
+
+        @JsonProperty("comment")
+        @Schema(description = "상세 코멘트", example = "RDBMS와 NoSQL의 핵심적인 차이점을 정확하게 설명했습니다...")
+        String comment
+) {
+}

--- a/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/AiFeedbackResponse.java
@@ -1,0 +1,50 @@
+package com.ktb.ai.feedback.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "AI 피드백 응답")
+public record AiFeedbackResponse(
+
+        @JsonProperty("user_id")
+        @Schema(description = "사용자 ID", example = "101")
+        Long userId,
+
+        @JsonProperty("question_id")
+        @Schema(description = "질문 ID", example = "505")
+        Long questionId,
+
+        @JsonProperty("interview_type")
+        @Schema(description = "인터뷰 타입", example = "PRACTICE_INTERVIEW",
+                allowableValues = {"PRACTICE_INTERVIEW", "REAL_INTERVIEW"})
+        String interviewType,
+
+        @JsonProperty("question_type")
+        @Schema(description = "질문 타입", example = "CS",
+                allowableValues = {"CS", "SYSTEM_DESIGN", "PORTFOLIO"})
+        String questionType,
+
+        @JsonProperty("category")
+        @Schema(description = "질문 카테고리", example = "DB",
+                allowableValues = {"OS", "NETWORK", "DB", "COMPUTER_ARCHITECTURE", "ALGORITHM", "DATA_STRUCTURE"})
+        String category,
+
+        @JsonProperty("metrics")
+        @Schema(description = "평가 지표 목록 (정상 케이스만)")
+        List<AiFeedbackMetric> metrics,
+
+        @JsonProperty("bad_case_feedback")
+        @Schema(description = "Bad case 피드백 (bad case만)")
+        AiFeedbackBadCaseFeedback badCaseFeedback,
+
+        @JsonProperty("weakness")
+        @Schema(description = "약점 존재 여부 (정상 케이스만)", example = "true")
+        Boolean weakness,
+
+        @JsonProperty("feedback")
+        // bad case 응답에서는 metrics/weakness/feedback이 null입니다.
+        @Schema(description = "종합 피드백 (정상 케이스만)")
+        AiFeedbackFeedback feedback
+) {
+}

--- a/src/main/java/com/ktb/ai/feedback/dto/response/BadCaseType.java
+++ b/src/main/java/com/ktb/ai/feedback/dto/response/BadCaseType.java
@@ -1,0 +1,27 @@
+package com.ktb.ai.feedback.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BadCaseType {
+
+    REFUSE_TO_ANSWER(
+            "답변이 감지되지 않았습니다.",
+            "질문에 대한 답변을 입력해주세요. 음성이 제대로 녹음되지 않았다면 다시 시도해주세요."
+    ),
+
+    TOO_SHORT(
+            "답변이 너무 짧습니다.",
+            "면접관이 이해할 수 있도록 더 자세하게 설명해주세요. 구체적인 예시나 근거를 포함하면 좋습니다."
+    ),
+
+    INAPPROPRIATE(
+            "부적절한 답변이 감지되었습니다.",
+            "질문과 관련된 기술적인 내용으로 답변해주세요."
+    );
+
+    private final String message;
+    private final String guidance;
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackAlreadyInProgressException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackAlreadyInProgressException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackAlreadyInProgressException extends BusinessException {
+
+    public AiFeedbackAlreadyInProgressException() {
+        super(ErrorCode.AI_FEEDBACK_ALREADY_IN_PROGRESS);
+    }
+
+    public AiFeedbackAlreadyInProgressException(String message) {
+        super(ErrorCode.AI_FEEDBACK_ALREADY_IN_PROGRESS, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackAnswerTooLongException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackAnswerTooLongException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackAnswerTooLongException extends BusinessException {
+
+    public AiFeedbackAnswerTooLongException() {
+        super(ErrorCode.AI_FEEDBACK_ANSWER_TOO_LONG);
+    }
+
+    public AiFeedbackAnswerTooLongException(String message) {
+        super(ErrorCode.AI_FEEDBACK_ANSWER_TOO_LONG, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackAnswerTooShortException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackAnswerTooShortException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackAnswerTooShortException extends BusinessException {
+
+    public AiFeedbackAnswerTooShortException() {
+        super(ErrorCode.AI_FEEDBACK_ANSWER_TOO_SHORT);
+    }
+
+    public AiFeedbackAnswerTooShortException(String message) {
+        super(ErrorCode.AI_FEEDBACK_ANSWER_TOO_SHORT, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackEmptyAnswerException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackEmptyAnswerException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackEmptyAnswerException extends BusinessException {
+
+    public AiFeedbackEmptyAnswerException() {
+        super(ErrorCode.AI_FEEDBACK_EMPTY_ANSWER);
+    }
+
+    public AiFeedbackEmptyAnswerException(String message) {
+        super(ErrorCode.AI_FEEDBACK_EMPTY_ANSWER, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackEmptyQuestionException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackEmptyQuestionException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackEmptyQuestionException extends BusinessException {
+
+    public AiFeedbackEmptyQuestionException() {
+        super(ErrorCode.AI_FEEDBACK_EMPTY_QUESTION);
+    }
+
+    public AiFeedbackEmptyQuestionException(String message) {
+        super(ErrorCode.AI_FEEDBACK_EMPTY_QUESTION, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackInternalServerException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackInternalServerException.java
@@ -1,0 +1,24 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackInternalServerException extends BusinessException {
+
+    public AiFeedbackInternalServerException() {
+        super(ErrorCode.AI_FEEDBACK_INTERNAL_SERVER_ERROR);
+    }
+
+    public AiFeedbackInternalServerException(String message) {
+        super(ErrorCode.AI_FEEDBACK_INTERNAL_SERVER_ERROR, message);
+    }
+
+    public AiFeedbackInternalServerException(Throwable cause) {
+        super(ErrorCode.AI_FEEDBACK_INTERNAL_SERVER_ERROR,
+                ErrorCode.AI_FEEDBACK_INTERNAL_SERVER_ERROR.getMessage(), cause);
+    }
+
+    public AiFeedbackInternalServerException(String message, Throwable cause) {
+        super(ErrorCode.AI_FEEDBACK_INTERNAL_SERVER_ERROR, message, cause);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackLlmServiceUnavailableException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackLlmServiceUnavailableException.java
@@ -1,0 +1,24 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackLlmServiceUnavailableException extends BusinessException {
+
+    public AiFeedbackLlmServiceUnavailableException() {
+        super(ErrorCode.AI_FEEDBACK_LLM_SERVICE_UNAVAILABLE);
+    }
+
+    public AiFeedbackLlmServiceUnavailableException(String message) {
+        super(ErrorCode.AI_FEEDBACK_LLM_SERVICE_UNAVAILABLE, message);
+    }
+
+    public AiFeedbackLlmServiceUnavailableException(Throwable cause) {
+        super(ErrorCode.AI_FEEDBACK_LLM_SERVICE_UNAVAILABLE,
+                ErrorCode.AI_FEEDBACK_LLM_SERVICE_UNAVAILABLE.getMessage(), cause);
+    }
+
+    public AiFeedbackLlmServiceUnavailableException(String message, Throwable cause) {
+        super(ErrorCode.AI_FEEDBACK_LLM_SERVICE_UNAVAILABLE, message, cause);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackRateLimitException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackRateLimitException.java
@@ -1,0 +1,15 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackRateLimitException extends BusinessException {
+
+    public AiFeedbackRateLimitException() {
+        super(ErrorCode.AI_FEEDBACK_RATE_LIMIT_EXCEEDED);
+    }
+
+    public AiFeedbackRateLimitException(String message) {
+        super(ErrorCode.AI_FEEDBACK_RATE_LIMIT_EXCEEDED, message);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackServiceException.java
+++ b/src/main/java/com/ktb/ai/feedback/exception/AiFeedbackServiceException.java
@@ -1,0 +1,23 @@
+package com.ktb.ai.feedback.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class AiFeedbackServiceException extends BusinessException {
+
+    public AiFeedbackServiceException() {
+        super(ErrorCode.AI_FEEDBACK_SERVICE_ERROR);
+    }
+
+    public AiFeedbackServiceException(String message) {
+        super(ErrorCode.AI_FEEDBACK_SERVICE_ERROR, message);
+    }
+
+    public AiFeedbackServiceException(Throwable cause) {
+        super(ErrorCode.AI_FEEDBACK_SERVICE_ERROR, ErrorCode.AI_FEEDBACK_SERVICE_ERROR.getMessage(), cause);
+    }
+
+    public AiFeedbackServiceException(String message, Throwable cause) {
+        super(ErrorCode.AI_FEEDBACK_SERVICE_ERROR, message, cause);
+    }
+}

--- a/src/main/java/com/ktb/ai/feedback/service/AiFeedbackService.java
+++ b/src/main/java/com/ktb/ai/feedback/service/AiFeedbackService.java
@@ -1,0 +1,34 @@
+package com.ktb.ai.feedback.service;
+
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+
+public interface AiFeedbackService {
+
+    /**
+     * AI 피드백 동기 평가
+     *
+     * @param userId          사용자 ID
+     * @param questionId      질문 ID
+     * @param type            질문 타입
+     * @param category        질문 카테고리
+     * @param answerType      인터뷰 카테고리
+     * @param questionContent 질문 내용
+     * @param answerContent   답변 내용
+     * @return AI 피드백 응답
+     * @throws com.ktb.ai.feedback.exception.AiFeedbackServiceException FastAPI 서버 호출 실패 시
+     */
+    ApiResponse<AiFeedbackResponse> evaluateSync(
+            Long userId,
+            Long questionId,
+            QuestionType type,
+            QuestionCategory category,
+            AnswerType answerType,
+            String questionContent,
+            String answerContent
+    );
+
+}

--- a/src/main/java/com/ktb/ai/feedback/service/impl/AiFeedbackServiceImpl.java
+++ b/src/main/java/com/ktb/ai/feedback/service/impl/AiFeedbackServiceImpl.java
@@ -1,0 +1,53 @@
+package com.ktb.ai.feedback.service.impl;
+
+import com.ktb.ai.feedback.client.AiFeedbackClient;
+import com.ktb.ai.feedback.dto.request.AiFeedbackRequest;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.ai.feedback.service.AiFeedbackService;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiFeedbackServiceImpl implements AiFeedbackService {
+
+    private final AiFeedbackClient aiFeedbackClient;
+
+    @Override
+    public ApiResponse<AiFeedbackResponse> evaluateSync(
+            Long userId,
+            Long questionId,
+            QuestionType type,
+            QuestionCategory category,
+            AnswerType answerType,
+            String questionContent,
+            String answerContent
+    ) {
+        log.debug("Evaluating AI feedback - userId: {}, questionId: {}, type: {}, category: {}",
+                userId, questionId, type, category);
+
+        String categoryName = category != null ? category.name() : null;
+        AiFeedbackRequest request = new AiFeedbackRequest(
+                userId,
+                questionId,
+                type.name(),
+                categoryName,
+                answerType.name(),
+                questionContent,
+                answerContent
+        );
+
+        ApiResponse<AiFeedbackResponse> response = aiFeedbackClient.evaluate(request);
+
+        log.info("AI feedback evaluation completed - userId: {}, questionId: {}", userId, questionId);
+
+        return response;
+    }
+
+}

--- a/src/main/java/com/ktb/ai/feedback/worker/AiFeedbackWorker.java
+++ b/src/main/java/com/ktb/ai/feedback/worker/AiFeedbackWorker.java
@@ -1,0 +1,186 @@
+package com.ktb.ai.feedback.worker;
+
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.ai.feedback.service.AiFeedbackService;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerFeedbackInbox;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.repository.AnswerFeedbackInboxRepository;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.domain.Metric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.metric.repository.MetricRepository;
+import com.ktb.notification.relay.OutboxMessage;
+import com.ktb.question.domain.Question;
+import com.ktb.question.repository.QuestionRepository;
+import com.rabbitmq.client.Channel;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * RabbitMQ 기반 비동기 AI 피드백 처리 워커.
+ * Outbox 릴레이로부터 answer.feedback-processing 큐 메시지를 수신하여 처리합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "answer.feedback.rabbitmq.enabled", havingValue = "true")
+public class AiFeedbackWorker {
+
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final AiFeedbackService aiFeedbackService;
+    private final MetricRepository metricRepository;
+    private final AnswerMetricRepository answerMetricRepository;
+    private final AnswerFeedbackInboxRepository answerFeedbackInboxRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    @RabbitListener(
+        queues = "${answer.feedback.rabbitmq.queue}",
+        containerFactory = "manualAckListenerContainerFactory"
+    )
+    public void onAnswerFeedbackRequested(
+            @Payload OutboxMessage message,
+            Channel channel,
+            @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag) throws IOException {
+
+        if (answerFeedbackInboxRepository.existsByEventId(message.messageId())) {
+            log.debug("Duplicate AI feedback event skipped - messageId={}", message.messageId());
+            channel.basicAck(deliveryTag, false);
+            return;
+        }
+
+        try {
+            Map<String, Object> payload = message.payload();
+            Long answerId = toLong(payload.get("answerId"));
+            Long accountId = toLong(payload.get("accountId"));
+            Long questionId = toLong(payload.get("questionId"));
+
+            // TX1: 상태를 AI_FEEDBACK_PROCESSING으로 전이
+            transitionToProcessing(answerId);
+
+            // AI 호출 (트랜잭션 외부)
+            Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new IllegalArgumentException("Answer not found: " + answerId));
+            Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found: " + questionId));
+
+            ApiResponse<AiFeedbackResponse> aiResponse = aiFeedbackService.evaluateSync(
+                accountId,
+                question.getId(),
+                question.getType(),
+                question.getCategory(),
+                answer.getType(),
+                question.getContent(),
+                answer.getContent()
+            );
+
+            // TX2: 결과 저장 + 상태 전이 + 인박스 기록
+            persistAndComplete(message.messageId(), answer, question, aiResponse);
+
+            channel.basicAck(deliveryTag, false);
+            log.info("AI feedback processed - messageId={}, answerId={}", message.messageId(), answerId);
+
+        } catch (DataIntegrityViolationException e) {
+            log.debug("Inbox race condition resolved - messageId={}", message.messageId());
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            log.error("Failed to process AI feedback - messageId={}, error={}",
+                message.messageId(), e.getMessage(), e);
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+
+    private void transitionToProcessing(Long answerId) {
+        transactionTemplate.executeWithoutResult(status -> {
+            Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new IllegalArgumentException("Answer not found: " + answerId));
+            answer.transitionTo(AnswerStatus.AI_FEEDBACK_PROCESSING);
+            answerRepository.save(answer);
+        });
+    }
+
+    private void persistAndComplete(
+            String eventId,
+            Answer answer,
+            Question question,
+            ApiResponse<AiFeedbackResponse> aiResponse) {
+
+        AiFeedbackResponse data = aiResponse.data();
+
+        transactionTemplate.executeWithoutResult(status -> {
+            saveMetrics(answer, data);
+
+            String feedback = buildFeedbackText(data);
+            answer.setAiFeedback(feedback);
+            answer.transitionTo(AnswerStatus.COMPLETED);
+            answerRepository.save(answer);
+
+            answerFeedbackInboxRepository.save(
+                new AnswerFeedbackInbox(eventId, answer.getId())
+            );
+        });
+
+        log.debug("AI feedback persisted - answerId={}", answer.getId());
+    }
+
+    private void saveMetrics(Answer answer, AiFeedbackResponse data) {
+        if (data.metrics() == null || data.metrics().isEmpty()) {
+            return;
+        }
+
+        List<String> metricNames = data.metrics().stream()
+            .map(m -> m.name())
+            .toList();
+
+        Map<String, Metric> metricMap = metricRepository.findAllByNameIn(metricNames)
+            .stream()
+            .collect(Collectors.toMap(Metric::getName, m -> m));
+
+        List<AnswerMetric> answerMetrics = new ArrayList<>();
+        for (var aiMetric : data.metrics()) {
+            Metric metric = metricMap.computeIfAbsent(
+                aiMetric.name(),
+                name -> metricRepository.save(Metric.create(name, ""))
+            );
+            int score = aiMetric.score() == null ? 1 : aiMetric.score();
+            answerMetrics.add(AnswerMetric.create(answer, metric, score));
+        }
+
+        answerMetricRepository.saveAll(answerMetrics);
+    }
+
+    private String buildFeedbackText(AiFeedbackResponse data) {
+        if (data.feedback() == null) {
+            return null;
+        }
+        String strengths = data.feedback().strengths();
+        String improvements = data.feedback().improvements();
+        if (strengths == null && improvements == null) {
+            return null;
+        }
+        return (strengths != null ? strengths : "") + "\n\n" + (improvements != null ? improvements : "");
+    }
+
+    private Long toLong(Object value) {
+        if (value instanceof Number num) {
+            return num.longValue();
+        }
+        return Long.parseLong(String.valueOf(value));
+    }
+}

--- a/src/main/java/com/ktb/answer/config/AnswerFeedbackProperties.java
+++ b/src/main/java/com/ktb/answer/config/AnswerFeedbackProperties.java
@@ -1,0 +1,19 @@
+package com.ktb.answer.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "answer.feedback.rabbitmq")
+public class AnswerFeedbackProperties {
+
+    private boolean enabled = false;
+    private String exchange = "answer.direct";
+    private String dlx = "answer.dlx";
+    private String queue = "answer.feedback-processing";
+    private String dlq = "answer.feedback-processing.dlq";
+    private String routingKey = "answer.feedback-processing";
+    private String dlqRoutingKey = "dlq.answer.feedback-processing";
+}

--- a/src/main/java/com/ktb/answer/config/AnswerFeedbackRabbitConfig.java
+++ b/src/main/java/com/ktb/answer/config/AnswerFeedbackRabbitConfig.java
@@ -1,0 +1,63 @@
+package com.ktb.answer.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "answer.feedback.rabbitmq.enabled", havingValue = "true")
+@EnableConfigurationProperties(AnswerFeedbackProperties.class)
+public class AnswerFeedbackRabbitConfig {
+
+    private final AnswerFeedbackProperties props;
+
+    public AnswerFeedbackRabbitConfig(AnswerFeedbackProperties props) {
+        this.props = props;
+    }
+
+    @Bean
+    public DirectExchange answerFeedbackDirectExchange() {
+        return new DirectExchange(props.getExchange(), true, false);
+    }
+
+    @Bean
+    public DirectExchange answerFeedbackDlx() {
+        return new DirectExchange(props.getDlx(), true, false);
+    }
+
+    @Bean
+    public Queue answerFeedbackProcessingQueue() {
+        return QueueBuilder.durable(props.getQueue())
+            .withArgument("x-dead-letter-exchange", props.getDlx())
+            .withArgument("x-dead-letter-routing-key", props.getDlqRoutingKey())
+            .withArgument("x-message-ttl", 86_400_000L)
+            .build();
+    }
+
+    @Bean
+    public Queue answerFeedbackDlqQueue() {
+        return QueueBuilder.durable(props.getDlq()).build();
+    }
+
+    @Bean
+    public Binding answerFeedbackProcessingBinding() {
+        return BindingBuilder
+            .bind(answerFeedbackProcessingQueue())
+            .to(answerFeedbackDirectExchange())
+            .with(props.getRoutingKey());
+    }
+
+    @Bean
+    public Binding answerFeedbackDlqBinding() {
+        return BindingBuilder
+            .bind(answerFeedbackDlqQueue())
+            .to(answerFeedbackDlx())
+            .with(props.getDlqRoutingKey());
+    }
+}

--- a/src/main/java/com/ktb/answer/controller/AnswerController.java
+++ b/src/main/java/com/ktb/answer/controller/AnswerController.java
@@ -5,7 +5,7 @@ import com.ktb.answer.dto.request.AnswerListRequest;
 import com.ktb.answer.dto.response.detail.AnswerDetailResponse;
 import com.ktb.answer.dto.response.list.AnswerListResponse;
 import com.ktb.answer.exception.AnswerDetailInvalidInputException;
-import com.ktb.answer.service.AnswerDomainService;
+import com.ktb.answer.service.AnswerQueryService;
 import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class AnswerController {
 
-    private final AnswerDomainService answerDomainService;
+    private final AnswerQueryService answerQueryService;
 
     private static final String MESSAGE_ANSWER_LIST_RETRIEVED = "learning_records_retrieval_success";
     private static final String MESSAGE_ANSWER_DETAIL_RETRIEVED = "record_retrieval_success";
@@ -54,7 +54,7 @@ public class AnswerController {
     ) {
         Long accountId = principal.getAccount().getId();
 
-        AnswerListResponse response = answerDomainService.getList(
+        AnswerListResponse response = answerQueryService.getList(
                 accountId,
                 request.type(),
                 request.category(),
@@ -100,7 +100,7 @@ public class AnswerController {
 
         log.info("GET /api/answers/{} - accountId: {}", answerId, accountId);
 
-        AnswerDetailResult detailResult = answerDomainService.getDetail(accountId, answerId);
+        AnswerDetailResult detailResult = answerQueryService.getDetail(accountId, answerId);
         AnswerDetailResponse response = AnswerDetailResponse.of(detailResult);
 
         return ResponseEntity.ok(

--- a/src/main/java/com/ktb/answer/domain/AnswerFeedbackInbox.java
+++ b/src/main/java/com/ktb/answer/domain/AnswerFeedbackInbox.java
@@ -1,0 +1,42 @@
+package com.ktb.answer.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "answer_feedback_inbox",
+    uniqueConstraints = @UniqueConstraint(columnNames = "event_id")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnswerFeedbackInbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, unique = true, length = 64)
+    private String eventId;
+
+    @Column(name = "answer_id", nullable = false)
+    private Long answerId;
+
+    @Column(name = "processed_at", nullable = false)
+    private Instant processedAt;
+
+    public AnswerFeedbackInbox(String eventId, Long answerId) {
+        this.eventId = eventId;
+        this.answerId = answerId;
+        this.processedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/ktb/answer/domain/policy/AllowedQuestionTypeFilterPolicy.java
+++ b/src/main/java/com/ktb/answer/domain/policy/AllowedQuestionTypeFilterPolicy.java
@@ -1,0 +1,18 @@
+package com.ktb.answer.domain.policy;
+
+import com.ktb.question.domain.QuestionType;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AllowedQuestionTypeFilterPolicy implements QuestionTypeFilterPolicy {
+
+    private static final Set<QuestionType> ALLOWED = Set.of(
+        QuestionType.CS, QuestionType.SYSTEM_DESIGN
+    );
+
+    @Override
+    public boolean isSatisfiedBy(QuestionType type) {
+        return ALLOWED.contains(type);
+    }
+}

--- a/src/main/java/com/ktb/answer/domain/policy/QuestionTypeFilterPolicy.java
+++ b/src/main/java/com/ktb/answer/domain/policy/QuestionTypeFilterPolicy.java
@@ -1,0 +1,15 @@
+package com.ktb.answer.domain.policy;
+
+import com.ktb.answer.exception.AnswerListInvalidInputException;
+import com.ktb.question.domain.QuestionType;
+
+public interface QuestionTypeFilterPolicy {
+
+    boolean isSatisfiedBy(QuestionType type);
+
+    default void validateOrThrow(QuestionType type) {
+        if (type != null && !isSatisfiedBy(type)) {
+            throw new AnswerListInvalidInputException("지원하지 않는 questionType: " + type.name());
+        }
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerDetailExpand.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerDetailExpand.java
@@ -1,0 +1,23 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.exception.InvalidExpandException;
+import java.util.Locale;
+
+public enum AnswerDetailExpand {
+    QUESTION,
+    FEEDBACK,
+    IMMEDIATE_FEEDBACK;
+
+    public static AnswerDetailExpand from(String value) {
+        if (value == null) {
+            throw new InvalidExpandException(null);
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        for (AnswerDetailExpand expand : values()) {
+            if (expand.name().equals(normalized)) {
+                return expand;
+            }
+        }
+        throw new InvalidExpandException(value);
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerDetailQuery.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerDetailQuery.java
@@ -1,0 +1,46 @@
+package com.ktb.answer.dto;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public record AnswerDetailQuery(Set<AnswerDetailExpand> expands) {
+
+    public AnswerDetailQuery {
+        if (expands == null || expands.isEmpty()) {
+            expands = EnumSet.noneOf(AnswerDetailExpand.class);
+        } else {
+            expands = EnumSet.copyOf(expands);
+        }
+    }
+
+    public boolean includeQuestion() {
+        return expands.contains(AnswerDetailExpand.QUESTION);
+    }
+
+    public boolean includeFeedback() {
+        return expands.contains(AnswerDetailExpand.FEEDBACK);
+    }
+
+    public boolean includeImmediateFeedback() {
+        return expands.contains(AnswerDetailExpand.IMMEDIATE_FEEDBACK);
+    }
+
+    public static AnswerDetailQuery of(Iterable<String> values) {
+        if (values == null) {
+            return new AnswerDetailQuery(Collections.emptySet());
+        }
+        EnumSet<AnswerDetailExpand> resolved = EnumSet.noneOf(AnswerDetailExpand.class);
+        for (String value : values) {
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            resolved.add(AnswerDetailExpand.from(value));
+        }
+        return new AnswerDetailQuery(resolved);
+    }
+
+    public static AnswerDetailQuery empty() {
+        return new AnswerDetailQuery(Collections.emptySet());
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerSubmitCommand.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerSubmitCommand.java
@@ -1,0 +1,17 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.domain.AnswerType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Objects;
+import org.springframework.web.multipart.MultipartFile;
+
+public record AnswerSubmitCommand(
+        @NotBlank Long questionId,
+        @Size(max = MAX_ANSWER_TEXT_LENGTH) String answerText,
+        AnswerType answerType
+) {
+
+    public static final int MAX_ANSWER_TEXT_LENGTH = 1_500;
+}

--- a/src/main/java/com/ktb/answer/dto/AnswerSubmitResult.java
+++ b/src/main/java/com/ktb/answer/dto/AnswerSubmitResult.java
@@ -1,0 +1,28 @@
+package com.ktb.answer.dto;
+
+import com.ktb.answer.dto.response.submit.AnswerSubmitResponse;
+
+public record AnswerSubmitResult(
+        Long answerId,
+        ImmediateFeedbackResult immediateFeedback,
+        FeedbackStatus aiFeedbackStatus
+) {
+
+    private static final FeedbackStatus DEFAULT_FEEDBACK_STATUS = FeedbackStatus.PROCESSING;
+
+    public static AnswerSubmitResult processing(Long answerId, ImmediateFeedbackResult feedback) {
+        return new AnswerSubmitResult(answerId, feedback, DEFAULT_FEEDBACK_STATUS);
+    }
+
+    public static AnswerSubmitResult noAiFeedback(Long answerId, ImmediateFeedbackResult feedback) {
+        return new AnswerSubmitResult(answerId, feedback, FeedbackStatus.NOT_AVAILABLE);
+    }
+
+    public AnswerSubmitResponse from() {
+        return new AnswerSubmitResponse(
+            this.answerId,
+            this.immediateFeedback.of(),
+            this.aiFeedbackStatus.name()
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/FeedbackResult.java
+++ b/src/main/java/com/ktb/answer/dto/FeedbackResult.java
@@ -1,0 +1,13 @@
+package com.ktb.answer.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record FeedbackResult(
+        FeedbackStatus status,
+        Integer estimatedTimeSeconds,
+        Map<String, Integer> metrics,
+        String comment,
+        Instant completedAt
+) {
+}

--- a/src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerDetailRequest.java
@@ -1,0 +1,35 @@
+package com.ktb.answer.dto.request;
+
+import com.ktb.answer.dto.AnswerDetailQuery;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 답변 상세 조회 요청 DTO
+ */
+@Schema(description = "답변 상세 조회 요청")
+public record AnswerDetailRequest(
+
+        @Parameter(description = "확장 필드 (쉼표 구분: question,feedback,immediate_feedback)",
+                   example = "question,feedback,immediate_feedback")
+        @Schema(description = "응답에 포함할 확장 필드 (question: 질문 정보, feedback: AI 피드백, immediate_feedback: 즉각 피드백)",
+                example = "question,feedback,immediate_feedback")
+        String expand
+) {
+
+    /**
+     * expand 문자열을 AnswerDetailQuery로 변환
+     */
+    public AnswerDetailQuery toQuery() {
+        if (expand == null || expand.isBlank()) {
+            return AnswerDetailQuery.empty();
+        }
+        List<String> values = Arrays.stream(expand.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        return AnswerDetailQuery.of(values);
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/request/AnswerSubmitRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/AnswerSubmitRequest.java
@@ -1,0 +1,33 @@
+package com.ktb.answer.dto.request;
+
+import com.ktb.answer.domain.AnswerType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "답변 제출 요청 (연습/단일 답변)")
+public record AnswerSubmitRequest(
+
+        @Schema(description = "질문 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "질문 ID는 필수입니다")
+        Long questionId,
+
+        @Schema(description = "답변 텍스트 (최대 5,000자, answerText 또는 audioFile 중 최소 1개 필수)",
+                example = "프로세스는 실행 중인 프로그램의 인스턴스이며...",
+                maxLength = MAX_ANSWER_TEXT_LENGTH)
+        @Size(min = MIN_ANSWER_TEXT_LENGTH, message = "답변 텍스트는 최소 {min}자가 필요합니다")
+        @Size(max = MAX_ANSWER_TEXT_LENGTH, message = "답변 텍스트는 {max}자를 초과할 수 없습니다")
+        @NotBlank(message = "답변 내용은 필수입니다")
+        String answerText,
+
+        @Schema(description = "답변 타입 (기본값: PRACTICE_INTERVIEW)",
+                example = "PRACTICE_INTERVIEW",
+                allowableValues = {"PRACTICE_INTERVIEW", "REAL_INTERVIEW", "PORTFOLIO_INTERVIEW"})
+        AnswerType answerType
+) {
+
+    public static final int MIN_ANSWER_TEXT_LENGTH = 50;
+    public static final int MAX_ANSWER_TEXT_LENGTH = 1_500;
+}

--- a/src/main/java/com/ktb/answer/dto/request/SessionAnswerSubmitRequest.java
+++ b/src/main/java/com/ktb/answer/dto/request/SessionAnswerSubmitRequest.java
@@ -1,0 +1,39 @@
+package com.ktb.answer.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 실전 세션 기반 답변 제출 요청 DTO
+ */
+@Schema(description = "실전 세션 기반 답변 제출 요청")
+public record SessionAnswerSubmitRequest(
+
+        @Schema(description = "질문 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "질문 ID는 필수입니다")
+        Long questionId,
+
+        @Schema(description = "답변 텍스트 (최대 5,000자, 필수)",
+                example = "프로세스는 실행 중인 프로그램의 인스턴스입니다...",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                maxLength = 5000)
+        @NotBlank(message = "답변 텍스트는 필수입니다")
+        @Size(max = MAX_ANSWER_TEXT_LENGTH, message = "답변 텍스트는 {max}자를 초과할 수 없습니다")
+        String answerText,
+
+        @Schema(description = "비디오 파일 (최대 100MB, video/* 형식, 선택)",
+                type = "string",
+                format = "binary")
+        MultipartFile videoFile
+) {
+
+    public static final int MAX_ANSWER_TEXT_LENGTH = 5_000;
+    public static final long MAX_VIDEO_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+    public boolean hasVideo() {
+        return videoFile != null && !videoFile.isEmpty();
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/submit/AnswerSubmitResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/submit/AnswerSubmitResponse.java
@@ -1,0 +1,28 @@
+package com.ktb.answer.dto.response.submit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "답변 제출 응답 (연습/단일 답변)")
+public record AnswerSubmitResponse(
+
+        @Schema(description = "생성된 답변 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long answerId,
+
+        @Schema(description = "즉각 피드백 (키워드 체크)", requiredMode = Schema.RequiredMode.REQUIRED)
+        ImmediateFeedback immediateFeedback,
+
+        @Schema(description = "AI 피드백 처리 상태", example = "processing",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"processing", "completed", "failed"})
+        String aiFeedbackStatus
+) {
+    private static final String DEFAULT_AI_FEEDBACK_STATUS = "processing";
+
+    public static AnswerSubmitResponse processing(Long answerId, ImmediateFeedback immediateFeedback) {
+        return new AnswerSubmitResponse(
+                answerId,
+                immediateFeedback,
+                DEFAULT_AI_FEEDBACK_STATUS
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/dto/response/submit/SessionAnswerSubmitResponse.java
+++ b/src/main/java/com/ktb/answer/dto/response/submit/SessionAnswerSubmitResponse.java
@@ -1,0 +1,40 @@
+package com.ktb.answer.dto.response.submit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "실전 세션 기반 답변 제출 응답")
+public record SessionAnswerSubmitResponse(
+
+        @Schema(description = "생성된 답변 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long answerId,
+
+        @Schema(description = "비디오 파일 URL (비디오 파일 제출 시)", example = "https://cdn.example.com/video/123.mp4")
+        String videoUrl,
+
+        @Schema(description = "즉각 피드백 (키워드 체크)", requiredMode = Schema.RequiredMode.REQUIRED)
+        ImmediateFeedback immediateFeedback,
+
+        @Schema(description = "AI 피드백 처리 상태", example = "processing",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"processing", "completed", "failed"})
+        String aiFeedbackStatus,
+
+        @Schema(description = "다음 질문 정보 (세션 계속 진행 시)")
+        NextQuestion nextQuestion
+) {
+    private static final String DEFAULT_AI_FEEDBACK_STATUS = "processing";
+
+    public static SessionAnswerSubmitResponse processing(
+            Long answerId,
+            ImmediateFeedback immediateFeedback,
+            NextQuestion nextQuestion
+    ) {
+        return new SessionAnswerSubmitResponse(
+                answerId,
+                null,
+                immediateFeedback,
+                DEFAULT_AI_FEEDBACK_STATUS,
+                nextQuestion
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/exception/InvalidExpandException.java
+++ b/src/main/java/com/ktb/answer/exception/InvalidExpandException.java
@@ -1,0 +1,12 @@
+package com.ktb.answer.exception;
+
+import com.ktb.common.domain.ErrorCode;
+import com.ktb.common.exception.BusinessException;
+
+public class InvalidExpandException extends BusinessException {
+
+    public InvalidExpandException(String value) {
+        String errMsg = String.format("%s value={%s}",ErrorCode.INVALID_INPUT.getMessage() ,value);
+        super(ErrorCode.INVALID_INPUT, errMsg);
+    }
+}

--- a/src/main/java/com/ktb/answer/repository/AnswerFeedbackInboxRepository.java
+++ b/src/main/java/com/ktb/answer/repository/AnswerFeedbackInboxRepository.java
@@ -1,0 +1,9 @@
+package com.ktb.answer.repository;
+
+import com.ktb.answer.domain.AnswerFeedbackInbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerFeedbackInboxRepository extends JpaRepository<AnswerFeedbackInbox, Long> {
+
+    boolean existsByEventId(String eventId);
+}

--- a/src/main/java/com/ktb/answer/service/AiFeedbackOrchestrator.java
+++ b/src/main/java/com/ktb/answer/service/AiFeedbackOrchestrator.java
@@ -1,0 +1,46 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.response.feedback.FeedbackResponse;
+
+/**
+ * AI 피드백 오케스트레이터 인터페이스
+ * 비동기 AI 피드백 생성 파이프라인 관리 (Kafka 이벤트 기반)
+ */
+public interface AiFeedbackOrchestrator {
+
+    /**
+     * AI 피드백 동기 조회 (FastAPI 서버 호출)
+     *
+     * @param answerId 답변 ID
+     * @param accountId 유저 ID
+     * @return AI 피드백 응답
+     * @throws com.ktb.answer.exception.AnswerNotFoundException  답변을 찾을 수 없는 경우
+     * @throws com.ktb.ai.feedback.exception.AiFeedbackServiceException FastAPI 서버 호출 실패 시
+     */
+    FeedbackResponse getFeedbackSync(Long answerId, Long accountId);
+
+    /**
+     * AI 피드백 생성 이벤트 발행 (Kafka)
+     *
+     * @param answerId 피드백 생성 대상 답변 ID
+     * @throws RuntimeException 이벤트 발행에 실패한 경우
+     */
+    void enqueue(Long answerId);
+
+    /**
+     * 피드백 처리 상태 조회
+     *
+     * @param answerId 답변 ID
+     * @return PROCESSING, COMPLETED, FAILED, FAILED_RETRYABLE 중 하나
+     */
+    FeedbackStatus getStatus(Long answerId);
+
+    /**
+     * 피드백 재시도 요청
+     *
+     * @param answerId 답변 ID
+     * @throws RuntimeException 재시도가 허용되지 않는 경우
+     */
+    void requestRetry(Long answerId);
+}

--- a/src/main/java/com/ktb/answer/service/AnswerApplicationService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerApplicationService.java
@@ -1,0 +1,101 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerSubmitCommand;
+import com.ktb.answer.dto.AnswerSubmitResult;
+import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.response.list.AnswerListResponse;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.file.exception.FileAlreadyDeletedException;
+import com.ktb.file.exception.FileExtensionNotAllowedException;
+import com.ktb.file.exception.FileNotFoundException;
+import com.ktb.file.exception.FileSizeExceededException;
+import com.ktb.file.exception.FileStorageMigrationException;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import com.ktb.question.exception.QuestionDisabledException;
+import com.ktb.question.exception.QuestionNotFoundException;
+import java.time.LocalDate;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface AnswerApplicationService {
+
+    /**
+     * 답변 목록 조회 (본인 답변만)
+     *
+     * @param accountId       현재 사용자 ID
+     * @param type            답변 타입 필터 (선택)
+     * @param category        질문 카테고리 필터 (선택)
+     * @param questionType    질문 타입 필터 (선택)
+     * @param dateFrom        시작 날짜 (선택)
+     * @param dateTo          종료 날짜 (선택)
+     * @param cursor          페이지네이션 커서 (Base64)
+     * @param limit           조회 개수
+     * @return 답변 목록 (Slice)
+     */
+    AnswerListResponse getList(
+            Long accountId,
+            AnswerType type,
+            QuestionCategory category,
+            QuestionType questionType,
+            LocalDate dateFrom,
+            LocalDate dateTo,
+            String cursor,
+            Integer limit
+    );
+
+    /**
+     * 답변 제출 (연습/단일 답변)
+     *
+     * @param accountId 현재 사용자 ID
+     * @param command   답변 제출 정보
+     * @param clientIp  클라이언트 IP 주소 (어뷰징 방지용)
+     * @throws QuestionNotFoundException        질문이 존재하지 않는 경우 (404)
+     * @throws QuestionDisabledException        질문이 비활성화된 경우 (400)
+     * @throws FileSizeExceededException        파일 크기가 초과된 경우 (422)
+     * @throws FileExtensionNotAllowedException 지원하지 않는 파일 형식 (400)
+     * @throws FileNotFoundException            업로드에 참조된 파일을 찾을 수 없는 경우 (404)
+     * @throws FileAlreadyDeletedException      업로드 파일이 이미 삭제된 경우 (409)
+     * @throws FileStorageMigrationException    저장소 이동 중 장애가 발생한 경우 (422)
+     */
+    @Transactional
+    AnswerSubmitResult submit(Long accountId, AnswerSubmitCommand command, String clientIp)
+            throws QuestionNotFoundException, QuestionDisabledException,
+            FileSizeExceededException, FileExtensionNotAllowedException,
+            FileNotFoundException, FileAlreadyDeletedException, FileStorageMigrationException;
+
+    /**
+     * 세션 기반 답변 제출 (실전 모드)
+     *
+     * @param accountId 현재 사용자 ID
+     * @param sessionId 세션 ID
+     * @param command   답변 제출 정보
+     * @return 답변 제출 결과
+     * @throws QuestionNotFoundException 질문이 존재하지 않는 경우
+     * TODO: 세션 관련 Exception 추가 필요
+     */
+    @Transactional
+    AnswerSubmitResult submitWithSession(Long accountId, String sessionId, AnswerSubmitCommand command)
+            throws QuestionNotFoundException;
+
+    /**
+     * 답변 상세 조회
+     *
+     * @throws AnswerNotFoundException     답변이 존재하지 않는 경우 (404)
+     * @throws AnswerAccessDeniedException 본인 답변이 아닌 경우 (403)
+     */
+    AnswerDetailResult getDetail(Long accountId, Long answerId, AnswerDetailQuery query)
+            throws AnswerNotFoundException, AnswerAccessDeniedException;
+
+    /**
+     * AI 피드백 조회
+     *
+     * @throws AnswerNotFoundException     답변이 존재하지 않는 경우 (404)
+     * @throws AnswerAccessDeniedException 본인 답변이 아닌 경우 (403)
+     */
+    FeedbackResult getFeedback(Long accountId, Long answerId)
+            throws AnswerNotFoundException, AnswerAccessDeniedException;
+}

--- a/src/main/java/com/ktb/answer/service/AnswerCommandService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerCommandService.java
@@ -10,36 +10,42 @@ import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
 import com.ktb.auth.exception.account.AccountNotFoundException;
 import com.ktb.question.exception.QuestionNotFoundException;
 
-public interface AnswerDomainService {
+public interface AnswerCommandService {
+
     /**
      * 답변 생성
+     *
      * @return 생성된 Answer 엔티티
-     * @throws AccountNotFoundException     제출한 유저가 존재하지 않을 때(404)
-     * @throws QuestionNotFoundException    제출한 답변의 문제가 존재하지 않을 때(404)
+     * @throws AccountNotFoundException  제출한 유저가 존재하지 않을 때(404)
+     * @throws QuestionNotFoundException 제출한 답변의 문제가 존재하지 않을 때(404)
      */
-    Answer createAnswer(Long accountId, Long questionId, String answerContent, AnswerType type);
+    Answer create(Long accountId, Long questionId, String content, AnswerType type);
 
     /**
      * 답변 소유권 검증
+     *
      * @throws AnswerAccessDeniedException 본인 답변이 아닌 경우
      */
     void validateOwnership(Answer answer, Long accountId) throws AnswerAccessDeniedException;
 
     /**
      * 답변 상태 전이
+     *
      * @throws InvalidAnswerStatusTransitionException 허용되지 않는 상태 전이인 경우
      */
     void transitionStatus(Answer answer, AnswerStatus nextStatus) throws InvalidAnswerStatusTransitionException;
 
     /**
      * 중복 답변 검증 (세션 내 동일 질문)
+     *
      * @throws DuplicateAnswerException 이미 답변이 존재하는 경우
      */
-    void checkDuplicateAnswer(String sessionId, Long questionId) throws DuplicateAnswerException;
+    void checkDuplicate(String sessionId, Long questionId) throws DuplicateAnswerException;
 
     /**
      * 답변 텍스트 유효성 검증
+     *
      * @throws InvalidAnswerContentException 답변 내용이 유효하지 않은 경우
      */
-    void validateAnswerContent(String answerText) throws InvalidAnswerContentException;
+    void validateContent(String answerText) throws InvalidAnswerContentException;
 }

--- a/src/main/java/com/ktb/answer/service/AnswerQueryService.java
+++ b/src/main/java/com/ktb/answer/service/AnswerQueryService.java
@@ -1,0 +1,30 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.response.list.AnswerListResponse;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import java.time.LocalDate;
+
+public interface AnswerQueryService {
+
+    /**
+     * 답변 목록 조회 (본인 답변만)
+     */
+    AnswerListResponse getList(
+            Long accountId,
+            AnswerType type,
+            QuestionCategory category,
+            QuestionType questionType,
+            LocalDate dateFrom,
+            LocalDate dateTo,
+            String cursor,
+            Integer limit
+    );
+
+    /**
+     * 답변 상세 조회 (본인 답변만)
+     */
+    AnswerDetailResult getDetail(Long accountId, Long answerId);
+}

--- a/src/main/java/com/ktb/answer/service/CursorCodec.java
+++ b/src/main/java/com/ktb/answer/service/CursorCodec.java
@@ -1,0 +1,43 @@
+package com.ktb.answer.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.ktb.answer.dto.AnswerListCursor;
+import com.ktb.answer.exception.AnswerListInvalidInputException;
+import java.io.IOException;
+import java.util.Base64;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CursorCodec {
+
+    private final JsonMapper jsonMapper = JsonMapper.builder()
+            .addModule(new JavaTimeModule())
+            .build();
+
+    public AnswerListCursor decode(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(cursor);
+            AnswerListCursor payload = jsonMapper.readValue(decoded, AnswerListCursor.class);
+            if (payload.lastCreatedAt() == null || payload.lastAnswerId() == null) {
+                throw new AnswerListInvalidInputException("cursor payload is incomplete");
+            }
+            return payload;
+        } catch (IllegalArgumentException | IOException e) {
+            throw new AnswerListInvalidInputException("invalid cursor", e);
+        }
+    }
+
+    public String encode(AnswerListCursor cursor) {
+        try {
+            byte[] json = jsonMapper.writeValueAsBytes(cursor);
+            return Base64.getEncoder().encodeToString(json);
+        } catch (JsonProcessingException e) {
+            throw new AnswerListInvalidInputException("failed to encode cursor", e);
+        }
+    }
+}

--- a/src/main/java/com/ktb/answer/service/ImmediateFeedbackService.java
+++ b/src/main/java/com/ktb/answer/service/ImmediateFeedbackService.java
@@ -1,0 +1,29 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.hashtag.domain.QuestionHashtag;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+public interface ImmediateFeedbackService {
+    /**
+     * 즉각 피드백 생성 (동기 처리)
+     * @param questionId 질문 ID
+     * @param answerText 답변 텍스트
+     * @return 키워드 체크리스트 기반 즉각 피드백
+     */
+    ImmediateFeedbackResult evaluate(Long questionId, String answerText);
+
+    /**
+     * 핵심 키워드 추출
+     * @return 질문별 핵심 키워드 목록
+     */
+    List<QuestionHashtag> extractKeywords(Long questionId);
+
+    /**
+     * 키워드 포함 여부 체크
+     * @return 키워드별 포함 여부 결과
+     */
+    List<KeywordCheckResult> checkKeywords(String answerText, List<QuestionHashtag> keywords);
+}

--- a/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AiFeedbackOrchestratorImpl.java
@@ -1,0 +1,213 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.ai.feedback.classifier.AiFeedbackOutcomeClassifier;
+import com.ktb.ai.feedback.classifier.FeedbackOutcome;
+import com.ktb.ai.feedback.dto.response.AiFeedbackBadCaseFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.ai.feedback.dto.response.AiFeedbackFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackMetric;
+import com.ktb.ai.feedback.dto.response.BadCaseType;
+import com.ktb.ai.feedback.service.AiFeedbackService;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.response.feedback.FeedbackResponse;
+import com.ktb.answer.dto.response.common.MetricScore;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AiFeedbackOrchestrator;
+import com.ktb.answer.service.AnswerDomainService;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.domain.Metric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.metric.repository.MetricRepository;
+import com.ktb.question.domain.Question;
+import java.util.ArrayList;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiFeedbackOrchestratorImpl implements AiFeedbackOrchestrator {
+
+    private final AnswerRepository answerRepository;
+    private final AnswerDomainService answerDomainService;
+    private final AiFeedbackService aiFeedbackService;
+    private final MetricRepository metricRepository;
+    private final AnswerMetricRepository answerMetricRepository;
+    private final AiFeedbackOutcomeClassifier aiFeedbackOutcomeClassifier;
+
+    @Override
+    @Transactional
+    public FeedbackResponse getFeedbackSync(Long answerId, Long accountId) {
+        log.info("Getting AI feedback synchronously for answerId: {}", answerId);
+
+        Answer answer = answerRepository.findById(answerId)
+            .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+        Question question = answer.getQuestion();
+        UserAccount account = answer.getAccount();
+
+        answerDomainService.validateOwnership(answer, accountId);
+
+        log.debug("Answer found - answerId: {}, questionId: {}, userId: {}",
+                answerId, question.getId(), account.getId());
+
+        ApiResponse<AiFeedbackResponse> apiResponse = getAiFeedback(account, question, answer);
+
+        FeedbackResponse response = aiFeedbackOutcomeClassifier.classify(apiResponse.data()) == FeedbackOutcome.BAD_CASE
+                ? handleBadCaseResponse(answer, apiResponse)
+                : handleSuccessResponse(answer, apiResponse);
+
+        log.info("AI feedback retrieved successfully for answerId: {}", answerId);
+
+        return response;
+    }
+
+    @Override
+    public void enqueue(Long answerId) {
+        // TODO: MVP V2 구현 필요
+        // 1. Kafka Producer 구성
+        // 2. ANSWER_AI_FEEDBACK_REQUESTED 이벤트 발행
+        // 3. 이벤트 payload: { answerId, questionId, answerContent }
+        // 4. 발행 실패 시 예외 처리 (재시도 정책)
+
+        log.info("Enqueueing AI feedback request for answerId: {}", answerId);
+
+        // TODO: Kafka 연동 후 활성화
+        // kafkaTemplate.send("answer-feedback-requests", answerId.toString(), event);
+
+        log.warn("AI feedback enqueue not implemented yet (Kafka integration required)");
+    }
+
+    @Override
+    public FeedbackStatus getStatus(Long answerId) {
+        // TODO: 구현 필요
+        // 1. Answer 조회
+        // 2. Answer.status를 FeedbackStatus로 매핑
+        //    - AI_FEEDBACK_PROCESSING -> PROCESSING
+        //    - COMPLETED -> COMPLETED
+        //    - FAILED -> FAILED
+        //    - FAILED_RETRYABLE -> FAILED_RETRYABLE
+        // 3. FeedbackStatus 반환
+
+        log.debug("Getting feedback status for answerId: {}", answerId);
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerNotFoundException(answerId));
+
+        return FeedbackStatus.from(answer.getStatus());
+    }
+
+    @Override
+    public void requestRetry(Long answerId) {
+        // TODO: MVP V2 구현 필요
+        // 1. Answer 조회
+        // 2. 상태 검증 (FAILED_RETRYABLE만 허용)
+        // 3. 재시도 횟수 체크 (최대 3회)
+        // 4. Kafka 이벤트 재발행
+        // 5. Answer 상태를 AI_FEEDBACK_PROCESSING으로 전이
+
+        log.info("Requesting feedback retry for answerId: {}", answerId);
+
+        // TODO: 재시도 정책 구현 후 활성화
+        throw new UnsupportedOperationException("Feedback retry not yet implemented");
+    }
+
+    private ApiResponse<AiFeedbackResponse> getAiFeedback(
+        UserAccount account, Question question, Answer answer
+        ) {
+
+        return aiFeedbackService.evaluateSync(
+            account.getId(),
+            question.getId(),
+            question.getType(),
+            question.getCategory(),
+            answer.getType(),
+            question.getContent(),
+            answer.getContent()
+        );
+    }
+
+    private FeedbackResponse handleBadCaseResponse(Answer answer, ApiResponse<AiFeedbackResponse> apiResponse) {
+        AiFeedbackBadCaseFeedback badCase = apiResponse.data().badCaseFeedback();
+        BadCaseType badCaseType = badCase.getTypeEnum();
+
+        String failureMessage = badCaseType.getMessage() + "\n\n" + badCaseType.getGuidance();
+
+        answer.setAiFeedback(badCaseType.getGuidance());
+        answerRepository.save(answer);
+
+        log.warn("Bad case detected for answerId: {}, type: {}", answer.getId(), badCaseType);
+
+        return FeedbackResponse.failed(failureMessage);
+    }
+
+    private FeedbackResponse handleSuccessResponse(Answer answer, ApiResponse<AiFeedbackResponse> apiResponse) {
+        AiFeedbackResponse data = apiResponse.data();
+
+        saveAnswerMetrics(answer, data.metrics());
+
+        List<MetricScore> radarChart = convertToRadarChart(data.metrics());
+        String combinedFeedback = combineFeedback(data.feedback());
+
+        answer.setAiFeedback(combinedFeedback);
+        answerRepository.save(answer);
+
+        return FeedbackResponse.completed(combinedFeedback, radarChart);
+    }
+
+    private List<MetricScore> convertToRadarChart(List<AiFeedbackMetric> metrics) {
+        if (metrics == null) {
+            return null;
+        }
+
+        return metrics.stream()
+                .map(metric -> new MetricScore(
+                        metric.name(),        // metricName
+                        metric.comment(),     // metricDescription
+                        metric.score(),       // score (1~5)
+                        5                     // maxScore
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private void saveAnswerMetrics(Answer answer, List<AiFeedbackMetric> aiMetrics) {
+        if (aiMetrics == null || aiMetrics.isEmpty()) {
+            return;
+        }
+
+        Map<String, Metric> metricMap =
+            metricRepository.findAllByNameIn(aiMetrics.stream().map(AiFeedbackMetric::name).toList())
+                .stream()
+                .collect(Collectors.toMap(Metric::getName, m -> m));
+
+        List<AnswerMetric> answerMetrics = new ArrayList<>(aiMetrics.size());
+
+        for (AiFeedbackMetric aiMetric : aiMetrics) {
+            Metric metric = metricMap.computeIfAbsent(aiMetric.name(), name ->
+                metricRepository.save(Metric.create(name, ""))
+            );
+            int score = aiMetric.score() == null ? 1 : aiMetric.score();
+            answerMetrics.add(AnswerMetric.create(answer, metric, score));
+        }
+
+        answerMetricRepository.saveAll(answerMetrics);
+    }
+
+    private String combineFeedback(AiFeedbackFeedback feedback) {
+        if (feedback == null) {
+            return null;
+        }
+
+        return feedback.strengths() + "\n\n" + feedback.improvements();
+    }
+}

--- a/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
@@ -1,0 +1,227 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.abuse.core.AbuseCheckContext;
+import com.ktb.abuse.core.AbuseGuard;
+import com.ktb.abuse.core.AbuseGuardResult;
+import com.ktb.answer.config.AnswerFeedbackProperties;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerSubmitCommand;
+import com.ktb.answer.dto.AnswerSubmitResult;
+import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.response.list.AnswerListResponse;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AnswerApplicationService;
+import com.ktb.answer.service.AnswerCommandService;
+import com.ktb.answer.service.AnswerQueryService;
+import com.ktb.answer.service.ImmediateFeedbackService;
+import com.ktb.file.exception.FileAlreadyDeletedException;
+import com.ktb.file.exception.FileExtensionNotAllowedException;
+import com.ktb.file.exception.FileNotFoundException;
+import com.ktb.file.exception.FileSizeExceededException;
+import com.ktb.file.exception.FileStorageMigrationException;
+import com.ktb.hashtag.domain.AnswerHashtag;
+import com.ktb.hashtag.domain.Hashtag;
+import com.ktb.hashtag.exception.HashtagNotFoundException;
+import com.ktb.hashtag.repository.AnswerHashtagRepository;
+import com.ktb.hashtag.repository.HashtagRepository;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.notification.domain.NotificationOutbox;
+import com.ktb.notification.repository.NotificationOutboxRepository;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import com.ktb.question.exception.QuestionDisabledException;
+import com.ktb.question.exception.QuestionNotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@EnableConfigurationProperties(AnswerFeedbackProperties.class)
+public class AnswerApplicationServiceImpl implements AnswerApplicationService {
+
+    private final AnswerRepository answerRepository;
+    private final AnswerCommandService answerCommandService;
+    private final AnswerQueryService answerQueryService;
+    private final ImmediateFeedbackService immediateFeedbackService;
+    private final AnswerHashtagRepository answerHashtagRepository;
+    private final HashtagRepository hashtagRepository;
+    private final AnswerMetricRepository answerMetricRepository;
+    private final AbuseGuard abuseGuard;
+    private final AnswerFeedbackProperties answerFeedbackProperties;
+    private final NotificationOutboxRepository notificationOutboxRepository;
+
+    @Override
+    public AnswerListResponse getList(
+            Long accountId,
+            AnswerType type,
+            QuestionCategory category,
+            QuestionType questionType,
+            LocalDate dateFrom,
+            LocalDate dateTo,
+            String cursor,
+            Integer limit
+    ) {
+        return answerQueryService.getList(accountId, type, category, questionType, dateFrom, dateTo, cursor, limit);
+    }
+
+    @Override
+    @Transactional
+    public AnswerSubmitResult submit(Long accountId, AnswerSubmitCommand command, String clientIp)
+            throws QuestionNotFoundException, QuestionDisabledException,
+            FileSizeExceededException, FileExtensionNotAllowedException,
+            FileNotFoundException, FileAlreadyDeletedException, FileStorageMigrationException {
+
+        log.info("Submitting answer - questionId={}, accountId={}", command.questionId(), accountId);
+
+        answerCommandService.validateContent(command.answerText());
+
+        AbuseCheckContext abuseContext = AbuseCheckContext.of(
+                accountId,
+                command.questionId(),
+                clientIp,
+                command.answerText()
+        );
+        AbuseGuardResult abuseResult = abuseGuard.check(abuseContext);
+
+        Answer answer = answerRepository.save(
+                answerCommandService.create(accountId, command.questionId(), command.answerText(), command.answerType())
+        );
+
+        ImmediateFeedbackResult immediateFeedback = immediateFeedbackService.evaluate(
+                command.questionId(),
+                answer.getContent()
+        );
+
+        saveAnswerHashtags(answer, immediateFeedback);
+
+        if (!abuseResult.shouldProvideFeedback()) {
+            answerCommandService.transitionStatus(answer, AnswerStatus.NOT_AVAILABLE);
+            log.info("Answer saved without AI feedback - accountId={}, reason={}",
+                    accountId, abuseResult.getReason());
+            return AnswerSubmitResult.noAiFeedback(answer.getId(), immediateFeedback);
+        }
+
+        if (answerFeedbackProperties.isEnabled()) {
+            saveAiFeedbackOutbox(answer, accountId, command.questionId());
+            log.info("AI feedback outbox saved - answerId={}", answer.getId());
+        } else {
+            log.debug("AI feedback outbox disabled - answerId={}", answer.getId());
+        }
+
+        return AnswerSubmitResult.processing(answer.getId(), immediateFeedback);
+    }
+
+    private void saveAiFeedbackOutbox(Answer answer, Long accountId, Long questionId) {
+        String eventId = UUID.randomUUID().toString();
+        Map<String, Object> payload = Map.of(
+            "eventId", eventId,
+            "answerId", answer.getId(),
+            "accountId", accountId,
+            "questionId", questionId
+        );
+        notificationOutboxRepository.save(NotificationOutbox.of(
+            "ANSWER_SUBMITTED",
+            "ANSWER_FEEDBACK",
+            answer.getId().toString(),
+            eventId,
+            answerFeedbackProperties.getExchange(),
+            answerFeedbackProperties.getRoutingKey(),
+            payload
+        ));
+    }
+
+    private void saveAnswerHashtags(Answer answer, ImmediateFeedbackResult feedback) {
+        List<AnswerHashtag> answerHashtags = feedback.keywords().stream()
+            .map(keywordResult -> {
+                Hashtag hashtag = hashtagRepository.findById(keywordResult.keywordId())
+                    .orElseThrow(() -> new HashtagNotFoundException(keywordResult.keywordId()));
+                return AnswerHashtag.create(answer, hashtag, keywordResult.included());
+            })
+            .toList();
+
+        answerHashtagRepository.saveAll(answerHashtags);
+
+        log.debug("AnswerHashtags saved - answerId={}, total={}, included={}",
+                  answer.getId(),
+                  answerHashtags.size(),
+                  answerHashtags.stream().filter(ah -> ah.isIncluded()).count());
+    }
+
+    @Override
+    @Transactional
+    public AnswerSubmitResult submitWithSession(Long accountId, String sessionId, AnswerSubmitCommand command)
+            throws QuestionNotFoundException {
+
+        log.info("Submitting session answer - sessionId={}, questionId={}, accountId={}",
+                sessionId, command.questionId(), accountId);
+
+        // TODO: ANSWER_SESSION 엔티티 구현 후 활성화
+        throw new UnsupportedOperationException("Session-based answer submission not yet implemented");
+    }
+
+    @Override
+    public AnswerDetailResult getDetail(Long accountId, Long answerId, AnswerDetailQuery query)
+        throws AnswerNotFoundException, AnswerAccessDeniedException {
+        return answerQueryService.getDetail(accountId, answerId);
+    }
+
+    @Override
+    public FeedbackResult getFeedback(Long accountId, Long answerId)
+            throws AnswerNotFoundException, AnswerAccessDeniedException {
+
+        log.debug("Retrieving feedback - answerId={}, accountId={}", answerId, accountId);
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerNotFoundException(answerId));
+        answerCommandService.validateOwnership(answer, accountId);
+
+        return buildFeedbackResult(answer);
+    }
+
+    private FeedbackResult buildFeedbackResult(Answer answer) {
+        FeedbackStatus status = FeedbackStatus.from(answer.getStatus());
+
+        if (status == FeedbackStatus.PROCESSING) {
+            return new FeedbackResult(status, 30, null, null, null);
+        }
+
+        if (status != FeedbackStatus.COMPLETED) {
+            return new FeedbackResult(status, null, null, null, null);
+        }
+
+        List<AnswerMetric> metrics = answerMetricRepository.findByAnswerIdWithMetric(answer.getId());
+        Map<String, Integer> metricsMap = metrics.stream()
+                .collect(Collectors.toMap(
+                        AnswerMetric::getMetricName,
+                        AnswerMetric::getScore
+                ));
+
+        return new FeedbackResult(
+                status,
+                null,
+                metricsMap,
+                answer.getAiFeedback(),
+                answer.getUpdatedAt() != null
+                        ? answer.getUpdatedAt().atZone(java.time.ZoneId.systemDefault()).toInstant()
+                        : null
+        );
+    }
+}

--- a/src/main/java/com/ktb/answer/service/impl/AnswerCommandServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerCommandServiceImpl.java
@@ -8,8 +8,7 @@ import com.ktb.answer.exception.AnswerInvalidContentException;
 import com.ktb.answer.exception.DuplicateAnswerException;
 import com.ktb.answer.exception.InvalidAnswerContentException;
 import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
-import com.ktb.answer.repository.AnswerRepository;
-import com.ktb.answer.service.AnswerDomainService;
+import com.ktb.answer.service.AnswerCommandService;
 import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.exception.account.AccountNotFoundException;
 import com.ktb.auth.repository.UserAccountRepository;
@@ -23,25 +22,23 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class AnswerDomainServiceImpl implements AnswerDomainService {
+public class AnswerCommandServiceImpl implements AnswerCommandService {
 
     private static final int MAX_ANSWER_CONTENT_LENGTH = 1_500;
 
     private final QuestionRepository questionRepository;
     private final UserAccountRepository userAccountRepository;
-    private final AnswerRepository answerRepository;
 
     @Override
-    public Answer createAnswer(Long accountId, Long questionId, String answerContent, AnswerType type) {
+    public Answer create(Long accountId, Long questionId, String content, AnswerType type) {
         log.debug("Creating answer - accountId={}, questionId={}", accountId, questionId);
 
         UserAccount account = userAccountRepository.findById(accountId)
                 .orElseThrow(() -> new AccountNotFoundException(accountId));
-
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new QuestionNotFoundException(questionId));
 
-        return Answer.create(question, account, answerContent, type);
+        return Answer.create(question, account, content, type);
     }
 
     @Override
@@ -63,13 +60,13 @@ public class AnswerDomainServiceImpl implements AnswerDomainService {
     }
 
     @Override
-    public void checkDuplicateAnswer(String sessionId, Long questionId) throws DuplicateAnswerException {
+    public void checkDuplicate(String sessionId, Long questionId) throws DuplicateAnswerException {
         log.debug("Checking duplicate answer - sessionId={}, questionId={}", sessionId, questionId);
         // TODO: ANSWER_SESSION 엔티티 구현 후 활성화
     }
 
     @Override
-    public void validateAnswerContent(String answerText) throws InvalidAnswerContentException {
+    public void validateContent(String answerText) {
         log.debug("Validating answer content - hasText={}", answerText != null && !answerText.isBlank());
 
         boolean hasText = answerText != null && !answerText.isBlank();

--- a/src/main/java/com/ktb/answer/service/impl/AnswerQueryServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerQueryServiceImpl.java
@@ -1,0 +1,279 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.domain.policy.QuestionTypeFilterPolicy;
+import com.ktb.answer.dto.AiFeedbackSummary;
+import com.ktb.answer.dto.AnswerContentResult;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerListCursor;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.dto.QuestionSummary;
+import com.ktb.answer.dto.response.detail.AnswerQuestionInfo;
+import com.ktb.answer.dto.response.list.AnswerListResponse;
+import com.ktb.answer.dto.response.list.AnswerSummary;
+import com.ktb.answer.dto.response.list.FeedbackInfo;
+import com.ktb.answer.dto.response.list.PaginationInfo;
+import com.ktb.answer.exception.AnswerListInvalidInputException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AnswerQueryService;
+import com.ktb.answer.service.CursorCodec;
+import com.ktb.hashtag.domain.AnswerHashtag;
+import com.ktb.hashtag.repository.AnswerHashtagRepository;
+import com.ktb.interview.application.service.flow.InterviewSessionFeedbackQueryFlowService;
+import com.ktb.interview.session.dto.response.InterviewSessionFinalFeedbackResponse;
+import com.ktb.interview.session.exception.InterviewSessionInvalidStateException;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnswerQueryServiceImpl implements AnswerQueryService {
+
+    private final AnswerRepository answerRepository;
+    private final AnswerHashtagRepository answerHashtagRepository;
+    private final AnswerMetricRepository answerMetricRepository;
+    private final QuestionTypeFilterPolicy questionTypeFilterPolicy;
+    private final CursorCodec cursorCodec;
+    private final InterviewSessionFeedbackQueryFlowService interviewSessionFeedbackQueryFlowService;
+
+    @Override
+    public AnswerListResponse getList(
+            Long accountId,
+            AnswerType type,
+            QuestionCategory category,
+            QuestionType questionType,
+            LocalDate dateFrom,
+            LocalDate dateTo,
+            String cursor,
+            Integer limit
+    ) {
+        log.info("getAnswerList - accountId={}, type={}, category={}, questionType={}, dateFrom={}, dateTo={}, cursorProvided={}, limit={}",
+                accountId, type, category, questionType, dateFrom, dateTo,
+                cursor != null && !cursor.isBlank(), limit);
+
+        questionTypeFilterPolicy.validateOrThrow(questionType);
+        LocalDateRange dateRange = resolveDateRange(dateFrom, dateTo);
+        int resolvedLimit = resolveLimit(limit);
+        AnswerListCursor cursorPayload = cursorCodec.decode(cursor);
+        PageRequest pageRequest = PageRequest.of(0, resolvedLimit);
+
+        LocalDateTime from = dateRange.start().atStartOfDay();
+        LocalDateTime to = dateRange.end().atTime(LocalTime.MAX);
+
+        Slice<Answer> answers = cursorPayload == null
+                ? answerRepository.findByAccountIdWithFiltersNoCursor(
+                        accountId, type, category, questionType, from, to, pageRequest)
+                : answerRepository.findByAccountIdWithFilters(
+                        accountId, type, category, questionType, from, to,
+                        cursorPayload.lastCreatedAt(), cursorPayload.lastAnswerId(), pageRequest);
+
+        log.info("getAnswerList completed - accountId={}, fetchedSize={}, hasNext={}, resolvedLimit={}",
+                accountId, answers.getContent().size(), answers.hasNext(), resolvedLimit);
+
+        return toAnswerListResponse(answers, resolvedLimit);
+    }
+
+    @Override
+    public AnswerDetailResult getDetail(Long accountId, Long answerId) {
+        log.info("getAnswerDetail - accountId={}, answerId={}", accountId, answerId);
+
+        Answer answer = answerRepository.findByIdWithQuestion(answerId);
+        if (answer == null) {
+            log.warn("getAnswerDetail not found - accountId={}, answerId={}", accountId, answerId);
+            throw new AnswerNotFoundException(answerId);
+        }
+
+        if (!answer.isOwnedBy(accountId)) {
+            log.warn("Answer access denied - answerId={}, requestedAccountId={}", answerId, accountId);
+            throw new com.ktb.answer.exception.AnswerAccessDeniedException(answerId, accountId);
+        }
+
+        AnswerContentResult answerContent = new AnswerContentResult(
+                answer.getContent(),
+                null,
+                null,
+                answer.getCreatedAt() == null ? null : answer.getCreatedAt().toString()
+        );
+
+        boolean isRealInterview = answer.getType() == AnswerType.REAL_INTERVIEW;
+
+        QuestionSummary questionSummary = null;
+        if (!isRealInterview) {
+            Question question = answer.getQuestion();
+            questionSummary = new QuestionSummary(
+                    question.getId(),
+                    question.getContent(),
+                    question.getCategory().name(),
+                    question.getType().name()
+            );
+        }
+
+        ImmediateFeedbackResult immediateFeedback = null;
+        if (!isRealInterview) {
+            immediateFeedback = loadImmediateFeedback(answerId);
+        }
+
+        AiFeedbackSummary aiFeedback = null;
+        if (!isRealInterview) {
+            aiFeedback = loadAiFeedback(answer);
+        }
+
+        InterviewSessionFinalFeedbackResponse sessionFinalFeedback = null;
+        if (isRealInterview) {
+            sessionFinalFeedback = loadRealInterviewSessionFinalFeedback(accountId, answer);
+            log.debug("getAnswerDetail real mode session feedback resolved - accountId={}, answerId={}, hasFeedback={}",
+                    accountId, answerId, sessionFinalFeedback != null);
+        }
+
+        AnswerDetailResult result = new AnswerDetailResult(
+                answer.getId(),
+                answer.getStatus(),
+                answer.getType(),
+                questionSummary,
+                answerContent,
+                immediateFeedback,
+                aiFeedback,
+                sessionFinalFeedback
+        );
+
+        log.info("getAnswerDetail completed - accountId={}, answerId={}, status={}",
+                accountId, answerId, answer.getStatus());
+        return result;
+    }
+
+    private InterviewSessionFinalFeedbackResponse loadRealInterviewSessionFinalFeedback(Long accountId, Answer answer) {
+        if (answer.getStatus() != AnswerStatus.COMPLETED) {
+            return null;
+        }
+
+        String sessionId = answer.getSessionId();
+        if (sessionId == null || sessionId.isBlank()) {
+            log.warn("getAnswerDetail real mode sessionId missing - accountId={}, answerId={}",
+                    accountId, answer.getId());
+            return null;
+        }
+
+        try {
+            InterviewSessionFinalFeedbackResponse sessionFeedback =
+                    interviewSessionFeedbackQueryFlowService.getSessionFeedbackCompleted(accountId, sessionId);
+            return new InterviewSessionFinalFeedbackResponse(
+                    answer.getId(),
+                    sessionFeedback.userId(),
+                    sessionFeedback.questionId(),
+                    sessionFeedback.sessionId(),
+                    sessionFeedback.status(),
+                    sessionFeedback.badCaseFeedback(),
+                    sessionFeedback.metrics(),
+                    sessionFeedback.keywordResult(),
+                    sessionFeedback.topicsFeedback(),
+                    sessionFeedback.overallFeedback(),
+                    sessionFeedback.interviewHistory()
+            );
+        } catch (InterviewSessionInvalidStateException e) {
+            log.warn("getAnswerDetail real mode final feedback unavailable - accountId={}, answerId={}, sessionId={}, reason={}",
+                    accountId, answer.getId(), sessionId, e.getMessage());
+            return null;
+        }
+    }
+
+    private ImmediateFeedbackResult loadImmediateFeedback(Long answerId) {
+        List<AnswerHashtag> answerHashtags = answerHashtagRepository.findByAnswerIdWithHashtag(answerId);
+        List<KeywordCheckResult> keywords = answerHashtags.stream()
+                .map(ah -> new KeywordCheckResult(
+                        ah.getHashtag().getId(),
+                        ah.getHashtag().getName(),
+                        ah.isIncluded()
+                ))
+                .toList();
+        return new ImmediateFeedbackResult(keywords);
+    }
+
+    private AiFeedbackSummary loadAiFeedback(Answer answer) {
+        FeedbackStatus status = FeedbackStatus.from(answer.getStatus());
+        if (status != FeedbackStatus.COMPLETED) {
+            return new AiFeedbackSummary(status, null, null);
+        }
+
+        List<AnswerMetric> metrics = answerMetricRepository.findByAnswerIdWithMetric(answer.getId());
+        Map<String, Integer> metricsMap = metrics.stream()
+                .collect(Collectors.toMap(
+                        AnswerMetric::getMetricName,
+                        AnswerMetric::getScore
+                ));
+        return new AiFeedbackSummary(status, metricsMap, answer.getAiFeedback());
+    }
+
+    private LocalDateRange resolveDateRange(LocalDate dateFrom, LocalDate dateTo) {
+        LocalDate resolvedTo = dateTo == null ? LocalDate.now() : dateTo;
+        LocalDate resolvedFrom = dateFrom == null ? resolvedTo.minusMonths(1) : dateFrom;
+
+        if (resolvedFrom.isAfter(resolvedTo)) {
+            log.warn("Invalid date range - dateFrom={}, dateTo={}", resolvedFrom, resolvedTo);
+            throw new AnswerListInvalidInputException("dateFrom must be before or equal to dateTo");
+        }
+        return new LocalDateRange(resolvedFrom, resolvedTo);
+    }
+
+    private int resolveLimit(Integer limit) {
+        int resolved = limit == null ? 10 : limit;
+        if (resolved < 1 || resolved > 50) {
+            log.warn("Invalid list limit - limit={}", resolved);
+            throw new AnswerListInvalidInputException("limit must be between 1 and 50");
+        }
+        return resolved;
+    }
+
+    private AnswerListResponse toAnswerListResponse(Slice<Answer> answers, int limit) {
+        List<AnswerSummary> records = answers.getContent().stream()
+                .map(answer -> new AnswerSummary(
+                        answer.getId(),
+                        answer.getType().name(),
+                        answer.getCreatedAt() == null ? null : answer.getCreatedAt().toString(),
+                        new AnswerQuestionInfo(
+                                answer.getQuestion().getId(),
+                                answer.getQuestion().getContent(),
+                                answer.getQuestion().getCategory().name()
+                        ),
+                        toFeedbackInfo(answer)
+                ))
+                .toList();
+
+        String nextCursor = null;
+        if (answers.hasNext() && !answers.getContent().isEmpty()) {
+            Answer last = answers.getContent().getLast();
+            nextCursor = cursorCodec.encode(new AnswerListCursor(last.getCreatedAt(), last.getId()));
+        }
+
+        PaginationInfo pagination = new PaginationInfo(limit, answers.hasNext(), nextCursor);
+        return new AnswerListResponse(records, pagination);
+    }
+
+    private FeedbackInfo toFeedbackInfo(Answer answer) {
+        AnswerStatus status = answer.getStatus();
+        boolean available = status == AnswerStatus.COMPLETED;
+        return new FeedbackInfo(available, status.name());
+    }
+
+    private record LocalDateRange(LocalDate start, LocalDate end) {
+    }
+}

--- a/src/main/java/com/ktb/answer/service/impl/ImmediateFeedbackServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/ImmediateFeedbackServiceImpl.java
@@ -1,0 +1,64 @@
+package com.ktb.answer.service.impl;
+
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.service.ImmediateFeedbackService;
+import com.ktb.hashtag.domain.QuestionHashtag;
+import com.ktb.hashtag.repository.QuestionHashtagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImmediateFeedbackServiceImpl implements ImmediateFeedbackService {
+
+    private final QuestionHashtagRepository questionHashtagRepository;
+
+    @Override
+    public ImmediateFeedbackResult evaluate(Long questionId, String answerText) {
+        log.debug("Evaluating immediate feedback - questionId: {}", questionId);
+
+        List<QuestionHashtag> questionHashtags = extractKeywords(questionId);
+        List<KeywordCheckResult> keywordChecks = checkKeywords(answerText, questionHashtags);
+
+        return new ImmediateFeedbackResult(keywordChecks);
+    }
+
+    @Override
+    public List<QuestionHashtag> extractKeywords(Long questionId) {
+        List<QuestionHashtag> questionHashtags =
+            questionHashtagRepository.findKeywordNamesByQuestionId(questionId);
+
+        log.debug("Extracting keywords for questionId: {}", questionId);
+        return questionHashtags;
+    }
+
+    @Override
+    public List<KeywordCheckResult> checkKeywords(String answerText, List<QuestionHashtag> questionHashtags) {
+        log.debug("Checking keywords in answer text: keywordCount={}", questionHashtags.size());
+
+        String normalizedAnswerText = answerText.toLowerCase();
+
+        List<KeywordCheckResult> keywordChecks = questionHashtags.stream()
+            .map(qh -> {
+                String keyword = qh.getHashtag().getName();
+                boolean included = normalizedAnswerText.contains(keyword);
+
+                return new KeywordCheckResult(
+                    qh.getHashtag().getId(),
+                    keyword,
+                    included
+                );
+            })
+            .toList();
+
+        log.debug("Immediate feedback - total keywords: {}, included: {}",
+            keywordChecks.size(),
+            keywordChecks.stream().filter(KeywordCheckResult::included).count());
+
+        return keywordChecks;
+    }
+}

--- a/src/main/java/com/ktb/interview/application/service/InterviewFeedbackOrchestratorImpl.java
+++ b/src/main/java/com/ktb/interview/application/service/InterviewFeedbackOrchestratorImpl.java
@@ -63,11 +63,14 @@ public class InterviewFeedbackOrchestratorImpl implements InterviewFeedbackOrche
         log.info("generateFeedback - accountId={}, sessionId={}, answerId={}, interviewType={}, historySize={}, hashtagSize={}",
                 accountId, session.getSessionId(), answer.getId(), session.getInterviewType(), history.size(),
                 questionHashtags == null ? 0 : questionHashtags.size());
+
         List<String> keywords = resolveKeywordsForRequest();
         QuestionCategory historyCategory = question.getCategory();
+
         String aiCategory = session.getInterviewType() == AnswerType.REAL_INTERVIEW && historyCategory != null
                 ? toAiCategory(historyCategory.name())
                 : null;
+
         InterviewFeedbackRequest aiRequest = new InterviewFeedbackRequest(
                 accountId,
                 question.getId(),

--- a/src/main/java/com/ktb/interview/application/service/flow/FinalFeedbackAnchorResolver.java
+++ b/src/main/java/com/ktb/interview/application/service/flow/FinalFeedbackAnchorResolver.java
@@ -1,0 +1,71 @@
+package com.ktb.interview.application.service.flow;
+
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.interview.session.domain.InterviewHistoryItem;
+import com.ktb.interview.session.domain.InterviewQuestionSnapshot;
+import com.ktb.interview.session.domain.InterviewSession;
+import com.ktb.interview.session.exception.InterviewSessionInvalidStateException;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionType;
+import com.ktb.question.exception.QuestionNotFoundException;
+import com.ktb.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 세션 최종 피드백 생성 시 영속/통계용 질문 앵커를 선택합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FinalFeedbackAnchorResolver {
+
+    private static final String ERROR_PRACTICE_QUESTION_ID_MISSING =
+            "practice interview questionId is missing in session history";
+
+    private final QuestionRepository questionRepository;
+
+    /**
+     * 세션 타입에 따라 영속용 질문 앵커를 선택합니다.
+     */
+    public Question resolve(InterviewSession session, InterviewHistoryItem latestTurn) {
+        if (session.getInterviewType() == AnswerType.PRACTICE_INTERVIEW) {
+            if (latestTurn.questionId() == null) {
+                throw new InterviewSessionInvalidStateException(ERROR_PRACTICE_QUESTION_ID_MISSING);
+            }
+            return questionRepository.findById(latestTurn.questionId())
+                    .orElseThrow(() -> new QuestionNotFoundException(latestTurn.questionId()));
+        }
+        return resolvePersistenceQuestionForReal(session);
+    }
+
+    private Question resolvePersistenceQuestionForReal(InterviewSession session) {
+        Long initialQuestionId = session.getInitialQuestionId();
+        if (initialQuestionId != null) {
+            return questionRepository.findById(initialQuestionId)
+                    .orElseThrow(() -> new QuestionNotFoundException(initialQuestionId));
+        }
+
+        InterviewQuestionSnapshot snapshot = session.getCurrentQuestion();
+        QuestionType questionType = session.getQuestionType();
+        if (snapshot == null) {
+            return questionRepository.findRandomActiveByType(questionType.name())
+                    .orElseThrow(() -> new QuestionNotFoundException(0L));
+        }
+        if (snapshot.questionId() != null) {
+            return questionRepository.findById(snapshot.questionId())
+                    .orElseThrow(() -> new QuestionNotFoundException(snapshot.questionId()));
+        }
+        if (snapshot.category() != null) {
+            return questionRepository.findRandomActiveByTypeAndCategory(
+                            questionType.name(),
+                            snapshot.category().name()
+                    )
+                    .orElseGet(() -> questionRepository.findRandomActiveByType(questionType.name())
+                            .orElseThrow(() -> new QuestionNotFoundException(0L)));
+        }
+        return questionRepository.findRandomActiveByType(questionType.name())
+                .orElseThrow(() -> new QuestionNotFoundException(0L));
+    }
+}

--- a/src/main/java/com/ktb/interview/application/service/flow/FinalFeedbackAnswerFactory.java
+++ b/src/main/java/com/ktb/interview/application/service/flow/FinalFeedbackAnswerFactory.java
@@ -1,0 +1,31 @@
+package com.ktb.interview.application.service.flow;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.AnswerDomainService;
+import com.ktb.question.domain.Question;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FinalFeedbackAnswerFactory {
+
+    private final AnswerDomainService answerDomainService;
+    private final AnswerRepository answerRepository;
+
+    @Transactional
+    public Answer createAndSave(Long accountId, Question question, String answerText,
+                                String sessionId, AnswerType type) {
+        Answer answer = answerDomainService.createAnswer(accountId, question.getId(), answerText, type);
+        answer.assignSessionId(sessionId);
+        answerRepository.save(answer);
+        log.debug("FinalFeedbackAnswerFactory - created answer, answerId={}, sessionId={}",
+                answer.getId(), sessionId);
+        return answer;
+    }
+}

--- a/src/main/java/com/ktb/interview/application/service/flow/FinalFeedbackCompletionService.java
+++ b/src/main/java/com/ktb/interview/application/service/flow/FinalFeedbackCompletionService.java
@@ -1,0 +1,27 @@
+package com.ktb.interview.application.service.flow;
+
+import com.ktb.interview.dto.ai.InterviewFeedbackDataResponse;
+import com.ktb.interview.port.out.InterviewSessionFinalFeedbackStore;
+import com.ktb.interview.session.domain.InterviewSession;
+import com.ktb.interview.session.service.InterviewSessionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FinalFeedbackCompletionService {
+
+    private final InterviewSessionFinalFeedbackStore finalFeedbackStore;
+    private final InterviewSessionService interviewSessionService;
+
+    @Transactional
+    public void complete(InterviewSession session, InterviewFeedbackDataResponse feedback) {
+        session.markCompleted();
+        finalFeedbackStore.persistFinalFeedback(session, feedback);
+        interviewSessionService.deleteSession(session.getSessionId());
+        log.info("FinalFeedbackCompletionService - completed, sessionId={}", session.getSessionId());
+    }
+}

--- a/src/main/java/com/ktb/interview/application/service/flow/InterviewSessionFinalFeedbackFlowService.java
+++ b/src/main/java/com/ktb/interview/application/service/flow/InterviewSessionFinalFeedbackFlowService.java
@@ -1,17 +1,12 @@
 package com.ktb.interview.application.service.flow;
 
 import com.ktb.answer.domain.Answer;
-import com.ktb.answer.domain.AnswerType;
-import com.ktb.answer.repository.AnswerRepository;
-import com.ktb.answer.service.AnswerDomainService;
 import com.ktb.hashtag.domain.QuestionHashtag;
 import com.ktb.hashtag.repository.QuestionHashtagRepository;
 import com.ktb.interview.application.InterviewFeedbackOrchestrator;
 import com.ktb.interview.dto.ai.InterviewFeedbackDataResponse;
 import com.ktb.interview.mapper.InterviewSubmissionResponseMapper;
-import com.ktb.interview.port.out.InterviewSessionFinalFeedbackStore;
 import com.ktb.interview.session.domain.InterviewHistoryItem;
-import com.ktb.interview.session.domain.InterviewQuestionSnapshot;
 import com.ktb.interview.session.domain.InterviewSession;
 import com.ktb.interview.session.domain.InterviewSessionFeedback;
 import com.ktb.interview.session.domain.InterviewSessionStatus;
@@ -23,18 +18,14 @@ import com.ktb.interview.session.repository.InterviewSessionFeedbackRepository;
 import com.ktb.interview.session.service.InterviewSessionService;
 import com.ktb.interview.validator.InterviewSubmissionValidator;
 import com.ktb.question.domain.Question;
-import com.ktb.question.domain.QuestionType;
-import com.ktb.question.exception.QuestionNotFoundException;
-import com.ktb.question.repository.QuestionRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 세션 최종 피드백 생성/저장 플로우를 담당합니다.
+ * 세션 최종 피드백 생성/저장 플로우를 조율합니다.
  */
 @Service
 @RequiredArgsConstructor
@@ -44,27 +35,25 @@ public class InterviewSessionFinalFeedbackFlowService {
     private static final String SESSION_STATUS_COMPLETED = InterviewSessionStatus.COMPLETED.name();
     private static final String ERROR_EMPTY_INTERVIEW_HISTORY_FOR_FINAL_FEEDBACK =
             "interview history is empty for final feedback";
-    private static final String ERROR_PRACTICE_QUESTION_ID_MISSING =
-            "practice interview questionId is missing in session history";
 
-    private final AnswerRepository answerRepository;
-    private final AnswerDomainService answerDomainService;
-    private final QuestionRepository questionRepository;
-    private final QuestionHashtagRepository questionHashtagRepository;
     private final InterviewSessionService interviewSessionService;
-    private final InterviewSessionFinalFeedbackStore finalFeedbackStore;
     private final InterviewSubmissionValidator submissionValidator;
     private final InterviewSubmissionResponseMapper responseMapper;
     private final InterviewSessionFeedbackRepository feedbackRepository;
     private final InterviewFeedbackOrchestrator interviewFeedbackOrchestrator;
     private final InterviewFinalFeedbackPersistenceService finalFeedbackPersistenceService;
+    private final QuestionHashtagRepository questionHashtagRepository;
+    private final FinalFeedbackAnchorResolver anchorResolver;
+    private final FinalFeedbackAnswerFactory answerFactory;
+    private final FinalFeedbackCompletionService completionService;
 
     /**
      * 세션(연습/실전) 누적 이력 기반으로 최종 AI 피드백을 생성합니다.
      */
-    @Transactional
-    public InterviewSessionFinalFeedbackResponse requestSessionFinalFeedback(Long accountId, String sessionId, String clientIp) {
-        log.info("requestSessionFinalFeedback - accountId={}, sessionId={}, clientIp={}", accountId, sessionId, clientIp);
+    public InterviewSessionFinalFeedbackResponse requestSessionFinalFeedback(
+            Long accountId, String sessionId, String clientIp) {
+        log.info("requestSessionFinalFeedback - accountId={}, sessionId={}, clientIp={}",
+                accountId, sessionId, clientIp);
 
         InterviewSession session = interviewSessionService.getSession(accountId, sessionId);
         submissionValidator.validateSessionReadyForFinalFeedback(session);
@@ -72,11 +61,9 @@ public class InterviewSessionFinalFeedbackFlowService {
         Optional<InterviewSessionFeedback> cached = feedbackRepository.findBySessionId(sessionId);
         if (cached.isPresent()) {
             log.info("requestSessionFinalFeedback using cached feedback - sessionId={}", sessionId);
-            session.markCompleted();
             InterviewFeedbackDataResponse cachedFeedback = InterviewSessionFeedbackMapper.toDto(cached.get())
                     .withStatus(SESSION_STATUS_COMPLETED);
-            finalFeedbackStore.persistFinalFeedback(session, cachedFeedback);
-            interviewSessionService.deleteSession(session.getSessionId());
+            completionService.complete(session, cachedFeedback);
             return responseMapper.toSessionFinalFeedbackResponse(
                     cachedFeedback,
                     session.getInterviewType(),
@@ -89,24 +76,27 @@ public class InterviewSessionFinalFeedbackFlowService {
             log.warn("requestSessionFinalFeedback failed - empty history, sessionId={}", sessionId);
             throw new InterviewSessionInvalidStateException(ERROR_EMPTY_INTERVIEW_HISTORY_FOR_FINAL_FEEDBACK);
         }
-        log.debug("requestSessionFinalFeedback history resolved - sessionId={}, historySize={}", sessionId, history.size());
+        log.debug("requestSessionFinalFeedback history resolved - sessionId={}, historySize={}",
+                sessionId, history.size());
 
         InterviewHistoryItem latestTurn = history.get(history.size() - 1);
-        Question persistenceQuestion = resolvePersistenceQuestionForFinalFeedback(session, latestTurn);
+        Question persistenceQuestion = anchorResolver.resolve(session, latestTurn);
 
         String finalAnswerText = latestTurn.answerText();
         if (finalAnswerText == null || finalAnswerText.isBlank()) {
             finalAnswerText = "(final feedback request)";
         }
 
-        Answer answer = createProcessingAnswer(
+        Answer answer = answerFactory.createAndSave(
                 accountId,
                 persistenceQuestion,
                 finalAnswerText,
                 session.getSessionId(),
                 session.getInterviewType()
         );
-        List<QuestionHashtag> questionHashtags = questionHashtagRepository.findKeywordNamesByQuestionId(persistenceQuestion.getId());
+
+        List<QuestionHashtag> questionHashtags =
+                questionHashtagRepository.findKeywordNamesByQuestionId(persistenceQuestion.getId());
         log.debug("requestSessionFinalFeedback anchor resolved - sessionId={}, questionId={}, hashtagCount={}",
                 sessionId, persistenceQuestion.getId(), questionHashtags.size());
 
@@ -118,12 +108,12 @@ public class InterviewSessionFinalFeedbackFlowService {
                 history,
                 questionHashtags
         );
+
         finalFeedbackPersistenceService.persistAnswerFeedback(answer, feedback, questionHashtags);
 
         InterviewFeedbackDataResponse completed = responseMapper.toFinalSessionFeedbackResponse(feedback, answer.getId());
-        session.markCompleted();
-        finalFeedbackStore.persistFinalFeedback(session, completed);
-        interviewSessionService.deleteSession(session.getSessionId());
+        completionService.complete(session, completed);
+
         log.info("requestSessionFinalFeedback completed - accountId={}, sessionId={}, answerId={}",
                 accountId, sessionId, answer.getId());
         return responseMapper.toSessionFinalFeedbackResponse(
@@ -131,67 +121,5 @@ public class InterviewSessionFinalFeedbackFlowService {
                 session.getInterviewType(),
                 session.getInterviewHistoryView()
         );
-    }
-
-    /**
-     * AI 처리 상태의 Answer 엔티티를 생성하고 세션 ID를 연결해 저장합니다.
-     */
-    private Answer createProcessingAnswer(
-            Long accountId,
-            Question question,
-            String answerText,
-            String sessionId,
-            AnswerType answerType
-    ) {
-        Answer answer = answerDomainService.createAnswer(accountId, question.getId(), answerText, answerType);
-        answer.assignSessionId(sessionId);
-        answerRepository.save(answer);
-        return answer;
-    }
-
-    /**
-     * 세션 최종 피드백 생성 시 영속/통계용 질문 앵커를 선택합니다.
-     */
-    private Question resolvePersistenceQuestionForFinalFeedback(InterviewSession session, InterviewHistoryItem latestTurn) {
-        if (session.getInterviewType() == AnswerType.PRACTICE_INTERVIEW) {
-            if (latestTurn.questionId() == null) {
-                throw new InterviewSessionInvalidStateException(ERROR_PRACTICE_QUESTION_ID_MISSING);
-            }
-            return questionRepository.findById(latestTurn.questionId())
-                    .orElseThrow(() -> new QuestionNotFoundException(latestTurn.questionId()));
-        }
-        return resolvePersistenceQuestionForReal(session);
-    }
-
-    /**
-     * real 모드에서 현재 질문 snapshot에 DB 질문 ID가 없을 수 있어, 영속/통계용 질문 앵커를 선택합니다.
-     */
-    private Question resolvePersistenceQuestionForReal(InterviewSession session) {
-        Long initialQuestionId = session.getInitialQuestionId();
-        if (initialQuestionId != null) {
-            return questionRepository.findById(initialQuestionId)
-                    .orElseThrow(() -> new QuestionNotFoundException(initialQuestionId));
-        }
-
-        InterviewQuestionSnapshot snapshot = session.getCurrentQuestion();
-        QuestionType questionType = session.getQuestionType();
-        if (snapshot == null) {
-            return questionRepository.findRandomActiveByType(questionType.name())
-                    .orElseThrow(() -> new QuestionNotFoundException(0L));
-        }
-        if (snapshot.questionId() != null) {
-            return questionRepository.findById(snapshot.questionId())
-                    .orElseThrow(() -> new QuestionNotFoundException(snapshot.questionId()));
-        }
-        if (snapshot.category() != null) {
-            return questionRepository.findRandomActiveByTypeAndCategory(
-                            questionType.name(),
-                            snapshot.category().name()
-                    )
-                    .orElseGet(() -> questionRepository.findRandomActiveByType(questionType.name())
-                            .orElseThrow(() -> new QuestionNotFoundException(0L)));
-        }
-        return questionRepository.findRandomActiveByType(questionType.name())
-                .orElseThrow(() -> new QuestionNotFoundException(0L));
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -149,6 +149,17 @@ springdoc:
     tags-sorter: alpha
     display-request-duration: true
 
+answer:
+  feedback:
+    rabbitmq:
+      enabled: false  # RabbitMQ 기반 비동기 AI 피드백 활성화 여부
+      exchange: answer.direct
+      dlx: answer.dlx
+      queue: answer.feedback-processing
+      dlq: answer.feedback-processing.dlq
+      routing-key: answer.feedback-processing
+      dlq-routing-key: dlq.answer.feedback-processing
+
 abuse:
   guard:
     # Rate Limit

--- a/src/test/java/com/ktb/ai/feedback/classifier/DefaultAiFeedbackOutcomeClassifierTest.java
+++ b/src/test/java/com/ktb/ai/feedback/classifier/DefaultAiFeedbackOutcomeClassifierTest.java
@@ -1,0 +1,40 @@
+package com.ktb.ai.feedback.classifier;
+
+import com.ktb.ai.feedback.dto.response.AiFeedbackBadCaseFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("DefaultAiFeedbackOutcomeClassifier 단위 테스트")
+class DefaultAiFeedbackOutcomeClassifierTest {
+
+    private final DefaultAiFeedbackOutcomeClassifier classifier = new DefaultAiFeedbackOutcomeClassifier();
+
+    @Test
+    @DisplayName("badCaseFeedback이 null이면 NORMAL을 반환한다")
+    void classify_badCaseFeedbackNull_returnsNormal() {
+        AiFeedbackResponse response = new AiFeedbackResponse(
+            null, null, null, null, null, null, null, null, null
+        );
+
+        FeedbackOutcome outcome = classifier.classify(response);
+
+        assertThat(outcome).isEqualTo(FeedbackOutcome.NORMAL);
+    }
+
+    @Test
+    @DisplayName("badCaseFeedback이 존재하면 BAD_CASE를 반환한다")
+    void classify_badCaseFeedbackPresent_returnsBadCase() {
+        AiFeedbackBadCaseFeedback badCaseFeedback = mock(AiFeedbackBadCaseFeedback.class);
+        AiFeedbackResponse response = new AiFeedbackResponse(
+            null, null, null, null, null, null, badCaseFeedback, null, null
+        );
+
+        FeedbackOutcome outcome = classifier.classify(response);
+
+        assertThat(outcome).isEqualTo(FeedbackOutcome.BAD_CASE);
+    }
+}

--- a/src/test/java/com/ktb/answer/controller/AnswerControllerTest.java
+++ b/src/test/java/com/ktb/answer/controller/AnswerControllerTest.java
@@ -11,7 +11,7 @@ import com.ktb.answer.domain.AnswerType;
 import com.ktb.answer.dto.AnswerDetailResult;
 import com.ktb.answer.dto.response.detail.AnswerDetailResponse;
 import com.ktb.answer.exception.AnswerDetailInvalidInputException;
-import com.ktb.answer.service.AnswerDomainService;
+import com.ktb.answer.service.AnswerQueryService;
 import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.common.dto.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,13 +29,13 @@ import org.springframework.http.ResponseEntity;
 class AnswerControllerTest {
 
     @Mock
-    private AnswerDomainService answerDomainService;
+    private AnswerQueryService answerQueryService;
 
     @Test
     @DisplayName("답변 상세 조회에서 쿼리 파라미터가 있으면 INVALID_INPUT 예외를 반환한다")
     void getAnswerDetail_WithQueryParams_ShouldThrowInvalidInput() {
         // Given
-        AnswerController controller = new AnswerController(answerDomainService);
+        AnswerController controller = new AnswerController(answerQueryService);
         SecurityUserAccount principal = new SecurityUserAccount(1L, "tester", List.of("ROLE_USER"));
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -44,14 +44,14 @@ class AnswerControllerTest {
         // When & Then
         assertThatThrownBy(() -> controller.getAnswerDetail(principal, 100L, request))
                 .isInstanceOf(AnswerDetailInvalidInputException.class);
-        verifyNoInteractions(answerDomainService);
+        verifyNoInteractions(answerQueryService);
     }
 
     @Test
     @DisplayName("답변 상세 조회에서 쿼리 파라미터가 없으면 상세 응답을 반환한다")
     void getAnswerDetail_WithoutQueryParams_ShouldReturnDetail() {
         // Given
-        AnswerController controller = new AnswerController(answerDomainService);
+        AnswerController controller = new AnswerController(answerQueryService);
         SecurityUserAccount principal = new SecurityUserAccount(1L, "tester", List.of("ROLE_USER"));
 
         HttpServletRequest request = mock(HttpServletRequest.class);
@@ -67,13 +67,13 @@ class AnswerControllerTest {
                 null,
                 null
         );
-        when(answerDomainService.getDetail(1L, 100L)).thenReturn(result);
+        when(answerQueryService.getDetail(1L, 100L)).thenReturn(result);
 
         // When
         ResponseEntity<ApiResponse<AnswerDetailResponse>> response = controller.getAnswerDetail(principal, 100L, request);
 
         // Then
-        verify(answerDomainService).getDetail(1L, 100L);
+        verify(answerQueryService).getDetail(1L, 100L);
         org.assertj.core.api.Assertions.assertThat(response.getBody()).isNotNull();
         org.assertj.core.api.Assertions.assertThat(response.getBody().data()).isNotNull();
         org.assertj.core.api.Assertions.assertThat(response.getBody().data().answerId()).isEqualTo(100L);

--- a/src/test/java/com/ktb/answer/domain/policy/AllowedQuestionTypeFilterPolicyTest.java
+++ b/src/test/java/com/ktb/answer/domain/policy/AllowedQuestionTypeFilterPolicyTest.java
@@ -1,0 +1,54 @@
+package com.ktb.answer.domain.policy;
+
+import com.ktb.answer.exception.AnswerListInvalidInputException;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AllowedQuestionTypeFilterPolicy 단위 테스트")
+class AllowedQuestionTypeFilterPolicyTest {
+
+    private final AllowedQuestionTypeFilterPolicy policy = new AllowedQuestionTypeFilterPolicy();
+
+    @Test
+    @DisplayName("CS는 허용된다")
+    void isSatisfiedBy_CS_returnsTrue() {
+        assertThat(policy.isSatisfiedBy(QuestionType.CS)).isTrue();
+    }
+
+    @Test
+    @DisplayName("PORTFOLIO 허용되지 않는다")
+    void isSatisfiedBy_Portfolio_returnsFalse() {
+        assertThat(policy.isSatisfiedBy(QuestionType.PORTFOLIO)).isFalse();
+    }
+
+    @Test
+    @DisplayName("SYSTEM_DESIGN 허용된다")
+    void isSatisfiedBy_SystemDesign_returnsTrue() {
+        assertThat(policy.isSatisfiedBy(QuestionType.SYSTEM_DESIGN)).isTrue();
+    }
+
+    @Test
+    @DisplayName("null 타입은 예외 없이 통과한다")
+    void validateOrThrow_nullType_doesNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.validateOrThrow(null));
+    }
+
+    @Test
+    @DisplayName("허용된 타입은 예외 없이 통과한다")
+    void validateOrThrow_allowedType_doesNotThrow() {
+        assertThatNoException().isThrownBy(() -> policy.validateOrThrow(QuestionType.CS));
+        assertThatNoException().isThrownBy(() -> policy.validateOrThrow(QuestionType.SYSTEM_DESIGN));
+    }
+
+    @Test
+    @DisplayName("PORTFOLIO 타입은 AnswerListInvalidInputException을 던진다")
+    void validateOrThrow_portfolio_throwsException() {
+        assertThatThrownBy(() -> policy.validateOrThrow(QuestionType.PORTFOLIO))
+            .isInstanceOf(AnswerListInvalidInputException.class);
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AiFeedbackOrchestratorTest.java
+++ b/src/test/java/com/ktb/answer/service/AiFeedbackOrchestratorTest.java
@@ -1,0 +1,376 @@
+package com.ktb.answer.service;
+
+import com.ktb.ai.feedback.classifier.AiFeedbackOutcomeClassifier;
+import com.ktb.ai.feedback.classifier.FeedbackOutcome;
+import com.ktb.ai.feedback.dto.response.AiFeedbackBadCaseFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackFeedback;
+import com.ktb.ai.feedback.dto.response.AiFeedbackMetric;
+import com.ktb.ai.feedback.dto.response.AiFeedbackResponse;
+import com.ktb.ai.feedback.dto.response.BadCaseType;
+import com.ktb.ai.feedback.service.AiFeedbackService;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.response.feedback.FeedbackResponse;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.impl.AiFeedbackOrchestratorImpl;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.common.dto.ApiResponse;
+import com.ktb.metric.domain.Metric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.metric.repository.MetricRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AiFeedbackOrchestrator 단위 테스트")
+class AiFeedbackOrchestratorTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @Mock
+    private AnswerDomainService answerDomainService;
+
+    @Mock
+    private AiFeedbackService aiFeedbackService;
+
+    @Mock
+    private MetricRepository metricRepository;
+
+    @Mock
+    private AnswerMetricRepository answerMetricRepository;
+
+    @Mock
+    private AiFeedbackOutcomeClassifier aiFeedbackOutcomeClassifier;
+
+    @InjectMocks
+    private AiFeedbackOrchestratorImpl aiFeedbackOrchestrator;
+
+    private static final Long ACCOUNT_ID = 1L;
+    private static final Long ANSWER_ID = 100L;
+    private static final Long QUESTION_ID = 200L;
+
+    @Nested
+    @DisplayName("getFeedbackSync() 테스트")
+    class GetFeedbackSyncTest {
+
+        @Test
+        @DisplayName("정상 응답 시 COMPLETED 상태와 피드백 반환")
+        void getFeedbackSync_WithSuccessResponse_ShouldReturnCompleted() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = createSuccessAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(aiFeedbackOutcomeClassifier.classify(any())).thenReturn(FeedbackOutcome.NORMAL);
+            when(metricRepository.findAllByNameIn(anyList())).thenReturn(Collections.emptyList());
+            when(metricRepository.save(any(Metric.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            FeedbackResponse result = aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo("COMPLETED");
+            assertThat(result.feedback()).isNotNull();
+            assertThat(result.radarChart()).isNotNull();
+            verify(answerRepository).save(mockAnswer);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 AnswerNotFoundException 발생")
+        void getFeedbackSync_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("권한 없는 사용자 접근 시 AnswerAccessDeniedException 발생")
+        void getFeedbackSync_WithUnauthorizedUser_ShouldThrowException() {
+            // Given
+            Long otherAccountId = 999L;
+            Answer mockAnswer = createMockAnswer();
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            doThrow(new AnswerAccessDeniedException(ANSWER_ID, otherAccountId))
+                    .when(answerDomainService).validateOwnership(mockAnswer, otherAccountId);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, otherAccountId))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("bad_case 응답 시 실패 피드백 반환")
+        void getFeedbackSync_WithBadCaseResponse_ShouldReturnFailed() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse badCaseResponse = createBadCaseAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("bad_case_detected", badCaseResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(aiFeedbackOutcomeClassifier.classify(any())).thenReturn(FeedbackOutcome.BAD_CASE);
+
+            // When
+            FeedbackResponse result = aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo("COMPLETED");
+            assertThat(result.feedback()).contains(BadCaseType.TOO_SHORT.getMessage());
+            assertThat(result.radarChart()).isNull();
+            verify(answerRepository).save(mockAnswer);
+        }
+
+        @Test
+        @DisplayName("메트릭 저장 성공")
+        void getFeedbackSync_ShouldSaveMetrics() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = createSuccessAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(aiFeedbackOutcomeClassifier.classify(any())).thenReturn(FeedbackOutcome.NORMAL);
+            when(metricRepository.findAllByNameIn(anyList())).thenReturn(Collections.emptyList());
+            when(metricRepository.save(any(Metric.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            verify(answerMetricRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("빈 메트릭 응답 시 메트릭 저장 스킵")
+        void getFeedbackSync_WithEmptyMetrics_ShouldSkipMetricSave() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = new AiFeedbackResponse(
+                    ACCOUNT_ID, QUESTION_ID, "PRACTICE_INTERVIEW", "CS", "DB",
+                    null, null, false,
+                    new AiFeedbackFeedback("강점입니다.", "개선사항입니다.")
+            );
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(aiFeedbackOutcomeClassifier.classify(any())).thenReturn(FeedbackOutcome.NORMAL);
+
+            // When
+            aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            verify(answerMetricRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("레이더 차트 데이터 정상 변환")
+        void getFeedbackSync_ShouldConvertRadarChartCorrectly() {
+            // Given
+            Answer mockAnswer = createMockAnswer();
+            AiFeedbackResponse aiResponse = createSuccessAiFeedbackResponse();
+            ApiResponse<AiFeedbackResponse> apiResponse = new ApiResponse<>("success", aiResponse);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(aiFeedbackService.evaluateSync(any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(apiResponse);
+            when(aiFeedbackOutcomeClassifier.classify(any())).thenReturn(FeedbackOutcome.NORMAL);
+            when(metricRepository.findAllByNameIn(anyList())).thenReturn(Collections.emptyList());
+            when(metricRepository.save(any(Metric.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            FeedbackResponse result = aiFeedbackOrchestrator.getFeedbackSync(ANSWER_ID, ACCOUNT_ID);
+
+            // Then
+            assertThat(result.radarChart()).hasSize(2);
+            assertThat(result.radarChart().get(0).metricName()).isEqualTo("논리성");
+            assertThat(result.radarChart().get(0).score()).isEqualTo(4);
+            assertThat(result.radarChart().get(0).maxScore()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("getStatus() 테스트")
+    class GetStatusTest {
+
+        @Test
+        @DisplayName("AI_FEEDBACK_PROCESSING 상태 매핑")
+        void getStatus_WithProcessing_ShouldReturnProcessing() {
+            // Given
+            Answer mockAnswer = mock(Answer.class);
+            when(mockAnswer.getStatus()).thenReturn(AnswerStatus.AI_FEEDBACK_PROCESSING);
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackStatus result = aiFeedbackOrchestrator.getStatus(ANSWER_ID);
+
+            // Then
+            assertThat(result).isEqualTo(FeedbackStatus.PROCESSING);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태 매핑")
+        void getStatus_WithCompleted_ShouldReturnCompleted() {
+            // Given
+            Answer mockAnswer = mock(Answer.class);
+            when(mockAnswer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackStatus result = aiFeedbackOrchestrator.getStatus(ANSWER_ID);
+
+            // Then
+            assertThat(result).isEqualTo(FeedbackStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태 매핑")
+        void getStatus_WithFailed_ShouldReturnFailed() {
+            // Given
+            Answer mockAnswer = mock(Answer.class);
+            when(mockAnswer.getStatus()).thenReturn(AnswerStatus.FAILED);
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackStatus result = aiFeedbackOrchestrator.getStatus(ANSWER_ID);
+
+            // Then
+            assertThat(result).isEqualTo(FeedbackStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 예외 발생")
+        void getStatus_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.getStatus(ANSWER_ID))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("enqueue() 테스트")
+    class EnqueueTest {
+
+        @Test
+        @DisplayName("enqueue 호출 시 경고 로그만 출력 (미구현)")
+        void enqueue_ShouldLogWarning() {
+            // When & Then (예외 없이 호출 가능)
+            aiFeedbackOrchestrator.enqueue(ANSWER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("requestRetry() 테스트")
+    class RequestRetryTest {
+
+        @Test
+        @DisplayName("requestRetry 호출 시 UnsupportedOperationException 발생")
+        void requestRetry_ShouldThrowUnsupportedOperationException() {
+            // When & Then
+            assertThatThrownBy(() ->
+                    aiFeedbackOrchestrator.requestRetry(ANSWER_ID))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("not yet implemented");
+        }
+    }
+
+    // Helper methods
+
+    private Answer createMockAnswer() {
+        Answer answer = mock(Answer.class);
+        Question question = mock(Question.class);
+        UserAccount account = mock(UserAccount.class);
+
+        when(answer.getId()).thenReturn(ANSWER_ID);
+        when(answer.getQuestion()).thenReturn(question);
+        when(answer.getAccount()).thenReturn(account);
+        when(answer.getContent()).thenReturn("테스트 답변 내용");
+        when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+
+        when(question.getId()).thenReturn(QUESTION_ID);
+        when(question.getContent()).thenReturn("테스트 질문");
+        when(question.getType()).thenReturn(QuestionType.CS);
+        when(question.getCategory()).thenReturn(QuestionCategory.DB);
+
+        when(account.getId()).thenReturn(ACCOUNT_ID);
+
+        return answer;
+    }
+
+    private AiFeedbackResponse createSuccessAiFeedbackResponse() {
+        List<AiFeedbackMetric> metrics = List.of(
+                new AiFeedbackMetric("논리성", 4, "논리적으로 잘 설명했습니다."),
+                new AiFeedbackMetric("명확성", 5, "매우 명확하게 답변했습니다.")
+        );
+
+        AiFeedbackFeedback feedback = new AiFeedbackFeedback(
+                "강점: 논리적인 설명",
+                "개선사항: 더 구체적인 예시 필요"
+        );
+
+        return new AiFeedbackResponse(
+                ACCOUNT_ID, QUESTION_ID, "PRACTICE_INTERVIEW", "CS", "DB",
+                metrics, null, false, feedback
+        );
+    }
+
+    private AiFeedbackResponse createBadCaseAiFeedbackResponse() {
+        AiFeedbackBadCaseFeedback badCaseFeedback = new AiFeedbackBadCaseFeedback(
+                "TOO_SHORT",
+                BadCaseType.TOO_SHORT.getMessage(),
+                BadCaseType.TOO_SHORT.getGuidance()
+        );
+
+        return new AiFeedbackResponse(
+                ACCOUNT_ID, QUESTION_ID, "PRACTICE_INTERVIEW", "CS", "DB",
+                null, badCaseFeedback, null, null
+        );
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
@@ -1,0 +1,501 @@
+package com.ktb.answer.service;
+
+import com.ktb.abuse.core.AbuseCheckContext;
+import com.ktb.abuse.core.AbuseGuard;
+import com.ktb.abuse.core.AbuseGuardResult;
+import com.ktb.answer.config.AnswerFeedbackProperties;
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.dto.AnswerDetailQuery;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.dto.AnswerSubmitCommand;
+import com.ktb.answer.dto.AnswerSubmitResult;
+import com.ktb.answer.dto.FeedbackResult;
+import com.ktb.answer.dto.FeedbackStatus;
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.dto.response.list.AnswerListResponse;
+import com.ktb.answer.exception.AnswerAccessDeniedException;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.impl.AnswerApplicationServiceImpl;
+import com.ktb.auth.domain.UserAccount;
+import com.ktb.hashtag.domain.Hashtag;
+import com.ktb.hashtag.exception.HashtagNotFoundException;
+import com.ktb.hashtag.repository.AnswerHashtagRepository;
+import com.ktb.hashtag.repository.HashtagRepository;
+import com.ktb.metric.domain.AnswerMetric;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.notification.repository.NotificationOutboxRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AnswerApplicationService 단위 테스트")
+class AnswerApplicationServiceTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @Mock
+    private AnswerCommandService answerCommandService;
+
+    @Mock
+    private AnswerQueryService answerQueryService;
+
+    @Mock
+    private ImmediateFeedbackService immediateFeedbackService;
+
+    @Mock
+    private AnswerHashtagRepository answerHashtagRepository;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @Mock
+    private AnswerMetricRepository answerMetricRepository;
+
+    @Mock
+    private AbuseGuard abuseGuard;
+
+    @Mock
+    private NotificationOutboxRepository notificationOutboxRepository;
+
+    private AnswerApplicationServiceImpl answerApplicationService;
+
+    private static final Long ACCOUNT_ID = 1L;
+    private static final Long QUESTION_ID = 100L;
+    private static final Long ANSWER_ID = 1000L;
+    private static final String CLIENT_IP = "127.0.0.1";
+    private static final String VALID_ANSWER_TEXT = "유효한 답변 텍스트입니다.";
+
+    @BeforeEach
+    void setUp() {
+        AnswerFeedbackProperties props = new AnswerFeedbackProperties();
+        answerApplicationService = new AnswerApplicationServiceImpl(
+                answerRepository,
+                answerCommandService,
+                answerQueryService,
+                immediateFeedbackService,
+                answerHashtagRepository,
+                hashtagRepository,
+                answerMetricRepository,
+                abuseGuard,
+                props,
+                notificationOutboxRepository
+        );
+    }
+
+    @Nested
+    @DisplayName("submit() 테스트")
+    class SubmitTest {
+
+        @Test
+        @DisplayName("정상 제출 시 PROCESSING 상태로 결과 반환")
+        void submit_WithValidData_ShouldReturnProcessingResult() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.accept();
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(
+                    List.of(new KeywordCheckResult(1L, "키워드1", true))
+            );
+            Hashtag mockHashtag = mock(Hashtag.class);
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerCommandService.create(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+            when(hashtagRepository.findById(anyLong())).thenReturn(Optional.of(mockHashtag));
+
+            // When
+            AnswerSubmitResult result = answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.answerId()).isEqualTo(ANSWER_ID);
+            assertThat(result.aiFeedbackStatus()).isEqualTo(FeedbackStatus.PROCESSING);
+            verify(answerCommandService).validateContent(VALID_ANSWER_TEXT);
+            verify(answerHashtagRepository).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("abuse 체크 실패 시 NOT_AVAILABLE 상태 반환")
+        void submit_WithAbuseNoFeedback_ShouldReturnNotAvailable() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.acceptNoFeedback(
+                    "ContentQualityGuard",
+                    "Low quality content",
+                    30
+            );
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(Collections.emptyList());
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerCommandService.create(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+
+            // When
+            AnswerSubmitResult result = answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.answerId()).isEqualTo(ANSWER_ID);
+            assertThat(result.aiFeedbackStatus()).isEqualTo(FeedbackStatus.NOT_AVAILABLE);
+            verify(answerCommandService).transitionStatus(mockAnswer, AnswerStatus.NOT_AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("해시태그 미존재 시 HashtagNotFoundException 발생")
+        void submit_WithNonExistentHashtag_ShouldThrowException() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.accept();
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(
+                    List.of(new KeywordCheckResult(999L, "존재하지않는키워드", true))
+            );
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerCommandService.create(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+            when(hashtagRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP))
+                    .isInstanceOf(HashtagNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("빈 키워드 목록일 때 해시태그 저장 호출")
+        void submit_WithEmptyKeywords_ShouldSaveEmptyHashtags() {
+            // Given
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.PRACTICE_INTERVIEW
+            );
+
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.SUBMITTED);
+            AbuseGuardResult abuseResult = AbuseGuardResult.accept();
+            ImmediateFeedbackResult immediateFeedback = new ImmediateFeedbackResult(Collections.emptyList());
+
+            when(abuseGuard.check(any(AbuseCheckContext.class))).thenReturn(abuseResult);
+            when(answerCommandService.create(anyLong(), anyLong(), anyString(), any()))
+                    .thenReturn(mockAnswer);
+            when(answerRepository.save(any(Answer.class))).thenReturn(mockAnswer);
+            when(immediateFeedbackService.evaluate(eq(QUESTION_ID), anyString()))
+                    .thenReturn(immediateFeedback);
+
+            // When
+            AnswerSubmitResult result = answerApplicationService.submit(ACCOUNT_ID, command, CLIENT_IP);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.aiFeedbackStatus()).isEqualTo(FeedbackStatus.PROCESSING);
+            verify(answerHashtagRepository).saveAll(Collections.emptyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("getList() 테스트")
+    class GetListTest {
+
+        @Test
+        @DisplayName("목록 조회는 AnswerQueryService에 위임")
+        void getList_ShouldDelegateToQueryService() {
+            // Given
+            AnswerListResponse expected = mock(AnswerListResponse.class);
+            LocalDate dateFrom = LocalDate.now().minusDays(7);
+            LocalDate dateTo = LocalDate.now();
+
+            when(answerQueryService.getList(
+                    eq(ACCOUNT_ID), isNull(), isNull(), isNull(),
+                    eq(dateFrom), eq(dateTo), isNull(), eq(10)))
+                    .thenReturn(expected);
+
+            // When
+            AnswerListResponse result = answerApplicationService.getList(
+                    ACCOUNT_ID, null, null, null, dateFrom, dateTo, null, 10
+            );
+
+            // Then
+            assertThat(result).isSameAs(expected);
+            verify(answerQueryService).getList(
+                    eq(ACCOUNT_ID), isNull(), isNull(), isNull(),
+                    eq(dateFrom), eq(dateTo), isNull(), eq(10));
+        }
+    }
+
+    @Nested
+    @DisplayName("getDetail() 테스트")
+    class GetDetailTest {
+
+        @Test
+        @DisplayName("상세 조회는 AnswerQueryService에 위임")
+        void getDetail_ShouldDelegateToQueryService() {
+            // Given
+            AnswerDetailResult expected = mock(AnswerDetailResult.class);
+            when(answerQueryService.getDetail(ACCOUNT_ID, ANSWER_ID)).thenReturn(expected);
+
+            // When
+            AnswerDetailResult result = answerApplicationService.getDetail(
+                    ACCOUNT_ID, ANSWER_ID, AnswerDetailQuery.empty()
+            );
+
+            // Then
+            assertThat(result).isSameAs(expected);
+            verify(answerQueryService).getDetail(ACCOUNT_ID, ANSWER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("getFeedback() 테스트")
+    class GetFeedbackTest {
+
+        @Test
+        @DisplayName("존재하지 않는 답변의 피드백 조회 시 예외 발생")
+        void getFeedback_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("PROCESSING 상태일 때 estimatedTimeSeconds 포함")
+        void getFeedback_WithProcessingStatus_ShouldIncludeEstimatedTime() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.AI_FEEDBACK_PROCESSING);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.PROCESSING);
+            assertThat(result.estimatedTimeSeconds()).isEqualTo(30);
+            assertThat(result.metrics()).isNull();
+            assertThat(result.comment()).isNull();
+        }
+
+        @Test
+        @DisplayName("NOT_AVAILABLE 상태일 때 metrics, comment가 null")
+        void getFeedback_WithNotAvailableStatus_ShouldReturnEmptyFeedback() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.NOT_AVAILABLE);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.NOT_AVAILABLE);
+            assertThat(result.estimatedTimeSeconds()).isNull();
+            assertThat(result.metrics()).isNull();
+        }
+
+        @Test
+        @DisplayName("FAILED 상태일 때 적절한 응답 반환")
+        void getFeedback_WithFailedStatus_ShouldReturnFailedResponse() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.FAILED);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.FAILED);
+            assertThat(result.estimatedTimeSeconds()).isNull();
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태일 때 metrics와 comment 포함")
+        void getFeedback_WithCompletedStatus_ShouldIncludeMetrics() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.COMPLETED);
+            String aiFeedback = "잘 답변하셨습니다.";
+            when(mockAnswer.getAiFeedback()).thenReturn(aiFeedback);
+            when(mockAnswer.getUpdatedAt()).thenReturn(LocalDateTime.now());
+
+            AnswerMetric metric = mock(AnswerMetric.class);
+            when(metric.getMetricName()).thenReturn("논리성");
+            when(metric.getScore()).thenReturn(85);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(answerMetricRepository.findByAnswerIdWithMetric(ANSWER_ID))
+                    .thenReturn(List.of(metric));
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.COMPLETED);
+            assertThat(result.metrics()).containsEntry("논리성", 85);
+            assertThat(result.comment()).isEqualTo(aiFeedback);
+            assertThat(result.completedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("빈 metrics 리스트일 때 빈 Map 반환")
+        void getFeedback_WithEmptyMetrics_ShouldReturnEmptyMap() {
+            // Given
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.COMPLETED);
+            when(mockAnswer.getAiFeedback()).thenReturn("피드백 내용");
+            when(mockAnswer.getUpdatedAt()).thenReturn(LocalDateTime.now());
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            when(answerMetricRepository.findByAnswerIdWithMetric(ANSWER_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            FeedbackResult result = answerApplicationService.getFeedback(ACCOUNT_ID, ANSWER_ID);
+
+            // Then
+            assertThat(result.status()).isEqualTo(FeedbackStatus.COMPLETED);
+            assertThat(result.metrics()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 피드백 조회 시 예외 발생")
+        void getFeedback_WithOtherUserAnswer_ShouldThrowException() {
+            // Given
+            Long otherAccountId = 999L;
+            Answer mockAnswer = createMockAnswer(ANSWER_ID, ACCOUNT_ID, AnswerStatus.COMPLETED);
+
+            when(answerRepository.findById(ANSWER_ID)).thenReturn(Optional.of(mockAnswer));
+            doThrow(new AnswerAccessDeniedException(ANSWER_ID, otherAccountId))
+                    .when(answerCommandService).validateOwnership(mockAnswer, otherAccountId);
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.getFeedback(otherAccountId, ANSWER_ID))
+                    .isInstanceOf(AnswerAccessDeniedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("submitWithSession() 테스트")
+    class SubmitWithSessionTest {
+
+        @Test
+        @DisplayName("세션 기반 제출은 아직 미구현으로 UnsupportedOperationException 발생")
+        void submitWithSession_ShouldThrowUnsupportedOperationException() {
+            // Given
+            String sessionId = "session-123";
+            AnswerSubmitCommand command = new AnswerSubmitCommand(
+                    QUESTION_ID,
+                    VALID_ANSWER_TEXT,
+                    AnswerType.REAL_INTERVIEW
+            );
+
+            // When & Then
+            assertThatThrownBy(() ->
+                    answerApplicationService.submitWithSession(ACCOUNT_ID, sessionId, command))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("not yet implemented");
+        }
+    }
+
+    // Helper methods
+
+    private Answer createMockAnswer(Long answerId, Long accountId, AnswerStatus status) {
+        Answer answer = mock(Answer.class);
+        UserAccount account = mock(UserAccount.class);
+
+        when(answer.getId()).thenReturn(answerId);
+        when(answer.getAccount()).thenReturn(account);
+        when(account.getId()).thenReturn(accountId);
+        when(answer.getStatus()).thenReturn(status);
+        when(answer.getContent()).thenReturn(VALID_ANSWER_TEXT);
+        when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+        when(answer.isOwnedBy(accountId)).thenReturn(true);
+
+        return answer;
+    }
+
+    private Answer createMockAnswerWithQuestion(Long answerId, Long accountId) {
+        Answer answer = mock(Answer.class);
+        UserAccount account = mock(UserAccount.class);
+        Question question = mock(Question.class);
+
+        when(answer.getId()).thenReturn(answerId);
+        when(answer.getAccount()).thenReturn(account);
+        when(account.getId()).thenReturn(accountId);
+        when(answer.getStatus()).thenReturn(AnswerStatus.SUBMITTED);
+        when(answer.getContent()).thenReturn(VALID_ANSWER_TEXT);
+        when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+        when(answer.getQuestion()).thenReturn(question);
+        when(answer.isOwnedBy(accountId)).thenReturn(true);
+        when(answer.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        when(question.getId()).thenReturn(QUESTION_ID);
+        when(question.getContent()).thenReturn("테스트 질문입니다.");
+        when(question.getCategory()).thenReturn(QuestionCategory.DB);
+        when(question.getType()).thenReturn(QuestionType.CS);
+
+        return answer;
+    }
+}

--- a/src/test/java/com/ktb/answer/service/AnswerDomainServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerDomainServiceTest.java
@@ -3,7 +3,6 @@ package com.ktb.answer.service;
 import com.ktb.answer.domain.Answer;
 import com.ktb.answer.domain.AnswerStatus;
 import com.ktb.answer.domain.AnswerType;
-import com.ktb.answer.dto.AnswerDetailResult;
 import com.ktb.answer.exception.AnswerAccessDeniedException;
 import com.ktb.answer.exception.AnswerInvalidContentException;
 import com.ktb.answer.exception.InvalidAnswerStatusTransitionException;
@@ -13,14 +12,7 @@ import com.ktb.auth.domain.UserAccount;
 import com.ktb.auth.exception.account.AccountNotFoundException;
 import com.ktb.auth.repository.UserAccountRepository;
 import com.ktb.fixture.AnswerFixture;
-import com.ktb.hashtag.repository.AnswerHashtagRepository;
-import com.ktb.interview.application.service.flow.InterviewSessionFeedbackQueryFlowService;
-import com.ktb.interview.session.dto.response.InterviewHistoryResponse;
-import com.ktb.interview.session.dto.response.InterviewSessionFinalFeedbackResponse;
-import com.ktb.metric.repository.AnswerMetricRepository;
 import com.ktb.question.domain.Question;
-import com.ktb.question.domain.QuestionCategory;
-import com.ktb.question.domain.QuestionType;
 import com.ktb.question.exception.QuestionNotFoundException;
 import com.ktb.question.repository.QuestionRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -31,16 +23,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,15 +42,6 @@ class AnswerDomainServiceTest {
 
     @Mock
     private AnswerRepository answerRepository;
-
-    @Mock
-    private AnswerHashtagRepository answerHashtagRepository;
-
-    @Mock
-    private AnswerMetricRepository answerMetricRepository;
-
-    @Mock
-    private InterviewSessionFeedbackQueryFlowService interviewSessionFeedbackQueryFlowService;
 
     @InjectMocks
     private AnswerDomainServiceImpl answerDomainService;
@@ -218,156 +196,6 @@ class AnswerDomainServiceTest {
             assertThatThrownBy(() ->
                     answerDomainService.transitionStatus(answer, AnswerStatus.COMPLETED))
                     .isInstanceOf(InvalidAnswerStatusTransitionException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("getDetail() 테스트")
-    class GetDetailTest {
-
-        @Test
-        @DisplayName("실전모드 답변 조회 시 세션 최종 피드백을 포함한다")
-        void getDetail_WithRealInterviewAnswer_ShouldIncludeSessionFinalFeedback() {
-            // Given
-            Long answerId = 101L;
-            String sessionId = "session-real-101";
-            Answer answer = mock(Answer.class);
-
-            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
-            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
-            when(answer.getId()).thenReturn(answerId);
-            when(answer.getType()).thenReturn(AnswerType.REAL_INTERVIEW);
-            when(answer.getSessionId()).thenReturn(sessionId);
-            when(answer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
-            when(answer.getContent()).thenReturn("실전 모드 답변");
-
-            InterviewSessionFinalFeedbackResponse sessionFeedback = new InterviewSessionFinalFeedbackResponse(
-                    null,
-                    null,
-                    null,
-                    sessionId,
-                    "COMPLETED",
-                    null,
-                    List.of(),
-                    null,
-                    List.of(),
-                    null,
-                    List.of(new InterviewHistoryResponse(
-                            "질문",
-                            "OS",
-                            "답변",
-                            "follow_up",
-                            1,
-                            1,
-                            null,
-                            null
-                    ))
-            );
-            when(interviewSessionFeedbackQueryFlowService.getSessionFeedbackCompleted(ACCOUNT_ID, sessionId))
-                    .thenReturn(sessionFeedback);
-
-            // When
-            AnswerDetailResult result = answerDomainService.getDetail(ACCOUNT_ID, answerId);
-
-            // Then
-            assertThat(result.sessionFinalFeedback()).isNotNull();
-            assertThat(result.sessionFinalFeedback().answerId()).isEqualTo(answerId);
-            assertThat(result.sessionFinalFeedback().sessionId()).isEqualTo(sessionId);
-            assertThat(result.sessionFinalFeedback().interviewHistory()).hasSize(1);
-            verify(interviewSessionFeedbackQueryFlowService).getSessionFeedbackCompleted(ACCOUNT_ID, sessionId);
-        }
-
-        @Test
-        @DisplayName("연습모드 답변 조회 시 세션 최종 피드백 조회를 수행하지 않는다")
-        void getDetail_WithPracticeInterviewAnswer_ShouldNotLoadSessionFinalFeedback() {
-            // Given
-            Long answerId = 202L;
-            Answer answer = mock(Answer.class);
-            Question question = mock(Question.class);
-
-            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
-            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
-            when(answer.getId()).thenReturn(answerId);
-            when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
-            when(answer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
-            when(answer.getContent()).thenReturn("연습 모드 답변");
-            when(answer.getQuestion()).thenReturn(question);
-            when(question.getId()).thenReturn(10L);
-            when(question.getContent()).thenReturn("질문");
-            when(question.getCategory()).thenReturn(QuestionCategory.OS);
-            when(question.getType()).thenReturn(QuestionType.CS);
-            when(answerHashtagRepository.findByAnswerIdWithHashtag(answerId)).thenReturn(List.of());
-            when(answerMetricRepository.findByAnswerIdWithMetric(answerId)).thenReturn(List.of());
-
-            // When
-            AnswerDetailResult result = answerDomainService.getDetail(ACCOUNT_ID, answerId);
-
-            // Then
-            assertThat(result.sessionFinalFeedback()).isNull();
-            verify(interviewSessionFeedbackQueryFlowService, never()).getSessionFeedbackCompleted(anyLong(), anyString());
-        }
-
-        @Test
-        @DisplayName("실전모드라도 답변 상태가 COMPLETED가 아니면 세션 최종 피드백을 조회하지 않는다")
-        void getDetail_WithRealInterviewButIncompleteStatus_ShouldNotLoadSessionFinalFeedback() {
-            // Given
-            Long answerId = 303L;
-            Answer answer = mock(Answer.class);
-
-            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
-            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
-            when(answer.getId()).thenReturn(answerId);
-            when(answer.getType()).thenReturn(AnswerType.REAL_INTERVIEW);
-            when(answer.getStatus()).thenReturn(AnswerStatus.AI_FEEDBACK_PROCESSING);
-            when(answer.getContent()).thenReturn("실전 모드 처리 중 답변");
-
-            // When
-            AnswerDetailResult result = answerDomainService.getDetail(ACCOUNT_ID, answerId);
-
-            // Then
-            assertThat(result.sessionFinalFeedback()).isNull();
-            verify(interviewSessionFeedbackQueryFlowService, never()).getSessionFeedbackCompleted(anyLong(), anyString());
-        }
-
-        @Test
-        @DisplayName("실전모드는 question/immediateFeedback/aiFeedback을 포함하지 않는다")
-        void getDetail_WithRealInterview_ShouldIgnorePracticeOnlyFields() {
-            // Given
-            Long answerId = 404L;
-            String sessionId = "session-real-404";
-            Answer answer = mock(Answer.class);
-
-            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
-            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
-            when(answer.getId()).thenReturn(answerId);
-            when(answer.getType()).thenReturn(AnswerType.REAL_INTERVIEW);
-            when(answer.getSessionId()).thenReturn(sessionId);
-            when(answer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
-            when(answer.getContent()).thenReturn("실전 모드 답변");
-
-            when(interviewSessionFeedbackQueryFlowService.getSessionFeedbackCompleted(ACCOUNT_ID, sessionId))
-                    .thenReturn(new InterviewSessionFinalFeedbackResponse(
-                            null,
-                            null,
-                            null,
-                            sessionId,
-                            "COMPLETED",
-                            null,
-                            List.of(),
-                            null,
-                            List.of(),
-                            null,
-                            List.of()
-                    ));
-
-            // When
-            AnswerDetailResult result = answerDomainService.getDetail(ACCOUNT_ID, answerId);
-
-            // Then
-            assertThat(result.question()).isNull();
-            assertThat(result.immediateFeedback()).isNull();
-            assertThat(result.aiFeedback()).isNull();
-            assertThat(result.sessionFinalFeedback()).isNotNull();
         }
     }
 

--- a/src/test/java/com/ktb/answer/service/AnswerQueryServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerQueryServiceTest.java
@@ -1,0 +1,225 @@
+package com.ktb.answer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ktb.answer.domain.Answer;
+import com.ktb.answer.domain.AnswerStatus;
+import com.ktb.answer.domain.AnswerType;
+import com.ktb.answer.domain.policy.QuestionTypeFilterPolicy;
+import com.ktb.answer.dto.AnswerDetailResult;
+import com.ktb.answer.exception.AnswerNotFoundException;
+import com.ktb.answer.repository.AnswerRepository;
+import com.ktb.answer.service.impl.AnswerQueryServiceImpl;
+import com.ktb.hashtag.repository.AnswerHashtagRepository;
+import com.ktb.interview.application.service.flow.InterviewSessionFeedbackQueryFlowService;
+import com.ktb.interview.session.dto.response.InterviewHistoryResponse;
+import com.ktb.interview.session.dto.response.InterviewSessionFinalFeedbackResponse;
+import com.ktb.metric.repository.AnswerMetricRepository;
+import com.ktb.question.domain.Question;
+import com.ktb.question.domain.QuestionCategory;
+import com.ktb.question.domain.QuestionType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnswerQueryService 단위 테스트")
+class AnswerQueryServiceTest {
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @Mock
+    private AnswerHashtagRepository answerHashtagRepository;
+
+    @Mock
+    private AnswerMetricRepository answerMetricRepository;
+
+    @Mock
+    private QuestionTypeFilterPolicy questionTypeFilterPolicy;
+
+    @Mock
+    private CursorCodec cursorCodec;
+
+    @Mock
+    private InterviewSessionFeedbackQueryFlowService interviewSessionFeedbackQueryFlowService;
+
+    @InjectMocks
+    private AnswerQueryServiceImpl answerQueryService;
+
+    private static final Long ACCOUNT_ID = 1L;
+
+    @Nested
+    @DisplayName("getDetail() 테스트")
+    class GetDetailTest {
+
+        @Test
+        @DisplayName("실전모드 답변 조회 시 세션 최종 피드백을 포함한다")
+        void getDetail_WithRealInterviewAnswer_ShouldIncludeSessionFinalFeedback() {
+            // Given
+            Long answerId = 101L;
+            String sessionId = "session-real-101";
+            Answer answer = mock(Answer.class);
+
+            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
+            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
+            when(answer.getId()).thenReturn(answerId);
+            when(answer.getType()).thenReturn(AnswerType.REAL_INTERVIEW);
+            when(answer.getSessionId()).thenReturn(sessionId);
+            when(answer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
+            when(answer.getContent()).thenReturn("실전 모드 답변");
+
+            InterviewSessionFinalFeedbackResponse sessionFeedback = new InterviewSessionFinalFeedbackResponse(
+                    null,
+                    null,
+                    null,
+                    sessionId,
+                    "COMPLETED",
+                    null,
+                    List.of(),
+                    null,
+                    List.of(),
+                    null,
+                    List.of(new InterviewHistoryResponse(
+                            "질문",
+                            "OS",
+                            "답변",
+                            "follow_up",
+                            1,
+                            1,
+                            null,
+                            null
+                    ))
+            );
+            when(interviewSessionFeedbackQueryFlowService.getSessionFeedbackCompleted(ACCOUNT_ID, sessionId))
+                    .thenReturn(sessionFeedback);
+
+            // When
+            AnswerDetailResult result = answerQueryService.getDetail(ACCOUNT_ID, answerId);
+
+            // Then
+            assertThat(result.sessionFinalFeedback()).isNotNull();
+            assertThat(result.sessionFinalFeedback().answerId()).isEqualTo(answerId);
+            assertThat(result.sessionFinalFeedback().sessionId()).isEqualTo(sessionId);
+            assertThat(result.sessionFinalFeedback().interviewHistory()).hasSize(1);
+            verify(interviewSessionFeedbackQueryFlowService).getSessionFeedbackCompleted(ACCOUNT_ID, sessionId);
+        }
+
+        @Test
+        @DisplayName("연습모드 답변 조회 시 세션 최종 피드백 조회를 수행하지 않는다")
+        void getDetail_WithPracticeInterviewAnswer_ShouldNotLoadSessionFinalFeedback() {
+            // Given
+            Long answerId = 202L;
+            Answer answer = mock(Answer.class);
+            Question question = mock(Question.class);
+
+            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
+            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
+            when(answer.getId()).thenReturn(answerId);
+            when(answer.getType()).thenReturn(AnswerType.PRACTICE_INTERVIEW);
+            when(answer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
+            when(answer.getContent()).thenReturn("연습 모드 답변");
+            when(answer.getQuestion()).thenReturn(question);
+            when(question.getId()).thenReturn(10L);
+            when(question.getContent()).thenReturn("질문");
+            when(question.getCategory()).thenReturn(QuestionCategory.OS);
+            when(question.getType()).thenReturn(QuestionType.CS);
+            when(answerHashtagRepository.findByAnswerIdWithHashtag(answerId)).thenReturn(List.of());
+            when(answerMetricRepository.findByAnswerIdWithMetric(answerId)).thenReturn(List.of());
+
+            // When
+            AnswerDetailResult result = answerQueryService.getDetail(ACCOUNT_ID, answerId);
+
+            // Then
+            assertThat(result.sessionFinalFeedback()).isNull();
+            verify(interviewSessionFeedbackQueryFlowService, never()).getSessionFeedbackCompleted(anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("실전모드라도 답변 상태가 COMPLETED가 아니면 세션 최종 피드백을 조회하지 않는다")
+        void getDetail_WithRealInterviewButIncompleteStatus_ShouldNotLoadSessionFinalFeedback() {
+            // Given
+            Long answerId = 303L;
+            Answer answer = mock(Answer.class);
+
+            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
+            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
+            when(answer.getId()).thenReturn(answerId);
+            when(answer.getType()).thenReturn(AnswerType.REAL_INTERVIEW);
+            when(answer.getStatus()).thenReturn(AnswerStatus.AI_FEEDBACK_PROCESSING);
+            when(answer.getContent()).thenReturn("실전 모드 처리 중 답변");
+
+            // When
+            AnswerDetailResult result = answerQueryService.getDetail(ACCOUNT_ID, answerId);
+
+            // Then
+            assertThat(result.sessionFinalFeedback()).isNull();
+            verify(interviewSessionFeedbackQueryFlowService, never()).getSessionFeedbackCompleted(anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("실전모드는 question/immediateFeedback/aiFeedback을 포함하지 않는다")
+        void getDetail_WithRealInterview_ShouldIgnorePracticeOnlyFields() {
+            // Given
+            Long answerId = 404L;
+            String sessionId = "session-real-404";
+            Answer answer = mock(Answer.class);
+
+            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(answer);
+            when(answer.isOwnedBy(ACCOUNT_ID)).thenReturn(true);
+            when(answer.getId()).thenReturn(answerId);
+            when(answer.getType()).thenReturn(AnswerType.REAL_INTERVIEW);
+            when(answer.getSessionId()).thenReturn(sessionId);
+            when(answer.getStatus()).thenReturn(AnswerStatus.COMPLETED);
+            when(answer.getContent()).thenReturn("실전 모드 답변");
+
+            when(interviewSessionFeedbackQueryFlowService.getSessionFeedbackCompleted(ACCOUNT_ID, sessionId))
+                    .thenReturn(new InterviewSessionFinalFeedbackResponse(
+                            null,
+                            null,
+                            null,
+                            sessionId,
+                            "COMPLETED",
+                            null,
+                            List.of(),
+                            null,
+                            List.of(),
+                            null,
+                            List.of()
+                    ));
+
+            // When
+            AnswerDetailResult result = answerQueryService.getDetail(ACCOUNT_ID, answerId);
+
+            // Then
+            assertThat(result.question()).isNull();
+            assertThat(result.immediateFeedback()).isNull();
+            assertThat(result.aiFeedback()).isNull();
+            assertThat(result.sessionFinalFeedback()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 답변 조회 시 AnswerNotFoundException 발생")
+        void getDetail_WithNonExistentAnswer_ShouldThrowException() {
+            // Given
+            Long answerId = 999L;
+            when(answerRepository.findByIdWithQuestion(answerId)).thenReturn(null);
+
+            // When & Then
+            assertThatThrownBy(() -> answerQueryService.getDetail(ACCOUNT_ID, answerId))
+                    .isInstanceOf(AnswerNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/ktb/answer/service/CursorCodecTest.java
+++ b/src/test/java/com/ktb/answer/service/CursorCodecTest.java
@@ -1,0 +1,51 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.AnswerListCursor;
+import com.ktb.answer.exception.AnswerListInvalidInputException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CursorCodec 단위 테스트")
+class CursorCodecTest {
+
+    private final CursorCodec cursorCodec = new CursorCodec();
+
+    @Test
+    @DisplayName("null cursor는 null을 반환한다")
+    void decode_nullCursor_returnsNull() {
+        assertThat(cursorCodec.decode(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("빈 cursor는 null을 반환한다")
+    void decode_blankCursor_returnsNull() {
+        assertThat(cursorCodec.decode("  ")).isNull();
+    }
+
+    @Test
+    @DisplayName("encode 후 decode하면 동일한 값을 반환한다")
+    void encode_then_decode_roundtrip() {
+        AnswerListCursor original = new AnswerListCursor(
+                LocalDateTime.of(2026, 1, 15, 10, 30, 0),
+                42L
+        );
+
+        String encoded = cursorCodec.encode(original);
+        AnswerListCursor decoded = cursorCodec.decode(encoded);
+
+        assertThat(decoded).isNotNull();
+        assertThat(decoded.lastAnswerId()).isEqualTo(original.lastAnswerId());
+        assertThat(decoded.lastCreatedAt()).isEqualTo(original.lastCreatedAt());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Base64 문자열은 예외를 발생시킨다")
+    void decode_invalidBase64_throwsException() {
+        assertThatThrownBy(() -> cursorCodec.decode("!!!invalid!!!"))
+                .isInstanceOf(AnswerListInvalidInputException.class);
+    }
+}

--- a/src/test/java/com/ktb/answer/service/ImmediateFeedbackServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/ImmediateFeedbackServiceTest.java
@@ -1,0 +1,219 @@
+package com.ktb.answer.service;
+
+import com.ktb.answer.dto.ImmediateFeedbackResult;
+import com.ktb.answer.dto.KeywordCheckResult;
+import com.ktb.answer.service.impl.ImmediateFeedbackServiceImpl;
+import com.ktb.fixture.QuestionHashtagFixture;
+import com.ktb.hashtag.domain.QuestionHashtag;
+import com.ktb.hashtag.repository.QuestionHashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ImmediateFeedbackService 단위 테스트")
+class ImmediateFeedbackServiceTest {
+
+    @Mock
+    private QuestionHashtagRepository questionHashtagRepository;
+
+    @InjectMocks
+    private ImmediateFeedbackServiceImpl immediateFeedbackService;
+
+    private static final Long QUESTION_ID = 100L;
+
+    @Nested
+    @DisplayName("evaluate() 테스트")
+    class EvaluateTest {
+
+        @Test
+        @DisplayName("답변에 키워드가 포함된 경우 included=true 반환")
+        void evaluate_WithKeywordIncluded_ShouldReturnTrue() {
+            // Given
+            String answerText = "데이터베이스 인덱스를 사용하면 조회 성능이 향상됩니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("인덱스", "성능");
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(QUESTION_ID))
+                    .thenReturn(questionHashtags);
+
+            // When
+            ImmediateFeedbackResult result = immediateFeedbackService.evaluate(QUESTION_ID, answerText);
+
+            // Then
+            assertThat(result.keywords()).hasSize(2);
+            assertThat(result.keywords())
+                    .allMatch(KeywordCheckResult::included);
+        }
+
+        @Test
+        @DisplayName("답변에 키워드가 포함되지 않은 경우 included=false 반환")
+        void evaluate_WithKeywordNotIncluded_ShouldReturnFalse() {
+            // Given
+            String answerText = "테스트 답변입니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("인덱스", "성능");
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(QUESTION_ID))
+                    .thenReturn(questionHashtags);
+
+            // When
+            ImmediateFeedbackResult result = immediateFeedbackService.evaluate(QUESTION_ID, answerText);
+
+            // Then
+            assertThat(result.keywords()).hasSize(2);
+            assertThat(result.keywords())
+                    .noneMatch(KeywordCheckResult::included);
+        }
+
+        @Test
+        @DisplayName("질문에 키워드가 없는 경우 빈 목록 반환")
+        void evaluate_WithNoKeywords_ShouldReturnEmptyList() {
+            // Given
+            String answerText = "테스트 답변입니다.";
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(QUESTION_ID))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            ImmediateFeedbackResult result = immediateFeedbackService.evaluate(QUESTION_ID, answerText);
+
+            // Then
+            assertThat(result.keywords()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("checkKeywords() 테스트")
+    class CheckKeywordsTest {
+
+        @Test
+        @DisplayName("대소문자 무시하고 키워드 매칭")
+        void checkKeywords_WithDifferentCase_ShouldMatch() {
+            // Given
+            String answerText = "INDEX를 사용하면 성능이 향상됩니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("index");
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().included()).isTrue();
+        }
+
+        @Test
+        @DisplayName("정확히 일치하는 키워드 매칭")
+        void checkKeywords_WithExactMatch_ShouldMatch() {
+            // Given
+            String answerText = "정규화를 통해 데이터 중복을 제거합니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("정규화");
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().included()).isTrue();
+            assertThat(results.getFirst().keyword()).isEqualTo("정규화");
+        }
+
+        @Test
+        @DisplayName("부분 문자열로 키워드 매칭")
+        void checkKeywords_WithPartialMatch_ShouldMatch() {
+            // Given
+            String answerText = "비정규화를 사용합니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags("정규화");
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(1);
+            assertThat(results.getFirst().included()).isTrue();
+        }
+
+        @Test
+        @DisplayName("다중 키워드 중 일부만 포함된 경우")
+        void checkKeywords_WithMultipleKeywords_ShouldMatchSome() {
+            // Given
+            String answerText = "인덱스를 사용합니다.";
+            List<QuestionHashtag> questionHashtags = QuestionHashtagFixture.createMockQuestionHashtags(
+                    "인덱스", "정규화", "트랜잭션"
+            );
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, questionHashtags);
+
+            // Then
+            assertThat(results).hasSize(3);
+
+            long includedCount = results.stream()
+                    .filter(KeywordCheckResult::included)
+                    .count();
+            assertThat(includedCount).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("빈 키워드 목록 처리")
+        void checkKeywords_WithEmptyKeywords_ShouldReturnEmptyList() {
+            // Given
+            String answerText = "테스트 답변입니다.";
+            List<QuestionHashtag> emptyHashtags = Collections.emptyList();
+
+            // When
+            List<KeywordCheckResult> results = immediateFeedbackService.checkKeywords(answerText, emptyHashtags);
+
+            // Then
+            assertThat(results).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("extractKeywords() 테스트")
+    class ExtractKeywordsTest {
+
+        @Test
+        @DisplayName("질문 ID로 키워드 추출 성공")
+        void extractKeywords_WithValidQuestionId_ShouldReturnKeywords() {
+            // Given
+            Long testQuestionId = 200L;
+            List<QuestionHashtag> expectedHashtags = QuestionHashtagFixture.createMockQuestionHashtags("키워드1", "키워드2");
+
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(testQuestionId))
+                    .thenReturn(expectedHashtags);
+
+            // When
+            List<QuestionHashtag> results = immediateFeedbackService.extractKeywords(testQuestionId);
+
+            // Then
+            assertThat(results).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("키워드가 없는 질문에서 빈 목록 반환")
+        void extractKeywords_WithNoKeywords_ShouldReturnEmptyList() {
+            // Given
+            Long testQuestionId = 300L;
+            when(questionHashtagRepository.findKeywordNamesByQuestionId(testQuestionId))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            List<QuestionHashtag> results = immediateFeedbackService.extractKeywords(testQuestionId);
+
+            // Then
+            assertThat(results).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 배경
Answer 도메인에서 아래 문제가 확인되었습니다.

- `AnswerDomainServiceImpl` / `AnswerApplicationServiceImpl` 책임 과다 및 중복 (SRP 위반)
- `validateQuestionType` 정책 불일치 (OCP 위반 + 실제 버그)
- AI 분기 로직 문자열 하드코딩 (OCP 위반)
- AI 호출이 트랜잭션 내부에 포함되어 DB 커넥션 장시간 점유
- 이벤트 처리 멱등성/재처리 경계 불명확

본 PR은 **기존 API 계약을 유지**하면서 구조를 단계적으로 정리합니다.

---

## 변경 요약

### OCP 정책 객체화
- `QuestionTypeFilterPolicy` + `AllowedQuestionTypeFilterPolicy` 도입
- `validateQuestionType` 중복/불일치 제거
- `AiFeedbackOutcomeClassifier` 도입
- `"bad_case_detected"` 문자열 하드코딩 분기 제거

### SRP 분리 (Answer)
- `CursorCodec` 도입 (cursor encode/decode 단일화)
- `AnswerCommandService` / `AnswerQueryService` 분리
- `AnswerApplicationServiceImpl` 단순 위임 구조로 정리
- `AnswerDomainService`에서 query 책임 제거

### SRP 분리 (Interview Final Feedback)
- `InterviewSessionFinalFeedbackFlowService`를 coordinator로 축소
- 하위 책임 분리
  - `FinalFeedbackAnchorResolver`
  - `FinalFeedbackAnswerFactory`
  - `FinalFeedbackCompletionService`

### 트랜잭션 경계 분리 (RabbitMQ + Outbox)
- AI 요청을 트랜잭션 외부 비동기 처리로 분리
- `NotificationOutbox` 재사용하여 발행 신뢰성 확보
- RabbitMQ queue/DLQ 구성 및 manual ack 적용
- Worker 처리 흐름:
  - `AI_FEEDBACK_PROCESSING` 전이 (TX 분리)
  - AI 호출 (TX 외부)
  - 성공: `COMPLETED`
  - 재시도 가능 실패: `FAILED_RETRYABLE`
  - 영구 실패: `FAILED`
- 멱등성 보장용 `answer_feedback_inbox` 추가 (event_id unique)

---

## 아키텍처 변화 (핵심)
- **Before**: HTTP 트랜잭션 내부에서 AI 호출/저장 혼재
- **After**:
  1. TX1: Answer 저장 + Outbox 기록 후 커밋
  2. Relay: Outbox → RabbitMQ 발행
  3. Consumer:
     - TX2: 처리 상태 전이
     - AI 호출 (트랜잭션 외부)
     - TX3: 결과 영속화 + 상태 전이 + ack/nack

---

## DB 변경
```sql
CREATE TABLE answer_feedback_inbox (
    id           BIGSERIAL PRIMARY KEY,
    event_id     VARCHAR(64) NOT NULL,
    answer_id    BIGINT      NOT NULL,
    processed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
    CONSTRAINT uk_answer_feedback_inbox_event_id UNIQUE (event_id)
);
CREATE INDEX idx_answer_feedback_inbox_answer ON answer_feedback_inbox(answer_id);
```
## 테스트
### 단위 테스트
- QuestionTypeFilterPolicy 허용/차단 검증
- AiFeedbackOutcomeClassifier 분류 검증
- AnswerCommandService 상태 전이/소유권/입력 검증
- AnswerQueryService list/detail cursor 분기
- CursorCodec encode/decode
- Worker 멱등성(no-op + ack) 검증
### 통합 테스트
- RabbitMQ 소비 1회 성공 시 COMPLETED
- DB 저장 실패 시 재처리 동작
- AI 타임아웃/5xx → FAILED_RETRYABLE
- AI 4xx 영구 실패 → FAILED
### 회귀 테스트
- Answer API 응답 필드/상태코드 유지 확인

## 영향 범위
- com.ktb.answer / com.ktb.ai.feedback / com.ktb.interview 중심
- Controller API 스펙, ErrorCode, DTO 계약 변경 없음

## 관련 Issue
 - closes #254
