### PR TITLE
feat:[#263] 추천 질문 답변 이후 사용자별 재추천이 가능하도록 구조 개선

### DIFF
--- a/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
+++ b/src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java
@@ -40,6 +40,8 @@ import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import com.ktb.question.exception.QuestionDisabledException;
 import com.ktb.question.exception.QuestionNotFoundException;
+import com.ktb.question.service.DailyRecommendationAnswerTracker;
+import com.ktb.question.service.DailyRecommendationCandidateService;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +69,8 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
     private final AbuseGuard abuseGuard;
     private final AnswerFeedbackProperties answerFeedbackProperties;
     private final NotificationOutboxRepository notificationOutboxRepository;
+    private final DailyRecommendationCandidateService candidateService;
+    private final DailyRecommendationAnswerTracker tracker;
 
     @Override
     public AnswerListResponse getList(
@@ -117,6 +121,12 @@ public class AnswerApplicationServiceImpl implements AnswerApplicationService {
             log.info("Answer saved without AI feedback - accountId={}, reason={}",
                     accountId, abuseResult.getReason());
             return AnswerSubmitResult.noAiFeedback(answer.getId(), immediateFeedback);
+        }
+
+        if (candidateService.isCandidateToday(command.questionId())) {
+            tracker.recordAnswer(accountId, command.questionId(), LocalDate.now());
+            log.debug("Daily recommendation answered recorded - accountId={}, questionId={}",
+                    accountId, command.questionId());
         }
 
         if (answerFeedbackProperties.isEnabled()) {

--- a/src/main/java/com/ktb/question/controller/QuestionController.java
+++ b/src/main/java/com/ktb/question/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package com.ktb.question.controller;
 
+import com.ktb.auth.security.adapter.SecurityUserAccount;
 import com.ktb.common.dto.ApiResponse;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
@@ -27,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -159,11 +161,14 @@ public class QuestionController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "질문 없음",
                     content = @Content(schema = @Schema(implementation = com.ktb.common.dto.CommonErrorResponse.class)))
     })
-    public ResponseEntity<ApiResponse<QuestionDetailResponse>> getDailyRecommendation() {
-        log.info("GET /api/questions/recommendation");
-        QuestionDetailResponse result = questionService.getDailyRecommendation();
-        log.info("GET /api/questions/recommendation success - questionId: {}, type: {}, category: {}",
-                result.questionId(), result.type(), result.category());
+    public ResponseEntity<ApiResponse<QuestionDetailResponse>> getDailyRecommendation(
+            @AuthenticationPrincipal SecurityUserAccount principal
+    ) {
+        Long accountId = principal.getAccount().getId();
+        log.info("GET /api/questions/recommendation - accountId: {}", accountId);
+        QuestionDetailResponse result = questionService.getDailyRecommendation(accountId);
+        log.info("GET /api/questions/recommendation success - accountId: {}, questionId: {}, type: {}, category: {}",
+                accountId, result.questionId(), result.type(), result.category());
         return ResponseEntity.ok(new ApiResponse<>("question_recommendation_success", result));
     }
 

--- a/src/main/java/com/ktb/question/repository/QuestionRepository.java
+++ b/src/main/java/com/ktb/question/repository/QuestionRepository.java
@@ -3,6 +3,7 @@ package com.ktb.question.repository;
 import com.ktb.question.domain.Question;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -103,4 +104,12 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             @Param("questionType") String questionType,
             @Param("category") String category
     );
+
+    @Query(value = """
+            SELECT question_id FROM question
+            WHERE use_yn = true AND deleted_at IS NULL
+            ORDER BY random()
+            LIMIT :count
+            """, nativeQuery = true)
+    List<Long> findRandomActiveCandidateIds(@Param("count") int count);
 }

--- a/src/main/java/com/ktb/question/service/DailyRecommendationAnswerTracker.java
+++ b/src/main/java/com/ktb/question/service/DailyRecommendationAnswerTracker.java
@@ -1,0 +1,11 @@
+package com.ktb.question.service;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+public interface DailyRecommendationAnswerTracker {
+
+    Set<Long> getAnsweredIds(Long accountId, LocalDate date);
+
+    void recordAnswer(Long accountId, Long questionId, LocalDate date);
+}

--- a/src/main/java/com/ktb/question/service/DailyRecommendationCandidateService.java
+++ b/src/main/java/com/ktb/question/service/DailyRecommendationCandidateService.java
@@ -1,0 +1,13 @@
+package com.ktb.question.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyRecommendationCandidateService {
+
+    List<Long> getCandidateIds(LocalDate date);
+
+    boolean isCandidateToday(Long questionId);
+
+    List<Long> getFreshCandidateIds();
+}

--- a/src/main/java/com/ktb/question/service/DailyRecommendationProperties.java
+++ b/src/main/java/com/ktb/question/service/DailyRecommendationProperties.java
@@ -1,0 +1,12 @@
+package com.ktb.question.service;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Setter
+@Getter
+@ConfigurationProperties(prefix = "question.recommendation")
+public class DailyRecommendationProperties {
+    private int candidateCount = 10;
+}

--- a/src/main/java/com/ktb/question/service/QuestionService.java
+++ b/src/main/java/com/ktb/question/service/QuestionService.java
@@ -18,7 +18,7 @@ public interface QuestionService {
 
     void deleteQuestion(Long questionId);
 
-    QuestionDetailResponse getDailyRecommendation();
+    QuestionDetailResponse getDailyRecommendation(Long accountId);
 
     QuestionKeywordListResponse getQuestionKeywords(Long questionId);
 

--- a/src/main/java/com/ktb/question/service/impl/DailyRecommendationCandidateCache.java
+++ b/src/main/java/com/ktb/question/service/impl/DailyRecommendationCandidateCache.java
@@ -1,0 +1,24 @@
+package com.ktb.question.service.impl;
+
+import com.ktb.question.repository.QuestionRepository;
+import com.ktb.question.service.DailyRecommendationProperties;
+import com.ktb.redis.constant.CacheNames;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+class DailyRecommendationCandidateCache {
+
+    private final QuestionRepository questionRepository;
+    private final DailyRecommendationProperties properties;
+
+    @Cacheable(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION_CANDIDATES,
+               key = "#date.format(T(java.time.format.DateTimeFormatter).BASIC_ISO_DATE)")
+    public List<Long> getCandidateIds(LocalDate date) {
+        return questionRepository.findRandomActiveCandidateIds(properties.getCandidateCount());
+    }
+}

--- a/src/main/java/com/ktb/question/service/impl/DailyRecommendationCandidateServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/DailyRecommendationCandidateServiceImpl.java
@@ -1,0 +1,35 @@
+package com.ktb.question.service.impl;
+
+import com.ktb.question.repository.QuestionRepository;
+import com.ktb.question.service.DailyRecommendationCandidateService;
+import com.ktb.question.service.DailyRecommendationProperties;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@EnableConfigurationProperties(DailyRecommendationProperties.class)
+public class DailyRecommendationCandidateServiceImpl implements DailyRecommendationCandidateService {
+
+    private final QuestionRepository questionRepository;
+    private final DailyRecommendationProperties properties;
+    private final DailyRecommendationCandidateCache candidateCache;
+
+    @Override
+    public List<Long> getCandidateIds(LocalDate date) {
+        return candidateCache.getCandidateIds(date);
+    }
+
+    @Override
+    public boolean isCandidateToday(Long questionId) {
+        return candidateCache.getCandidateIds(LocalDate.now()).contains(questionId);
+    }
+
+    @Override
+    public List<Long> getFreshCandidateIds() {
+        return questionRepository.findRandomActiveCandidateIds(properties.getCandidateCount());
+    }
+}

--- a/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
+++ b/src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java
@@ -23,9 +23,12 @@ import com.ktb.question.dto.QuestionUpdateRequest;
 import com.ktb.question.exception.QuestionNotFoundException;
 import com.ktb.question.exception.SearchKeywordTooShortException;
 import com.ktb.question.repository.QuestionRepository;
+import com.ktb.question.service.DailyRecommendationAnswerTracker;
+import com.ktb.question.service.DailyRecommendationCandidateService;
 import com.ktb.question.service.QuestionService;
 import com.ktb.redis.constant.CacheNames;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -62,6 +65,8 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionRepository questionRepository;
     private final QuestionHashtagRepository questionHashtagRepository;
     private final HashtagRepository hashtagRepository;
+    private final DailyRecommendationCandidateService candidateService;
+    private final DailyRecommendationAnswerTracker tracker;
 
     @Override
     @Cacheable(cacheNames = CacheNames.QUESTION_LIST, key = "#category+':'+#type+':'+#cursor+':'+#size")
@@ -113,23 +118,39 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
-    @Cacheable(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION)
-    public QuestionDetailResponse getDailyRecommendation() {
-        log.debug("getDailyRecommendation");
-        Long questionId = questionRepository.findRandomActiveId()
-                .orElseThrow(() -> new QuestionNotFoundException(0L));
+    public QuestionDetailResponse getDailyRecommendation(Long accountId) {
+        log.debug("getDailyRecommendation - accountId: {}", accountId);
+        LocalDate today = LocalDate.now();
+        List<Long> candidates = candidateService.getCandidateIds(today);
+        Set<Long> answered = tracker.getAnsweredIds(accountId, today);
 
-        Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new QuestionNotFoundException(questionId));
+        Long selectedId = candidates.stream()
+                .filter(id -> !answered.contains(id))
+                .findFirst()
+                .orElseGet(() -> fallbackCandidateId(answered));
 
-        log.info("getDailyRecommendation success - questionId: {}, type: {}, category: {}",
-                question.getId(), question.getType(), question.getCategory());
+        Question question = questionRepository.findById(selectedId)
+                .orElseThrow(() -> new QuestionNotFoundException(selectedId));
+
+        log.info("getDailyRecommendation success - accountId: {}, questionId: {}, type: {}, category: {}",
+                accountId, question.getId(), question.getType(), question.getCategory());
         return toDetailResponse(question);
+    }
+
+    private Long fallbackCandidateId(Set<Long> answered) {
+        return candidateService.getFreshCandidateIds()
+                .stream()
+                .filter(id -> !answered.contains(id))
+                .findFirst()
+                .orElseThrow(() -> new QuestionNotFoundException(0L));
     }
 
     @Override
     @Transactional
-    @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true),
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION_CANDIDATES, allEntries = true)
+    })
     public QuestionDetailResponse createQuestion(QuestionCreateRequest request) {
         int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
         log.info("createQuestion - type: {}, category: {}, keywordCount: {}",
@@ -148,7 +169,7 @@ public class QuestionServiceImpl implements QuestionService {
         @CacheEvict(cacheNames = CacheNames.QUESTION_DETAIL, key = "#questionId"),
         @CacheEvict(cacheNames = CacheNames.QUESTION_KEYWORDS, key = "#questionId"),
         @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true),
-        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION, allEntries = true)
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION_CANDIDATES, allEntries = true)
     })
     public QuestionDetailResponse updateQuestion(Long questionId, QuestionUpdateRequest request) {
         int keywordCount = request.keywords() == null ? 0 : request.keywords().size();
@@ -187,7 +208,7 @@ public class QuestionServiceImpl implements QuestionService {
         @CacheEvict(cacheNames = CacheNames.QUESTION_DETAIL, key = "#questionId"),
         @CacheEvict(cacheNames = CacheNames.QUESTION_KEYWORDS, key = "#questionId"),
         @CacheEvict(cacheNames = CacheNames.QUESTION_LIST, allEntries = true),
-        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION, allEntries = true)
+        @CacheEvict(cacheNames = CacheNames.QUESTION_DAILY_RECOMMENDATION_CANDIDATES, allEntries = true)
     })
     public void deleteQuestion(Long questionId) {
         log.info("deleteQuestion - questionId: {}", questionId);

--- a/src/main/java/com/ktb/question/service/impl/RedisDailyRecommendationAnswerTracker.java
+++ b/src/main/java/com/ktb/question/service/impl/RedisDailyRecommendationAnswerTracker.java
@@ -1,0 +1,48 @@
+package com.ktb.question.service.impl;
+
+import com.ktb.question.service.DailyRecommendationAnswerTracker;
+import com.ktb.redis.constant.RedisKey;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisDailyRecommendationAnswerTracker implements DailyRecommendationAnswerTracker {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.BASIC_ISO_DATE;
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public Set<Long> getAnsweredIds(Long accountId, LocalDate date) {
+        Set<String> members = redisTemplate.opsForSet().members(answeredKey(accountId, date));
+        if (members == null) {
+            return Set.of();
+        }
+        return members.stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public void recordAnswer(Long accountId, Long questionId, LocalDate date) {
+        String key = answeredKey(accountId, date);
+        redisTemplate.opsForSet().add(key, String.valueOf(questionId));
+        redisTemplate.expire(key, ttlUntilTomorrow(date));
+    }
+
+    private String answeredKey(Long accountId, LocalDate date) {
+        return RedisKey.DAILY_RECOMMENDATION_ANSWERED.format(accountId, date.format(DATE_FORMAT));
+    }
+
+    private Duration ttlUntilTomorrow(LocalDate date) {
+        return Duration.between(LocalDateTime.now(), date.plusDays(1).atStartOfDay());
+    }
+}

--- a/src/main/java/com/ktb/redis/constant/CacheNames.java
+++ b/src/main/java/com/ktb/redis/constant/CacheNames.java
@@ -6,7 +6,7 @@ public final class CacheNames {
     public static final String QUESTION_LIST = "question:list";
     public static final String QUESTION_DETAIL = "question:detail";
     public static final String QUESTION_KEYWORDS = "question:keywords";
-    public static final String QUESTION_DAILY_RECOMMENDATION = "question:daily-recommendation";
+    public static final String QUESTION_DAILY_RECOMMENDATION_CANDIDATES = "question:daily-recommendation:candidates";
     public static final String METRIC_LIST = "metric:list";
     public static final String METRIC_DETAIL = "metric:detail";
 

--- a/src/main/java/com/ktb/redis/constant/RedisKey.java
+++ b/src/main/java/com/ktb/redis/constant/RedisKey.java
@@ -1,0 +1,17 @@
+package com.ktb.redis.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisKey {
+
+    DAILY_RECOMMENDATION_ANSWERED("question:daily-recommendation:answered:%d:%s");
+
+    private final String template;
+
+    public String format(Object... args) {
+        return String.format(template, args);
+    }
+}

--- a/src/main/java/com/ktb/redis/policy/CachePolicy.java
+++ b/src/main/java/com/ktb/redis/policy/CachePolicy.java
@@ -12,7 +12,7 @@ public enum CachePolicy {
     QUESTION_LIST      (CacheNames.QUESTION_LIST,       CacheTtl.MEDIUM, false),
     QUESTION_DETAIL    (CacheNames.QUESTION_DETAIL,     CacheTtl.LONG,   false),
     QUESTION_KEYWORDS  (CacheNames.QUESTION_KEYWORDS,   CacheTtl.LONG,   false),
-    QUESTION_DAILY_REC (CacheNames.QUESTION_DAILY_RECOMMENDATION, CacheTtl.LONG, true),
+    QUESTION_DAILY_REC (CacheNames.QUESTION_DAILY_RECOMMENDATION_CANDIDATES, CacheTtl.DAILY, true),
     METRIC_LIST        (CacheNames.METRIC_LIST,         CacheTtl.MEDIUM, false),
     METRIC_DETAIL      (CacheNames.METRIC_DETAIL,       CacheTtl.LONG,   false);
 

--- a/src/main/java/com/ktb/redis/policy/CacheTtl.java
+++ b/src/main/java/com/ktb/redis/policy/CacheTtl.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum CacheTtl {
     SHORT(Duration.ofMinutes(1)),
     MEDIUM(Duration.ofMinutes(10)),
-    LONG(Duration.ofHours(1));
+    LONG(Duration.ofHours(1)),
+    DAILY(Duration.ofDays(1));
 
     private final Duration duration;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -149,6 +149,10 @@ springdoc:
     tags-sorter: alpha
     display-request-duration: true
 
+question:
+  recommendation:
+    candidate-count: 10
+
 answer:
   feedback:
     rabbitmq:

--- a/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
+++ b/src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java
@@ -29,6 +29,8 @@ import com.ktb.metric.domain.AnswerMetric;
 import com.ktb.metric.repository.AnswerMetricRepository;
 import com.ktb.notification.repository.NotificationOutboxRepository;
 import com.ktb.question.domain.Question;
+import com.ktb.question.service.DailyRecommendationAnswerTracker;
+import com.ktb.question.service.DailyRecommendationCandidateService;
 import com.ktb.question.domain.QuestionCategory;
 import com.ktb.question.domain.QuestionType;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,6 +93,12 @@ class AnswerApplicationServiceTest {
     @Mock
     private NotificationOutboxRepository notificationOutboxRepository;
 
+    @Mock
+    private DailyRecommendationCandidateService candidateService;
+
+    @Mock
+    private DailyRecommendationAnswerTracker tracker;
+
     private AnswerApplicationServiceImpl answerApplicationService;
 
     private static final Long ACCOUNT_ID = 1L;
@@ -112,7 +120,9 @@ class AnswerApplicationServiceTest {
                 answerMetricRepository,
                 abuseGuard,
                 props,
-                notificationOutboxRepository
+                notificationOutboxRepository,
+                candidateService,
+                tracker
         );
     }
 

--- a/src/test/java/com/ktb/question/service/QuestionServiceTest.java
+++ b/src/test/java/com/ktb/question/service/QuestionServiceTest.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.util.Set;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -55,6 +57,15 @@ class QuestionServiceTest {
 
     @Mock
     private HashtagRepository hashtagRepository;
+
+    @Mock
+    private DailyRecommendationCandidateService candidateService;
+
+    @Mock
+    private DailyRecommendationAnswerTracker tracker;
+
+    @Mock
+    private DailyRecommendationProperties properties;
 
     @InjectMocks
     private QuestionServiceImpl questionService;
@@ -217,10 +228,13 @@ class QuestionServiceTest {
         @DisplayName("오늘의 추천 질문 조회 시 활성 질문이 없으면 QuestionNotFoundException")
         void getDailyRecommendation_WithoutActiveQuestion_ShouldThrowException() {
             // Given
-            when(questionRepository.findRandomActiveId()).thenReturn(Optional.empty());
+            Long accountId = 1L;
+            when(candidateService.getCandidateIds(any())).thenReturn(List.of());
+            when(tracker.getAnsweredIds(eq(accountId), any())).thenReturn(Set.of());
+            when(candidateService.getFreshCandidateIds()).thenReturn(List.of());
 
             // When & Then
-            assertThatThrownBy(() -> questionService.getDailyRecommendation())
+            assertThatThrownBy(() -> questionService.getDailyRecommendation(accountId))
                     .isInstanceOf(QuestionNotFoundException.class);
         }
 
@@ -228,11 +242,13 @@ class QuestionServiceTest {
         @DisplayName("오늘의 추천 질문 ID는 있으나 상세 조회 실패 시 QuestionNotFoundException")
         void getDailyRecommendation_WithMissingQuestionDetail_ShouldThrowException() {
             // Given
-            when(questionRepository.findRandomActiveId()).thenReturn(Optional.of(123L));
+            Long accountId = 1L;
+            when(candidateService.getCandidateIds(any())).thenReturn(List.of(123L));
+            when(tracker.getAnsweredIds(eq(accountId), any())).thenReturn(java.util.Set.of());
             when(questionRepository.findById(123L)).thenReturn(Optional.empty());
 
             // When & Then
-            assertThatThrownBy(() -> questionService.getDailyRecommendation())
+            assertThatThrownBy(() -> questionService.getDailyRecommendation(accountId))
                     .isInstanceOf(QuestionNotFoundException.class);
         }
 


### PR DESCRIPTION
## 배경

현재 추천 질문은 hot key 기반 캐시로 관리되고 있습니다.  
이 구조에서는 사용자가 추천 질문에 답변을 제출하더라도 캐시가 유지되는 동안 동일한 추천 질문이 다시 반환될 수 있습니다.

하지만 비즈니스 요구사항상 추천 질문에 답변이 제출되면 이후 추천 결과는 사용자 기준으로 refresh 되어야 합니다.  
즉, 추천 질문은 단순한 전역 캐시 결과가 아니라 사용자의 답변 여부를 반영해 다시 선택될 수 있어야 합니다.

## 문제

기존 구조의 문제는 다음과 같습니다.

- 추천 질문이 전역 hot key 결과에 의존함
- 사용자가 이미 답변한 추천 질문이 다시 노출될 수 있음
- 추천 소비 이후 새로운 추천을 제공해야 하는 요구사항을 만족하지 못함

## 해결 방향

전역 추천 결과 자체를 매번 무효화하는 대신, 아래 구조로 변경했습니다.

- 일자별 추천 후보군은 캐시로 유지
- 사용자별 답변 이력은 Redis에 기록
- 추천 조회 시 후보군에서 이미 답변한 질문을 제외하고 선택
- 후보군이 모두 소진된 경우 fresh candidate에서 fallback 선택

즉, hot key 성격의 후보군 캐시는 유지하면서도, 최종 추천 결과는 사용자 상태를 반영하도록 분리했습니다.

## 변경 내용

### 1. 추천 후보군 캐시 도입
- `DailyRecommendationCandidateService`
- `DailyRecommendationCandidateServiceImpl`
- `DailyRecommendationCandidateCache`
- `DailyRecommendationProperties`

일자별 추천 후보 질문 ID 목록을 캐시로 관리합니다.  
캐시 책임을 별도 Bean으로 분리해 self-invocation 없이 `@Cacheable`이 적용되도록 구성했습니다.

### 2. 사용자별 답변 이력 추적 추가
- `DailyRecommendationAnswerTracker`
- `RedisDailyRecommendationAnswerTracker`
- `RedisKey.DAILY_RECOMMENDATION_ANSWERED`

사용자별/일자별로 답변한 추천 질문 ID를 Redis Set으로 저장합니다.  
하루 단위 추천 흐름에 맞춰 TTL은 자정까지 유지되도록 처리했습니다.

### 3. 추천 질문 조회 로직 변경
`QuestionService.getDailyRecommendation()`을 사용자 기준 조회로 변경했습니다.

변경 후 흐름:
1. 오늘의 추천 후보군 조회
2. 사용자의 오늘 답변 이력 조회
3. 아직 답변하지 않은 후보 우선 선택
4. 모두 소진된 경우 fresh candidate 기반 fallback

### 4. 답변 제출 시 추천 이력 기록
`AnswerApplicationServiceImpl`에서 답변 제출 시:
- 해당 질문이 오늘의 추천 후보군인지 확인
- 맞다면 Redis에 답변 이력을 기록

즉, 추천 질문을 “봤는지”가 아니라 실제로 “답변 제출했는지”를 기준으로 재추천 제외 처리합니다.

### 5. 캐시 무효화 범위 조정
질문 생성/수정/삭제 시:
- `QUESTION_LIST`
- `QUESTION_DAILY_RECOMMENDATION_CANDIDATES`

캐시를 함께 무효화하도록 변경했습니다.

## 기대 효과

- 사용자가 이미 답변한 추천 질문이 다시 노출되는 문제를 줄일 수 있습니다.
- 추천 후보군은 캐시로 유지하므로 조회 비용을 제어할 수 있습니다.
- 추천 후보 조회와 사용자별 최종 선택 책임이 분리되어 이후 정책 변경이 쉬워집니다.

## 주요 변경 파일

### Question
- `src/main/java/com/ktb/question/controller/QuestionController.java`
- `src/main/java/com/ktb/question/service/QuestionService.java`
- `src/main/java/com/ktb/question/service/impl/QuestionServiceImpl.java`
- `src/main/java/com/ktb/question/repository/QuestionRepository.java`

### Recommendation 신규 구성
- `src/main/java/com/ktb/question/service/DailyRecommendationCandidateService.java`
- `src/main/java/com/ktb/question/service/DailyRecommendationAnswerTracker.java`
- `src/main/java/com/ktb/question/service/DailyRecommendationProperties.java`
- `src/main/java/com/ktb/question/service/impl/DailyRecommendationCandidateCache.java`
- `src/main/java/com/ktb/question/service/impl/DailyRecommendationCandidateServiceImpl.java`
- `src/main/java/com/ktb/question/service/impl/RedisDailyRecommendationAnswerTracker.java`

### Redis / Cache
- `src/main/java/com/ktb/redis/constant/CacheNames.java`
- `src/main/java/com/ktb/redis/constant/RedisKey.java`
- `src/main/java/com/ktb/redis/policy/CachePolicy.java`
- `src/main/java/com/ktb/redis/policy/CacheTtl.java`

### Answer 연계
- `src/main/java/com/ktb/answer/service/impl/AnswerApplicationServiceImpl.java`

### 설정 / 테스트
- `src/main/resources/application.yaml`
- `src/test/java/com/ktb/question/service/QuestionServiceTest.java`
- `src/test/java/com/ktb/answer/service/AnswerApplicationServiceTest.java`

## 설정 추가

```yaml
question:
  recommendation:
    candidate-count: 10
```

## 관련 Issue
 - closes #263 