### PR TITLE
feat:[#261] Spring Cache 기반 Redis 캐시 계층 도입

### DIFF
--- a/src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
+++ b/src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
@@ -10,8 +10,12 @@ import com.ktb.metric.dto.MetricUpdateRequest;
 import com.ktb.metric.exception.MetricNotFoundException;
 import com.ktb.metric.repository.MetricRepository;
 import com.ktb.metric.service.MetricService;
+import com.ktb.redis.constant.CacheNames;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
@@ -26,6 +30,7 @@ public class MetricServiceImpl implements MetricService {
     private final MetricRepository metricRepository;
 
     @Override
+    @Cacheable(cacheNames = CacheNames.METRIC_LIST, key = "#useYn+':'+#cursor+':'+#size")
     public MetricListResponse getMetrics(Boolean useYn, Long cursor, int size) {
         PageRequest pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "id"));
         Slice<Metric> metrics = findMetrics(useYn, cursor, pageable);
@@ -38,6 +43,7 @@ public class MetricServiceImpl implements MetricService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheNames.METRIC_DETAIL, key = "#metricId")
     public MetricDetailResponse getMetric(Long metricId) {
         Metric metric = metricRepository.findById(metricId)
                 .orElseThrow(() -> new MetricNotFoundException(metricId));
@@ -46,6 +52,7 @@ public class MetricServiceImpl implements MetricService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.METRIC_LIST, allEntries = true)
     public MetricDetailResponse createMetric(MetricCreateRequest request) {
         Metric metric = Metric.create(request.name(), request.description());
         Metric saved = metricRepository.save(metric);
@@ -54,6 +61,10 @@ public class MetricServiceImpl implements MetricService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(cacheNames = CacheNames.METRIC_DETAIL, key = "#metricId"),
+        @CacheEvict(cacheNames = CacheNames.METRIC_LIST, allEntries = true)
+    })
     public MetricDetailResponse updateMetric(Long metricId, MetricUpdateRequest request) {
         Metric metric = metricRepository.findById(metricId)
                 .orElseThrow(() -> new MetricNotFoundException(metricId));
@@ -77,6 +88,10 @@ public class MetricServiceImpl implements MetricService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(cacheNames = CacheNames.METRIC_DETAIL, key = "#metricId"),
+        @CacheEvict(cacheNames = CacheNames.METRIC_LIST, allEntries = true)
+    })
     public void deleteMetric(Long metricId) {
         Metric metric = metricRepository.findById(metricId)
                 .orElseThrow(() -> new MetricNotFoundException(metricId));

--- a/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
@@ -24,6 +24,7 @@ import com.ktb.question.exception.QuestionNotFoundException;
 import com.ktb.question.exception.SearchKeywordTooShortException;
 import com.ktb.question.repository.QuestionRepository;
 import com.ktb.question.service.QuestionService;
+import com.ktb.redis.constant.CacheNames;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +38,9 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
@@ -60,6 +64,7 @@ public class QuestionServiceImpl implements QuestionService {
     private final HashtagRepository hashtagRepository;
 
     @Override
+    @Cacheable(cacheNames = CacheNames.QUESTION_LIST, key = "#category+':'+#type+':'+#cursor+':'+#size")
     public QuestionListResponse getQuestions(QuestionCategory category, QuestionType type, Long cursor, int size) {
         log.debug("getQuestions - type: {}, category: {}, cursor: {}, size: {}",
                 type, category, cursor, size);
@@ -77,6 +82,7 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheNames.QUESTION_DETAIL, key = "#questionId")
     public QuestionDetailResponse getQuestionDetail(Long questionId) {
         log.debug("getQuestionDetail - questionId: {}", questionId);
         Question question = questionRepository.findById(questionId)
@@ -107,6 +113,7 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION)
     public QuestionDetailResponse getDailyRecommendation() {
         log.debug("getDailyRecommendation");
         Long questionId = questionRepository.findRandomActiveId()
@@ -122,6 +129,7 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true)
     public QuestionDetailResponse createQuestion(QuestionCreateRequest request) {
         int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
         log.info("createQuestion - type: {}, category: {}, keywordCount: {}",
@@ -136,6 +144,12 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DETAIL, key = "#questionId"),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_KEYWORDS, key = "#questionId"),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION, allEntries = true)
+    })
     public QuestionDetailResponse updateQuestion(Long questionId, QuestionUpdateRequest request) {
         int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
         log.info("updateQuestion - questionId: {}, hasContent: {}, type: {}, category: {}, useYn: {}, keywordCount: {}",
@@ -169,6 +183,12 @@ public class QuestionServiceImpl implements QuestionService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DETAIL, key = "#questionId"),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_KEYWORDS, key = "#questionId"),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION, allEntries = true)
+    })
     public void deleteQuestion(Long questionId) {
         log.info("deleteQuestion - questionId: {}", questionId);
         Question question = questionRepository.findById(questionId)
@@ -183,6 +203,7 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheNames.QUESTION_KEYWORDS, key = "#questionId")
     public QuestionKeywordListResponse getQuestionKeywords(Long questionId) {
         log.debug("getQuestionKeywords - questionId: {}", questionId);
         validateQuestionExists(questionId);
@@ -217,6 +238,7 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheNames.QUESTION_CATEGORIES)
     public QuestionCategoryListResponse getQuestionCategories() {
         log.debug("getQuestionCategories");
         Map<String, Map<String, String>> categories = EXPOSED_TYPES.stream()
@@ -238,6 +260,7 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheNames.QUESTION_TYPES)
     public QuestionTypeListResponse getQuestionTypes() {
         log.debug("getQuestionTypes");
         Map<String, String> types = Arrays.stream(QuestionType.values())

--- a/src/main/java/com/ktb/redis/cache/JitterPERRedisCache.java
+++ b/src/main/java/com/ktb/redis/cache/JitterPERRedisCache.java
@@ -1,0 +1,93 @@
+package com.ktb.redis.cache;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.lang.Nullable;
+
+@Slf4j
+public class JitterPERRedisCache extends LuaRedisCache {
+
+    private static final int JITTER_PERCENT = 10;
+    private static final double PER_BETA = 1.0;
+    private static final long PER_DELTA_MS = 100L;
+    private static final String PER_META_SUFFIX = ":per";
+
+    private static final RedisScript<Object> LUA_SET_WITH_PER = RedisScript.of(
+            "redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2])\n"
+            + "redis.call('SET', KEYS[2], ARGV[3], 'PX', ARGV[2])\n"
+            + "return nil",
+            Object.class);
+
+    public JitterPERRedisCache(String name, RedisCacheWriter cacheWriter, RedisCacheConfiguration cacheConfig,
+                               RedisConnectionFactory connectionFactory, Duration ttl) {
+        super(name, cacheWriter, cacheConfig, connectionFactory, ttl);
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        if (value == null) {
+            return;
+        }
+
+        Object storeValue = toStoreValue(value);
+        try {
+            Duration jittered = computeJitteredTtl();
+            long expiresAt = System.currentTimeMillis() + jittered.toMillis();
+            byte[] k = serializeCacheKey(createCacheKey(key));
+            byte[] metaK = serializeCacheKey(createCacheKey(key) + PER_META_SUFFIX);
+            byte[] v = serializeCacheValue(storeValue);
+            executeScript(LUA_SET_WITH_PER, ReturnType.VALUE, List.of(k, metaK),
+                    v,
+                    String.valueOf(jittered.toMillis()).getBytes(StandardCharsets.UTF_8),
+                    String.valueOf(expiresAt).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.warn("[Cache] put failed - cache={} key={}", getName(), key, e);
+        }
+    }
+
+    @Override
+    protected Object lookup(Object key) {
+        Object value = super.lookup(key);
+        if (value == null) {
+            return null;
+        }
+        byte[] metaK = serializeCacheKey(createCacheKey(key) + PER_META_SUFFIX);
+        try (RedisConnection conn = connectionFactory.getConnection()) {
+            byte[] raw = conn.get(metaK);
+            if (raw != null) {
+                long expiresAt = Long.parseLong(new String(raw, StandardCharsets.UTF_8));
+                if (isPERTriggered(expiresAt)) {
+                    log.debug("[PER] early recompute triggered - cache={} key={}", getName(), key);
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("[Cache] PER meta lookup failed - cache={} key={}", getName(), key, e);
+        }
+        return value;
+    }
+
+    private boolean isPERTriggered(long expiresAt) {
+        double random = ThreadLocalRandom.current().nextDouble();
+        if (random <= 0) {
+            return false;
+        }
+        return System.currentTimeMillis() - PER_BETA * PER_DELTA_MS * Math.log(random) > expiresAt;
+    }
+
+    private Duration computeJitteredTtl() {
+        double r = ThreadLocalRandom.current().nextDouble(-1.0, 1.0);
+        long jitterMs = (long) (ttl.toMillis() * JITTER_PERCENT / 100.0 * r);
+        return Duration.ofMillis(Math.max(1_000L, ttl.toMillis() + jitterMs));
+    }
+}

--- a/src/main/java/com/ktb/redis/cache/LuaRedisCache.java
+++ b/src/main/java/com/ktb/redis/cache/LuaRedisCache.java
@@ -1,0 +1,104 @@
+package com.ktb.redis.cache;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.cache.RedisCache;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.lang.Nullable;
+
+@Slf4j
+public class LuaRedisCache extends RedisCache {
+
+    private static final RedisScript<Object> LUA_SET = RedisScript.of(
+            "redis.call('SET', KEYS[1], ARGV[1])\n"
+            + "redis.call('PEXPIRE', KEYS[1], ARGV[2])\n"
+            + "return nil",
+            Object.class);
+
+    private static final RedisScript<byte[]> LUA_SET_NX = RedisScript.of(
+            "if redis.call('SETNX', KEYS[1], ARGV[1]) == 1 then\n"
+            + "  redis.call('PEXPIRE', KEYS[1], ARGV[2])\n"
+            + "  return nil\n"
+            + "end\n"
+            + "return redis.call('GET', KEYS[1])",
+            byte[].class);
+
+    protected final RedisConnectionFactory connectionFactory;
+    protected final Duration ttl;
+
+    public LuaRedisCache(String name, RedisCacheWriter cacheWriter, RedisCacheConfiguration cacheConfig,
+                         RedisConnectionFactory connectionFactory, Duration ttl) {
+        super(name, cacheWriter, cacheConfig);
+        this.connectionFactory = connectionFactory;
+        this.ttl = ttl;
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        if (value == null) {
+            return;
+        }
+
+        Object storeValue = toStoreValue(value);
+        try {
+            byte[] k = serializeCacheKey(createCacheKey(key));
+            byte[] v = serializeCacheValue(storeValue);
+            executeScript(LUA_SET, ReturnType.VALUE, List.of(k),
+                    v, String.valueOf(ttl.toMillis()).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.warn("[Cache] put failed - cache={} key={}", getName(), key, e);
+        }
+    }
+
+    @Override
+    public ValueWrapper putIfAbsent(Object key, @Nullable Object value) {
+        if (value == null) {
+            return get(key);
+        }
+        Object storeValue = toStoreValue(value);
+        try {
+            byte[] k = serializeCacheKey(createCacheKey(key));
+            byte[] v = serializeCacheValue(storeValue);
+            byte[] existing = executeScript(LUA_SET_NX, ReturnType.VALUE, List.of(k),
+                    v, String.valueOf(ttl.toMillis()).getBytes(StandardCharsets.UTF_8));
+            if (existing != null) {
+                Object existingValue = deserializeCacheValue(existing);
+                return () -> fromStoreValue(existingValue);
+            }
+            return null;
+        } catch (Exception e) {
+            log.warn("[Cache] putIfAbsent failed - cache={} key={}", getName(), key, e);
+            return null;
+        }
+    }
+
+    @Override
+    protected Object lookup(Object key) {
+        try {
+            return super.lookup(key);
+        } catch (Exception e) {
+            log.warn("[Cache] lookup failed - cache={} key={}", getName(), key, e);
+            return null;
+        }
+    }
+
+    protected byte[] executeScript(RedisScript<?> script, ReturnType returnType,
+                                   List<byte[]> keys, byte[]... args) {
+        byte[] scriptBytes = script.getScriptAsString().getBytes(StandardCharsets.UTF_8);
+        byte[][] keysAndArgs = Stream.concat(keys.stream(), Arrays.stream(args))
+                .toArray(byte[][]::new);
+        try (RedisConnection conn = connectionFactory.getConnection()) {
+            return (byte[]) conn.eval(scriptBytes, returnType, keys.size(), keysAndArgs);
+        }
+    }
+}

--- a/src/main/java/com/ktb/redis/cache/QFeedCacheManager.java
+++ b/src/main/java/com/ktb/redis/cache/QFeedCacheManager.java
@@ -1,0 +1,43 @@
+package com.ktb.redis.cache;
+
+import com.ktb.redis.policy.CachePolicy;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import lombok.NonNull;
+import org.springframework.cache.Cache;
+import org.springframework.cache.transaction.AbstractTransactionSupportingCacheManager;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+public class QFeedCacheManager extends AbstractTransactionSupportingCacheManager {
+
+    private final RedisCacheWriter cacheWriter;
+    private final RedisCacheConfiguration defaultConfig;
+    private final RedisConnectionFactory connectionFactory;
+
+    public QFeedCacheManager(RedisCacheWriter cacheWriter, RedisCacheConfiguration defaultConfig,
+                             RedisConnectionFactory connectionFactory) {
+        this.cacheWriter = cacheWriter;
+        this.defaultConfig = defaultConfig;
+        this.connectionFactory = connectionFactory;
+        setTransactionAware(true);
+    }
+
+    @Override
+    protected @NonNull Collection<? extends Cache> loadCaches() {
+        return Arrays.stream(CachePolicy.values())
+                .map(this::createCache)
+                .toList();
+    }
+
+    private Cache createCache(CachePolicy policy) {
+        Duration ttl = policy.getTtl().getDuration();
+        RedisCacheConfiguration config = defaultConfig.entryTtl(ttl);
+        if (policy.isHotKey()) {
+            return new JitterPERRedisCache(policy.getCacheName(), cacheWriter, config, connectionFactory, ttl);
+        }
+        return new LuaRedisCache(policy.getCacheName(), cacheWriter, config, connectionFactory, ttl);
+    }
+}

--- a/src/main/java/com/ktb/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/ktb/redis/config/RedisCacheConfig.java
@@ -1,27 +1,19 @@
 package com.ktb.redis.config;
 
-import com.ktb.redis.policy.CachePolicy;
+import com.ktb.redis.cache.QFeedCacheManager;
+import java.time.Duration;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
-
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Configuration
 @EnableCaching
 public class RedisCacheConfig {
 
-    /**
-     *
-     * Default 캐시 정책
-     */
     @Bean
     public RedisCacheConfiguration defaultRedisCacheConfiguration(
             RedisSerializationContext.SerializationPair<String> redisKeySerializer,
@@ -34,31 +26,17 @@ public class RedisCacheConfig {
                 .disableCachingNullValues();
     }
 
-    /**
-     * Enum 기반 개별 캐시 정책
-     */
     @Bean
-    public Map<String, RedisCacheConfiguration> redisCacheConfigurations(RedisCacheConfiguration defaultRedisCacheConfiguration) {
-        return Arrays.stream(CachePolicy.values())
-                .collect(Collectors.toMap(
-                        CachePolicy::getCacheName,
-                        policy -> defaultRedisCacheConfiguration.entryTtl(policy.getTtl())
-                ));
+    public RedisCacheWriter redisCacheWriter(RedisConnectionFactory connectionFactory) {
+        return RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory);
     }
 
-    /**
-     * 실제 Redis CacheManager
-     */
     @Bean
-    public RedisCacheManager redisCacheManager(
-            RedisConnectionFactory connectionFactory,
+    public QFeedCacheManager qFeedCacheManager(
+            RedisCacheWriter redisCacheWriter,
             RedisCacheConfiguration defaultRedisCacheConfiguration,
-            Map<String, RedisCacheConfiguration> redisCacheConfigurations
+            RedisConnectionFactory connectionFactory
     ) {
-        return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(defaultRedisCacheConfiguration)
-                .withInitialCacheConfigurations(redisCacheConfigurations)
-                .transactionAware()
-                .build();
+        return new QFeedCacheManager(redisCacheWriter, defaultRedisCacheConfiguration, connectionFactory);
     }
 }

--- a/src/main/java/com/ktb/redis/constant/CacheNames.java
+++ b/src/main/java/com/ktb/redis/constant/CacheNames.java
@@ -1,7 +1,14 @@
 package com.ktb.redis.constant;
 
 public final class CacheNames {
-    public static final String EXAMPLE_CACHE_NAME = "example cache name";
+    public static final String QUESTION_CATEGORIES = "question:categories";
+    public static final String QUESTION_TYPES = "question:types";
+    public static final String QUESTION_LIST = "question:list";
+    public static final String QUESTION_DETAIL = "question:detail";
+    public static final String QUESTION_KEYWORDS = "question:keywords";
+    public static final String QUESTION_DAILY_RECOMMENDATION = "question:daily-recommendation";
+    public static final String METRIC_LIST = "metric:list";
+    public static final String METRIC_DETAIL = "metric:detail";
 
     private CacheNames() {
     }

--- a/src/main/java/com/ktb/redis/policy/CachePolicy.java
+++ b/src/main/java/com/ktb/redis/policy/CachePolicy.java
@@ -2,18 +2,21 @@ package com.ktb.redis.policy;
 
 import com.ktb.redis.constant.CacheNames;
 import lombok.Getter;
-
-import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum CachePolicy {
-    EXAMPLE_POLICY(CacheNames.EXAMPLE_CACHE_NAME, Duration.ofMinutes(10));
+    QUESTION_CATEGORIES(CacheNames.QUESTION_CATEGORIES, CacheTtl.LONG,   false),
+    QUESTION_TYPES     (CacheNames.QUESTION_TYPES,      CacheTtl.LONG,   false),
+    QUESTION_LIST      (CacheNames.QUESTION_LIST,       CacheTtl.MEDIUM, false),
+    QUESTION_DETAIL    (CacheNames.QUESTION_DETAIL,     CacheTtl.LONG,   false),
+    QUESTION_KEYWORDS  (CacheNames.QUESTION_KEYWORDS,   CacheTtl.LONG,   false),
+    QUESTION_DAILY_REC (CacheNames.QUESTION_DAILY_RECOMMENDATION, CacheTtl.LONG, true),
+    METRIC_LIST        (CacheNames.METRIC_LIST,         CacheTtl.MEDIUM, false),
+    METRIC_DETAIL      (CacheNames.METRIC_DETAIL,       CacheTtl.LONG,   false);
 
     private final String cacheName;
-    private final Duration ttl;
-
-    CachePolicy(String cacheName, Duration ttl) {
-        this.cacheName = cacheName;
-        this.ttl = ttl;
-    }
+    private final CacheTtl ttl;
+    private final boolean hotKey;
 }

--- a/src/main/java/com/ktb/redis/policy/CacheTtl.java
+++ b/src/main/java/com/ktb/redis/policy/CacheTtl.java
@@ -1,0 +1,15 @@
+package com.ktb.redis.policy;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheTtl {
+    SHORT(Duration.ofMinutes(1)),
+    MEDIUM(Duration.ofMinutes(10)),
+    LONG(Duration.ofHours(1));
+
+    private final Duration duration;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,7 +84,7 @@ cors:
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 600000  # 10분 (ms)
-  refresh-token-expiration: 1209600000  # 14일 (ms)
+  refresh-token-expiration: 300000   # 5분 (ms)
 
 aws:
   region: ${AWS_REGION}

--- a/src/test/java/com/ktb/redis/AbstractRedisContainerTest.java
+++ b/src/test/java/com/ktb/redis/AbstractRedisContainerTest.java
@@ -10,8 +10,8 @@ public class AbstractRedisContainerTest {
 
     @SuppressWarnings("resource")
     private static final GenericContainer<?> REDIS =
-            new GenericContainer<>("redis:7-alpine")
-                    .withExposedPorts(6379);
+        new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
 
     static {
         REDIS.start();

--- a/src/test/java/com/ktb/redis/RedisCacheManagerTest.java
+++ b/src/test/java/com/ktb/redis/RedisCacheManagerTest.java
@@ -3,6 +3,7 @@ package com.ktb.redis;
 import com.ktb.fixture.RedisFixture;
 import com.ktb.redis.config.RedisCacheConfig;
 import com.ktb.redis.config.RedisSerializationConfig;
+import com.ktb.redis.constant.CacheNames;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,9 +36,10 @@ public class RedisCacheManagerTest extends AbstractRedisContainerTest{
 
     @Test
     void cache_manager_should_store_and_get_value() {
-        Cache cache = cacheManager.getCache("questionList");
+        Cache cache = cacheManager.getCache(CacheNames.QUESTION_LIST);
         RedisFixture.RedisTestUser user = RedisFixture.createTestUser();
 
+        assertThat(cache).isNotNull();
         cache.put("test:user:1", user);
 
         RedisFixture.RedisTestUser cached = cache.get("test:user:1", RedisFixture.RedisTestUser.class);


### PR DESCRIPTION
## 제목
feat(cache): Spring Cache 기반 Redis 캐시 계층 도입

## 배경
현재 Redis는 RTR, abuse guard, event idempotency 등 직접 구현 계층에서 사용되고 있습니다.  
반면 Spring Cache 계층은 `RedisCacheManager`와 `CachePolicy` 설정만 존재하고 실제 `@Cacheable` 적용은 없는 상태였습니다.

이번 PR은 Question/Metric 도메인의 반복 DB 조회를 Spring Cache로 전환하고, Hot Key인 일일 추천 질문 캐시에 Jitter/PER 전략을 적용합니다.

## 변경 요약
- `CachePolicy`를 TTL 티어 기반으로 재설계
  - SHORT: 1분
  - MEDIUM: 10분
  - LONG: 1시간
- `LuaRedisCache` 추가
  - `put`
  - `putIfAbsent`
  - Lua 기반 원자적 `SET + PEXPIRE`, `SETNX + PEXPIRE`
  - Redis 장애 시 graceful degradation
- `JitterPERRedisCache` 추가
  - 일일 추천 질문 Hot Key 전용
  - TTL Jitter ±10%
  - PER(Probabilistic Early Recompute) 기반 조기 재계산
- `QFeedCacheManager` 추가
  - `CachePolicy`를 순회해 캐시 인스턴스 생성
  - Hot Key 여부에 따라 `LuaRedisCache` 또는 `JitterPERRedisCache` 선택
- Question/Metric 도메인에 `@Cacheable`, `@CacheEvict` 적용
- Refresh Token TTL을 14일에서 5분으로 변경

## 캐시 정책
| 캐시 | TTL | 비고 |
| --- | --- | --- |
| `question:list` | 10분 | 목록 조회 |
| `metric:list` | 10분 | 목록 조회 |
| `question:detail` | 1시간 | 상세 조회 |
| `question:keywords` | 1시간 | 질문 키워드 |
| `question:categories` | 1시간 | 카테고리 |
| `question:types` | 1시간 | 질문 타입 |
| `metric:detail` | 1시간 | 메트릭 상세 |
| `question:daily-recommendation` | 1시간 + Jitter/PER | Hot Key |

## Spring Cache 적용 범위
### Question
- `getQuestionCategories()`
- `getQuestionTypes()`
- `getQuestions(category, type, cursor, size)`
- `getQuestionDetail(questionId)`
- `getQuestionKeywords(questionId)`
- `getDailyRecommendation()`

변경/삭제 계열 메서드는 관련 캐시를 evict합니다.

### Metric
- `getMetrics(useYn, cursor, size)`
- `getMetric(metricId)`

생성/수정/삭제 계열 메서드는 관련 캐시를 evict합니다.

## 직접 Redis 구현 유지 범위
아래 영역은 Spring Cache로 전환하지 않습니다.

- Auth RTR
  - Lua CAS
  - 동적 TTL
  - 토큰 패밀리 상태 관리
- Abuse Guard
  - 카운터
  - rate limit 상태
- Event Idempotency
  - eventId 기반 중복 처리 방지

## Refresh Token TTL 변경
```yaml
jwt:
  refresh-token-expiration: 300000
```

## 주요 변경 파일
- src/main/java/com/ktb/redis/policy/CacheTtl.java
- src/main/java/com/ktb/redis/cache/LuaRedisCache.java
- src/main/java/com/ktb/redis/cache/JitterPERRedisCache.java
- src/main/java/com/ktb/redis/cache/QFeedCacheManager.java
- src/main/java/com/ktb/redis/constant/CacheNames.java
- src/main/java/com/ktb/redis/policy/CachePolicy.java
- src/main/java/com/ktb/redis/config/RedisCacheConfig.java
- src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
- src/main/java/com/ktb/metric/service/impl/MetricServiceImpl.java
- src/main/resources/application.yaml

## 테스트 코드 변경 사항
1. Redis CachePolicy에서 등록하는 캐시명은 question:list인데 테스트는 기존 questionList를 조회해
CacheManager#getCache()가 null을 반환하고 NPE가 발생

2. AbstractRedisContainerTest에서 static initializer로 Redis 컨테이너를 시작
Docker 접근이 불가능한 환경에서는 ExceptionInInitializerError가 발생하고 Redis 관련 테스트가
NoClassDefFoundError로 연쇄 실패

- RedisCacheManagerTest에서 CacheNames.QUESTION_LIST 사용
- cache null 여부 명시 검증 추가
- static REDIS.start() 제거
- @Testcontainers(disabledWithoutDocker = true), @Container 기반으로 컨테이너 생명주기 관리

## 관련 Issue
- closes #261 