### PR TITLE
refactor:[#261] RTR Redis 스크립트 실행을 CacheManager 기반으로 전환

### DIFF
--- a/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
+++ b/src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java
@@ -3,14 +3,15 @@ package com.ktb.auth.service.impl;
 import com.ktb.auth.domain.RevokeReason;
 import com.ktb.auth.dto.TokenFamilyInfo;
 import com.ktb.auth.service.TokenFamilyStore;
-import java.time.Duration;
+import com.ktb.redis.cache.ScriptableRedisCache;
+import com.ktb.redis.constant.CacheNames;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
@@ -18,11 +19,11 @@ import org.springframework.stereotype.Service;
  * Redis 기반 Token Family State Store
  * <p>
  * 전략: DB SoT(TokenFamily 유효성) + Redis fast path(hash CAS)
- * - initFamilyState: DB RefreshToken write + Redis HASH write
+ * - initFamilyState: DB RefreshToken write + Redis HASH write (Lua 원자적 초기화)
  * - rotateFamilyToken: Redis Lua CAS only; 재사용 시 DB revoke
  * - revoke*: Redis HASH(존재 시만) + DB revoke
  * <p>
- * Key: auth:family:{familyUuid}  (HASH)
+ * Key: auth:family::{familyUuid}  (HASH, Spring Cache prefix 포함)
  * Fields:
  *   currentHash  → SHA256(현재 유효한 refresh token)
  *   revoked      → "0" | "1"
@@ -32,14 +33,17 @@ import org.springframework.stereotype.Service;
 @Service
 @Primary
 @Profile("redis")
-@RequiredArgsConstructor
 public class RedisTokenFamilyStore implements TokenFamilyStore {
 
-    private static final String KEY_PREFIX = "auth:family:";
-    private static final String FIELD_CURRENT_HASH = "currentHash";
-    private static final String FIELD_REVOKED = "revoked";
-    private static final String REVOKED_FALSE = "0";
-    private static final String REVOKED_TRUE = "1";
+    /**
+     * 원자적 Hash 초기화 — currentHash + revoked=0 설정 후 TTL 적용
+     */
+    private static final RedisScript<Object> INIT_SCRIPT = RedisScript.of(
+        "redis.call('HSET', KEYS[1], 'currentHash', ARGV[1], 'revoked', '0')\n"
+        + "redis.call('PEXPIRE', KEYS[1], ARGV[2])\n"
+        + "return nil",
+        Object.class
+    );
 
     /**
      * 원자적 RTR Rotate (compare-and-swap)
@@ -73,8 +77,19 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
         Long.class
     );
 
+    private final ScriptableRedisCache tokenFamilyCache;
     private final JpaTokenFamilyStore jpaStore;
-    private final StringRedisTemplate redisTemplate;
+
+    public RedisTokenFamilyStore(CacheManager cacheManager, JpaTokenFamilyStore jpaStore) {
+        var cache = cacheManager.getCache(CacheNames.TOKEN_FAMILY);
+        if (!(cache instanceof ScriptableRedisCache)) {
+            throw new IllegalStateException(
+                    "TOKEN_FAMILY cache must be ScriptableRedisCache, but was: "
+                    + (cache == null ? "null" : cache.getClass().getSimpleName()));
+        }
+        this.tokenFamilyCache = (ScriptableRedisCache) cache;
+        this.jpaStore = jpaStore;
+    }
 
     @Override
     public Optional<TokenFamilyInfo> findByUuid(String uuid) {
@@ -84,21 +99,15 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
     @Override
     public void initFamilyState(String familyUuid, String tokenHash, long ttlMillis) {
         jpaStore.initFamilyState(familyUuid, tokenHash, ttlMillis);
-
-        String key = familyKey(familyUuid);
-        redisTemplate.opsForHash().put(key, FIELD_CURRENT_HASH, tokenHash);
-        redisTemplate.opsForHash().put(key, FIELD_REVOKED, REVOKED_FALSE);
-        redisTemplate.expire(key, Duration.ofMillis(ttlMillis));
+        tokenFamilyCache.execute(INIT_SCRIPT, ReturnType.VALUE, familyUuid,
+                tokenHash, String.valueOf(ttlMillis));
         log.debug("Family 초기 상태 등록: familyUuid={}", familyUuid);
     }
 
     @Override
     public int rotateFamilyToken(String familyUuid, String oldHash, String newHash, long ttlMillis) {
-        Long result = redisTemplate.execute(
-            ROTATE_SCRIPT,
-            List.of(familyKey(familyUuid)),
-            oldHash, newHash, String.valueOf(ttlMillis)
-        );
+        Long result = tokenFamilyCache.execute(ROTATE_SCRIPT, ReturnType.INTEGER, familyUuid,
+                oldHash, newHash, String.valueOf(ttlMillis));
         int code = (result != null) ? result.intValue() : -1;
 
         if (code == -3) {
@@ -110,7 +119,7 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
 
     @Override
     public void revokeFamilyState(String familyUuid, RevokeReason reason) {
-        redisTemplate.execute(REVOKE_IF_EXISTS_SCRIPT, List.of(familyKey(familyUuid)));
+        tokenFamilyCache.execute(REVOKE_IF_EXISTS_SCRIPT, ReturnType.INTEGER, familyUuid);
         jpaStore.revokeFamilyState(familyUuid, reason);
         log.debug("Family 폐기: familyUuid={}, reason={}", familyUuid, reason);
     }
@@ -119,12 +128,8 @@ public class RedisTokenFamilyStore implements TokenFamilyStore {
     public int revokeAllFamilyStates(Long accountId, RevokeReason reason) {
         List<String> activeUuids = jpaStore.findActiveUuids(accountId);
         activeUuids.forEach(uuid ->
-            redisTemplate.execute(REVOKE_IF_EXISTS_SCRIPT, List.of(familyKey(uuid)))
+                tokenFamilyCache.execute(REVOKE_IF_EXISTS_SCRIPT, ReturnType.INTEGER, uuid)
         );
         return jpaStore.revokeAllFamilyStates(accountId, reason);
-    }
-
-    private String familyKey(String familyUuid) {
-        return KEY_PREFIX + familyUuid;
     }
 }

--- a/src/main/java/com/ktb/redis/cache/QFeedCacheManager.java
+++ b/src/main/java/com/ktb/redis/cache/QFeedCacheManager.java
@@ -38,6 +38,6 @@ public class QFeedCacheManager extends AbstractTransactionSupportingCacheManager
         if (policy.isHotKey()) {
             return new JitterPERRedisCache(policy.getCacheName(), cacheWriter, config, connectionFactory, ttl);
         }
-        return new LuaRedisCache(policy.getCacheName(), cacheWriter, config, connectionFactory, ttl);
+        return new ScriptableRedisCache(policy.getCacheName(), cacheWriter, config, connectionFactory, ttl);
     }
 }

--- a/src/main/java/com/ktb/redis/cache/ScriptableRedisCache.java
+++ b/src/main/java/com/ktb/redis/cache/ScriptableRedisCache.java
@@ -1,0 +1,58 @@
+package com.ktb.redis.cache;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.core.script.RedisScript;
+
+/**
+ * Lua 스크립트를 Spring Cache 키 직렬화와 함께 실행할 수 있는 RedisCache.
+ * <p>
+ * {@link LuaRedisCache}를 상속하며, key prefix 관리는 {@link com.ktb.redis.policy.CachePolicy}에 위임한다.
+ * {@code execute()} 메서드는 캐시 이름 prefix가 붙은 키를 자동으로 생성하여 스크립트에 전달한다.
+ */
+@Slf4j
+public class ScriptableRedisCache extends LuaRedisCache {
+
+    public ScriptableRedisCache(String name, RedisCacheWriter cacheWriter,
+                                RedisCacheConfiguration cacheConfig,
+                                RedisConnectionFactory connectionFactory, Duration ttl) {
+        super(name, cacheWriter, cacheConfig, connectionFactory, ttl);
+    }
+
+    /**
+     * Lua 스크립트를 실행한다.
+     * <p>
+     * KEYS[1]에는 {@code cacheName::key} 형식의 직렬화된 키가 전달되며,
+     * ARGV[1..N]에는 {@code scriptArgs}가 순서대로 전달된다.
+     *
+     * @param script     실행할 Lua 스크립트
+     * @param returnType Redis 반환 타입 (INTEGER, VALUE 등)
+     * @param key        캐시 키 (cache name prefix가 자동 추가됨)
+     * @param scriptArgs 스크립트 ARGV 인자 목록
+     * @param <T>        반환 타입
+     * @return 스크립트 실행 결과, 실패 시 null
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T execute(RedisScript<T> script, ReturnType returnType, Object key, String... scriptArgs) {
+        byte[] k = serializeCacheKey(createCacheKey(key));
+        byte[] scriptBytes = script.getScriptAsString().getBytes(StandardCharsets.UTF_8);
+        byte[][] argBytes = Arrays.stream(scriptArgs)
+                .map(s -> s.getBytes(StandardCharsets.UTF_8))
+                .toArray(byte[][]::new);
+        byte[][] keysAndArgs = Stream.concat(Stream.of(k), Arrays.stream(argBytes))
+                .toArray(byte[][]::new);
+        try (var conn = connectionFactory.getConnection()) {
+            return (T) conn.eval(scriptBytes, returnType, 1, keysAndArgs);
+        } catch (Exception e) {
+            log.warn("[Cache] execute failed - cache={} key={}", getName(), key, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/ktb/redis/constant/CacheNames.java
+++ b/src/main/java/com/ktb/redis/constant/CacheNames.java
@@ -9,6 +9,7 @@ public final class CacheNames {
     public static final String QUESTION_DAILY_RECOMMENDATION = "question:daily-recommendation";
     public static final String METRIC_LIST = "metric:list";
     public static final String METRIC_DETAIL = "metric:detail";
+    public static final String TOKEN_FAMILY = "auth:family";
 
     private CacheNames() {
     }

--- a/src/main/java/com/ktb/redis/policy/CachePolicy.java
+++ b/src/main/java/com/ktb/redis/policy/CachePolicy.java
@@ -14,7 +14,8 @@ public enum CachePolicy {
     QUESTION_KEYWORDS  (CacheNames.QUESTION_KEYWORDS,   CacheTtl.LONG,   false),
     QUESTION_DAILY_REC (CacheNames.QUESTION_DAILY_RECOMMENDATION, CacheTtl.LONG, true),
     METRIC_LIST        (CacheNames.METRIC_LIST,         CacheTtl.MEDIUM, false),
-    METRIC_DETAIL      (CacheNames.METRIC_DETAIL,       CacheTtl.LONG,   false);
+    METRIC_DETAIL      (CacheNames.METRIC_DETAIL,       CacheTtl.LONG,   false),
+    TOKEN_FAMILY       (CacheNames.TOKEN_FAMILY,        CacheTtl.SHORT,  false);
 
     private final String cacheName;
     private final CacheTtl ttl;


### PR DESCRIPTION
## 변경 배경

RTR(Refresh Token Rotation) 처리에서 `RedisTokenFamilyStore`는 Redis를 직접 접근해
Lua 스크립트를 실행하고 있었습니다.

이 구조는 동작 자체는 문제없지만
- Redis key prefix 관리가 auth 도메인 내부 상수에 흩어져 있고
- Spring Cache 인프라와 별도 경로로 Redis script를 실행하며
- cache 정책/키 네이밍 관리가 분산된 상태였습니다.

이번 변경은 RTR의 기존 Lua CAS 흐름은 유지하면서
Redis key 관리와 script 실행 경로를 CacheManager 기반으로 정리하는 리팩토링입니다.

## 변경 내용

### 1. `ScriptableRedisCache` 추가
- `LuaRedisCache`를 확장한 `ScriptableRedisCache`를 추가했습니다.
- Spring Cache의 key 직렬화 규칙과 cache prefix를 그대로 사용한 채 Lua 스크립트를 실행할 수 있도록 `execute()` 메서드를 제공합니다.
- 이를 통해 Redis script 실행이 cache 인프라 안에서 일관된 방식으로 처리되도록 맞췄습니다.

### 2. `TOKEN_FAMILY` cache policy 추가
- `CacheNames.TOKEN_FAMILY = "auth:family"` 상수를 추가했습니다.
- `CachePolicy`에 `TOKEN_FAMILY`를 등록했습니다.
- RTR token family key prefix를 auth 구현체 내부 상수 대신 cache 정책으로 관리하도록 정리했습니다.

### 3. `QFeedCacheManager` 일반 캐시 생성 타입 변경
- hot key가 아닌 일반 캐시 생성 시 `LuaRedisCache` 대신 `ScriptableRedisCache`를 생성하도록 변경했습니다.
- 이를 통해 token family cache도 CacheManager를 통해 script 실행 가능한 타입으로 일관되게 생성됩니다.

### 4. `RedisTokenFamilyStore` Redis 접근 방식 변경
기존:
- `StringRedisTemplate` 직접 사용
- `KEY_PREFIX` 조합
- `opsForHash()` / `execute()` 혼합 사용

변경 후:
- `CacheManager`에서 `TOKEN_FAMILY` cache를 조회
- `ScriptableRedisCache`로 캐스팅해 사용
- `initFamilyState`, `rotateFamilyToken`, `revokeFamilyState`, `revokeAllFamilyStates`를 모두 `execute()` 경로로 통일

추가로 `initFamilyState`는 기존 hash field 개별 쓰기 대신
Lua 기반 원자적 초기화 스크립트로 변경했습니다.

## 유지되는 사항

- RTR rotate/revoke의 핵심 Lua CAS 동작은 유지됩니다.
- refresh token family의 DB SoT + Redis fast path 전략은 유지됩니다.
- TTL은 기존과 동일하게 고정 cache TTL이 아니라 script 인자로 전달되는 동적 TTL을 사용합니다.

## 영향 범위

### Redis key 형식
Spring Cache prefix 규칙이 적용되므로 token family key는 다음 형태를 사용합니다.

- 이전: `auth:family:{familyUuid}`
- 이후: `auth:family::{familyUuid}`

즉, key prefix에 `::`가 포함됩니다.

### 호환성
기존 Redis에 남아 있는 이전 형식의 RTR key와는 직접 호환되지 않습니다.
다만 RTR key는 TTL 기반으로 관리되므로 기존 세션은 자연 만료 대상입니다.

## 기대 효과

- Redis key prefix와 cache naming을 중앙 정책으로 관리할 수 있습니다.
- auth 도메인의 Redis 접근 경로를 cache 인프라와 정렬할 수 있습니다.
- Lua script 실행을 통일된 추상화로 감싸 이후 Redis script 확장 시 재사용성이 좋아집니다.

## 변경 파일

- `src/main/java/com/ktb/auth/service/impl/RedisTokenFamilyStore.java`
- `src/main/java/com/ktb/redis/cache/ScriptableRedisCache.java`
- `src/main/java/com/ktb/redis/cache/QFeedCacheManager.java`
- `src/main/java/com/ktb/redis/constant/CacheNames.java`
- `src/main/java/com/ktb/redis/policy/CachePolicy.java`

## 리뷰 포인트

- `ScriptableRedisCache`의 script 실행 경로가 기존 RedisTemplate 기반 호출과 의미적으로 동일한지
- `TOKEN_FAMILY` cache가 항상 `ScriptableRedisCache`로 생성된다는 전제가 안전한지
- key prefix 변경(`auth:family::{uuid}`)이 운영상 허용 가능한지
- `initFamilyState`의 Lua 원자 초기화가 기존 hash write 동작과 동일한 의미를 보장하는지
